### PR TITLE
[POC] Implement offline support for E2E tests

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/ReconnectionView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ReconnectionView.swift
@@ -27,6 +27,7 @@ public struct ReconnectionView<Factory: ViewFactory>: View {
                     Text(L10n.Call.Current.reconnecting)
                         .applyCallingStyle()
                         .padding()
+                        .accessibility(identifier: "reconnectingMessage")
                     CallingIndicator()
                 }
                 .padding()

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -12,8 +12,9 @@
 		82392D662993CD7B00941435 /* StreamChatTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 82392D652993CD7B00941435 /* StreamChatTestHelpers */; };
 		82392D6B2993CDF500941435 /* UserRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D6A2993CDF500941435 /* UserRobot.swift */; };
 		82392D6D2993CE7200941435 /* StreamVideoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D6C2993CE7200941435 /* StreamVideoUITests.swift */; };
-		82392D6F2994027C00941435 /* TerminalRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D6E2994027C00941435 /* TerminalRobot.swift */; };
+		82392D6F2994027C00941435 /* Sinatra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D6E2994027C00941435 /* Sinatra.swift */; };
 		82392D71299403B200941435 /* CallViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D70299403B200941435 /* CallViewsTests.swift */; };
+		824DBAA029F6D77B005ACD09 /* ReconnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824DBA9F29F6D77B005ACD09 /* ReconnectionTests.swift */; };
 		82686160290A7556005BFFED /* SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8268615F290A7556005BFFED /* SystemEnvironment.swift */; };
 		828DE5BD299521EF00F93197 /* UserRobot+Asserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828DE5BC299521EF00F93197 /* UserRobot+Asserts.swift */; };
 		82AD932529E6FCCF00D4D295 /* LobbyPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AD932429E6FCCF00D4D295 /* LobbyPage.swift */; };
@@ -556,9 +557,10 @@
 		82392D5E2993CCB300941435 /* ParticipantRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRobot.swift; sourceTree = "<group>"; };
 		82392D6A2993CDF500941435 /* UserRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRobot.swift; sourceTree = "<group>"; };
 		82392D6C2993CE7200941435 /* StreamVideoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamVideoUITests.swift; sourceTree = "<group>"; };
-		82392D6E2994027C00941435 /* TerminalRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRobot.swift; sourceTree = "<group>"; };
+		82392D6E2994027C00941435 /* Sinatra.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sinatra.swift; sourceTree = "<group>"; };
 		82392D70299403B200941435 /* CallViewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewsTests.swift; sourceTree = "<group>"; };
 		82392D7429940C4500941435 /* SwiftUIDemoApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUIDemoApp.xctestplan; sourceTree = "<group>"; };
+		824DBA9F29F6D77B005ACD09 /* ReconnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectionTests.swift; sourceTree = "<group>"; };
 		8268615F290A7556005BFFED /* SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEnvironment.swift; sourceTree = "<group>"; };
 		828DE5BC299521EF00F93197 /* UserRobot+Asserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserRobot+Asserts.swift"; sourceTree = "<group>"; };
 		82AD932429E6FCCF00D4D295 /* LobbyPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbyPage.swift; sourceTree = "<group>"; };
@@ -1084,7 +1086,7 @@
 			isa = PBXGroup;
 			children = (
 				82392D5E2993CCB300941435 /* ParticipantRobot.swift */,
-				82392D6E2994027C00941435 /* TerminalRobot.swift */,
+				82392D6E2994027C00941435 /* Sinatra.swift */,
 			);
 			path = Robots;
 			sourceTree = "<group>";
@@ -1107,6 +1109,7 @@
 				82B8C0F929E80997001F816C /* RingProcessTests.swift */,
 				82B8C0FB29E80A2A001F816C /* CallLifecycleTests.swift */,
 				82D858B729EDAE0A00CF9F8B /* ParticipantActionsTests.swift */,
+				824DBA9F29F6D77B005ACD09 /* ReconnectionTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -2406,9 +2409,10 @@
 				82392D6B2993CDF500941435 /* UserRobot.swift in Sources */,
 				82D858B829EDAE0A00CF9F8B /* ParticipantActionsTests.swift in Sources */,
 				82B8C0F829E80933001F816C /* LobbyTests.swift in Sources */,
-				82392D6F2994027C00941435 /* TerminalRobot.swift in Sources */,
+				82392D6F2994027C00941435 /* Sinatra.swift in Sources */,
 				82392D6D2993CE7200941435 /* StreamVideoUITests.swift in Sources */,
 				82AD932529E6FCCF00D4D295 /* LobbyPage.swift in Sources */,
+				824DBAA029F6D77B005ACD09 /* ReconnectionTests.swift in Sources */,
 				828DE5BD299521EF00F93197 /* UserRobot+Asserts.swift in Sources */,
 				82B8C0FC29E80A2A001F816C /* CallLifecycleTests.swift in Sources */,
 				82392D71299403B200941435 /* CallViewsTests.swift in Sources */,

--- a/SwiftUIDemoAppUITests/Pages/CallPage.swift
+++ b/SwiftUIDemoAppUITests/Pages/CallPage.swift
@@ -75,4 +75,5 @@ enum CallPage {
     static var spotlightViewParticipantListDetails: XCUIElement {
         spotlightViewParticipantList.otherElements.matching(NSPredicate(format: "label CONTAINS 'Horizontal scroll bar'")).firstMatch
     }
+    static var reconnectingMessage: XCUIElement { app.staticTexts["reconnectingMessage"] }
 }

--- a/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
@@ -218,6 +218,16 @@ extension UserRobot {
         XCTAssertEqual(count, CallPage.participantView.waitCount(count, timeout: UserRobot.defaultTimeout).count)
         return self
     }
+    
+    @discardableResult
+    func assertReconnectingMessage(isVisible: Bool) -> Self {
+        if isVisible {
+            XCTAssertTrue(CallPage.reconnectingMessage.wait().exists, "reconnectingMessage should appear")
+        } else {
+            XCTAssertFalse(CallPage.reconnectingMessage.waitForDisappearance(timeout: UserRobot.defaultTimeout).exists, "reconnectingMessage should disappear")
+        }
+        return self
+    }
 }
 
 extension XCUIElement {

--- a/SwiftUIDemoAppUITests/Robots/UserRobot.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot.swift
@@ -53,6 +53,7 @@ extension UserRobot {
         typeText(callId, clean: clean)
         tapOnStartCallButton()
         if waitForCompletion {
+            CallPage.hangUpButton.wait()
             CallPage.ConnectingView.callConnectingView.waitForDisappearance(timeout: Self.defaultTimeout)
         }
         return self

--- a/SwiftUIDemoAppUITests/Tests/ReconnectionTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/ReconnectionTests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+// Requires running a standalone Sinatra server
+final class ReconnectionTests: StreamTestCase {
+    
+    override func tearDownWithError() throws {
+        sinatra.setConnection(state: .on)
+    
+        try super.tearDownWithError()
+    }
+    
+    func testReconnectingMessage() {
+        linkToScenario(withId: 2030)
+        
+        GIVEN("user starts a new call") {
+            userRobot.login().startCall(callId)
+        }
+        WHEN("user loses the internet connection") {
+            sinatra.setConnection(state: .off)
+        }
+        THEN("user observes a reconnecting message") {
+            userRobot.assertReconnectingMessage(isVisible: true)
+        }
+        WHEN("user restores the internet connection") {
+            sinatra.setConnection(state: .on)
+        }
+        THEN("reconnecting message disappears") {
+            userRobot.assertReconnectingMessage(isVisible: false)
+        }
+    }
+}

--- a/SwiftUIDemoAppUITests/Tests/StreamTestCase.swift
+++ b/SwiftUIDemoAppUITests/Tests/StreamTestCase.swift
@@ -11,7 +11,7 @@ class StreamTestCase: XCTestCase {
     let deviceRobot = DeviceRobot(app)
     var userRobot = UserRobot()
     var participantRobot = ParticipantRobot()
-    var terminalRobot = TerminalRobot()
+    var sinatra = Sinatra()
     var recordVideo = false
     let callId = randomCallId
     let allViews: [UserRobot.View] = [.grid, .fullscreen, .spotlight]
@@ -65,13 +65,13 @@ extension StreamTestCase {
 
     private func startVideo() {
         if recordVideo {
-            terminalRobot.recordVideo(name: testName)
+            sinatra.recordVideo(name: testName)
         }
     }
 
     private func stopVideo() {
         if recordVideo {
-            terminalRobot.recordVideo(name: testName, delete: !isTestFailed(), stop: true)
+            sinatra.recordVideo(name: testName, delete: !isTestFailed(), stop: true)
         }
     }
 

--- a/TestTools/Robots/Sinatra.swift
+++ b/TestTools/Robots/Sinatra.swift
@@ -4,8 +4,18 @@
 
 import Foundation
 
-public class TerminalRobot {
+public class Sinatra {
     private let baseUrl = "http://localhost:4567"
+    
+    enum ConnectionState: String {
+        case on
+        case off
+    }
+    
+    func setConnection(state: ConnectionState) {
+        let url = URL(string: "\(baseUrl)/connection/\(state.rawValue)")!
+        invokeSinatra(url: url)
+    }
     
     func recordVideo(name: String, delete: Bool = false, stop: Bool = false) {
         let json: [String: Any] = ["delete": delete, "stop": stop]
@@ -14,7 +24,7 @@ public class TerminalRobot {
         invokeSinatra(url: url, body: json)
     }
     
-    private func invokeSinatra(url: URL, body: [String: Any]) {
+    private func invokeSinatra(url: URL, body: [String: Any] = [:]) {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])

--- a/fastlane/sinatra.rb
+++ b/fastlane/sinatra.rb
@@ -7,6 +7,12 @@ post '/push/:udid/:bundle_id' do
   puts `xcrun simctl push #{params['udid']} #{params['bundle_id']} #{push_data_file}`
 end
 
+post '/connection/:state' do
+  ['Ethernet', 'Wi-Fi'].each do |service|
+    `networksetup -setnetworkserviceenabled '#{service}' #{params['state']} || true`
+  end
+end
+
 post '/record_video/:udid/:test_name' do
   recordings_dir = 'recordings'
   video_base_name = "#{recordings_dir}/#{params['test_name']}"


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/399

### 🎯 Goal

Implement offline support for E2E tests

### 📝 Summary

The test case called `testReconnectingMessage()` was added as an example of how this works. Locally it takes about 27 seconds for it to pass:

**GIVEN** user starts a new call
**WHEN** user loses the internet connection
**THEN** user observes a reconnecting message
**WHEN** user restores the internet connection
**THEN** reconnecting message disappears

### 🛠 Implementation

The new endpoint was added to `sinatra` so it could handle the `macOS` connection

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/9J7tdYltWyXIY/giphy.gif)
