### PR TITLE
Update release pipeline

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,33 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Publish new release
+    runs-on: macos-12
+    if: github.event.pull_request.merged == true # only merged pull requests must trigger this job
+    steps:
+      - name: Install Bot SSH Key
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
+      - uses: actions/checkout@v3.1.0
+      - name: Extract version from branch name (for release branches)
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+      - uses: ./.github/actions/bootstrap
+      - name: "Fastlane - Publish Release"
+        # if: startsWith(github.event.pull_request.head.ref, 'release/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }}
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: bundle exec fastlane publish_release version:${{ env.RELEASE_VERSION }} --verbose

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -10,10 +10,6 @@ on:
     branches:
       - '**'
 
-  release:
-    types:
-      - created
-
   workflow_dispatch:
 
 concurrency:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GEM
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.761.0)
-    aws-sdk-core (3.172.0)
+    aws-partitions (1.766.0)
+    aws-sdk-core (3.173.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -188,7 +188,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.2.4)
+    fastlane-plugin-stream_actions (0.3.4)
     fastlane-plugin-versioning (0.5.1)
     ffi (1.15.5)
     fourflusher (2.3.1)
@@ -197,7 +197,7 @@ GEM
     git (1.18.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
-    google-apis-androidpublisher_v3 (0.41.0)
+    google-apis-androidpublisher_v3 (0.42.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -276,8 +276,8 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.0)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (5.6.1)
       faraday (>= 1, < 3)
@@ -355,7 +355,7 @@ GEM
       clamp (~> 1.3)
       nokogiri (>= 1.13.9)
       xcodeproj (~> 1.21)
-    sqlite3 (1.6.2)
+    sqlite3 (1.6.3)
       mini_portile2 (~> 2.8.0)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
@@ -405,7 +405,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-emerge
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.2.4)
+  fastlane-plugin-stream_actions (= 0.3.4)
   fastlane-plugin-versioning
   jazzy
   json

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,6 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/StreamVideo"><img src="https://img.shields.io/badge/CocoaPods-compatible-green" /></a>
-  <a href="https://github.com/Carthage/Carthage"><img src="https://img.shields.io/badge/Carthage-compatible-green" /></a>
   <a href="https://www.swift.org/package-manager/"><img src="https://img.shields.io/badge/SPM-compatible-green" /></a>
 </p>
 <p align="center">

--- a/Sources/StreamVideo/Info.plist
+++ b/Sources/StreamVideo/Info.plist
@@ -2,23 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>NSHumanReadableCopyright</key>
-	<string></string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.21</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string/>
 </dict>
 </plist>

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
@@ -41,7 +41,7 @@ struct CallParticipantBackground<Background: View>: View {
     var body: some View {
         ZStack {
             if #available(iOS 14.0, *), let imageURL = imageURL {
-                LazyImage(url: imageURL)
+                LazyImage(imageURL: imageURL)
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .blur(radius: 8)

--- a/Sources/StreamVideoSwiftUI/Info.plist
+++ b/Sources/StreamVideoSwiftUI/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>0.0.21</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string></string>
+	<string/>
 </dict>
 </plist>

--- a/Sources/StreamVideoSwiftUI/Utils/LazyImageExtensions.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/LazyImageExtensions.swift
@@ -1,0 +1,28 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Nuke
+import NukeUI
+import SwiftUI
+
+@available(iOS 14.0, *)
+extension LazyImage {
+
+    public init(imageURL: URL?) where Content == NukeUI.Image {
+        #if COCOAPODS
+        self.init(source: imageURL)
+        #else
+        self.init(url: imageURL, resizingMode: .aspectFill)
+        #endif
+    }
+
+    public init(imageURL: URL?, @ViewBuilder content: @escaping (LazyImageState) -> Content) {
+        #if COCOAPODS
+        self.init(source: imageURL, content: content)
+        #else
+        self.init(url: imageURL, content: content)
+        #endif
+        return
+    }
+}

--- a/Sources/StreamVideoSwiftUI/Utils/UserAvatar.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/UserAvatar.swift
@@ -20,7 +20,7 @@ public struct UserAvatar: View {
     }
     
     public var body: some View {
-        LazyImage(url: imageURL)
+        LazyImage(imageURL: imageURL)
             .frame(width: size, height: size)
             .clipShape(Circle())
     }

--- a/Sources/StreamVideoUIKit/Info.plist
+++ b/Sources/StreamVideoUIKit/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>0.0.21</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string></string>
+	<string/>
 </dict>
 </plist>

--- a/StreamVideo.podspec
+++ b/StreamVideo.podspec
@@ -1,24 +1,24 @@
 Pod::Spec.new do |spec|
-  spec.name = "StreamVideo"
-  spec.version = "1.0.0"
-  spec.summary = "StreamVideo iOS Video Client"
-  spec.description = "stream-video-swift is the official Swift client for Stream Video, a service for building video applications."
+  spec.name = 'StreamVideo'
+  spec.version = '0.0.21'
+  spec.summary = 'StreamVideo iOS Video Client'
+  spec.description = 'StreamVideo is the official Swift client for Stream Video, a service for building video applications.'
 
-  spec.homepage = "https://getstream.io/video/"
-  spec.license = { type: "BSD-3", file: "LICENSE" }
-  spec.author = { "getstream.io" => "support@getstream.io" }
-  spec.social_media_url = "https://getstream.io"
+  spec.homepage = 'https://getstream.io/video/'
+  spec.license = { type: 'BSD-3', file: 'LICENSE' }
+  spec.author = { 'getstream.io' => 'support@getstream.io' }
+  spec.social_media_url = 'https://getstream.io'
 
-  spec.swift_version = "5.2"
-  spec.platform = :ios, "14.0"
+  spec.swift_version = '5.3'
+  spec.platform = :ios, '13.0'
   spec.requires_arc = true
 
-  spec.framework = "Foundation"
+  spec.framework = 'Foundation'
   spec.module_name = spec.name
-  spec.source = { git: "https://github.com/GetStream/stream-video-swift.git", tag: spec.version }
-  spec.source_files = ["Sources/StreamVideo/**/*.swift"]
-  spec.exclude_files = ["Sources/StreamVideo/**/*_Tests.swift", "Sources/StreamVideo/**/*_Mock.swift"]
+  spec.source = { git: 'https://github.com/GetStream/stream-video-swift.git', tag: spec.version }
+  spec.source_files = ["Sources/#{spec.name}/**/*.swift"]
+  spec.exclude_files = ["Sources/#{spec.name}/**/*_Tests.swift", "Sources/#{spec.name}/**/*_Mock.swift"]
 
-  spec.dependency("SwiftProtobuf", "~> 1.18.0")
-  spec.dependency("WebRTC-SDK", "104.5112.11")
+  spec.dependency('SwiftProtobuf', '~> 1.18.0')
+  spec.dependency('WebRTC-SDK', '104.5112.11')
 end

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		8251E6302A17BEEF00E7257A /* ImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251E62E2A17BEEF00E7257A /* ImageFactory.swift */; };
 		8251E6312A17BEEF00E7257A /* ImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251E62E2A17BEEF00E7257A /* ImageFactory.swift */; };
 		82686160290A7556005BFFED /* SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8268615F290A7556005BFFED /* SystemEnvironment.swift */; };
+		827D893E2A16369300838B1A /* LazyImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827D893D2A16369300838B1A /* LazyImageExtensions.swift */; };
 		828DE5BD299521EF00F93197 /* UserRobot+Asserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828DE5BC299521EF00F93197 /* UserRobot+Asserts.swift */; };
 		829A1F6929FACCAF0072ED75 /* ParticipantsGridLayout_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829A1F6829FACCAF0072ED75 /* ParticipantsGridLayout_Tests.swift */; };
 		829A1F6B29FACCC20072ED75 /* ParticipantsSpotlightLayout_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829A1F6A29FACCC20072ED75 /* ParticipantsSpotlightLayout_Tests.swift */; };
@@ -673,6 +674,7 @@
 		8251E62A2A17BEB400E7257A /* StreamVideoTestResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamVideoTestResources.swift; sourceTree = "<group>"; };
 		8251E62E2A17BEEF00E7257A /* ImageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFactory.swift; sourceTree = "<group>"; };
 		8268615F290A7556005BFFED /* SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEnvironment.swift; sourceTree = "<group>"; };
+		827D893D2A16369300838B1A /* LazyImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyImageExtensions.swift; sourceTree = "<group>"; };
 		828DE5BC299521EF00F93197 /* UserRobot+Asserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserRobot+Asserts.swift"; sourceTree = "<group>"; };
 		829A1F6829FACCAF0072ED75 /* ParticipantsGridLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsGridLayout_Tests.swift; sourceTree = "<group>"; };
 		829A1F6A29FACCC20072ED75 /* ParticipantsSpotlightLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsSpotlightLayout_Tests.swift; sourceTree = "<group>"; };
@@ -2006,6 +2008,7 @@
 				8469593D29BF214700134EA0 /* ViewExtensions.swift */,
 				846E4B0429D2D3D3003733AB /* ModifiedContent.swift */,
 				8479F83329C09EF1009ECE37 /* UserAvatar.swift */,
+				827D893D2A16369300838B1A /* LazyImageExtensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3049,6 +3052,7 @@
 				84F3B0E228916FF20088751D /* CallParticipantsInfoView.swift in Sources */,
 				8434C52B289AA3150001490A /* Appearance.swift in Sources */,
 				8434C527289AA2F00001490A /* Images.swift in Sources */,
+				827D893E2A16369300838B1A /* LazyImageExtensions.swift in Sources */,
 				8435EB9229CDAD0D00E02651 /* ParticipantsFullScreenLayout.swift in Sources */,
 				84DC382F29A8BB8D00946713 /* CallParticipantsInfoViewModel.swift in Sources */,
 				846FBE9128AAF52600147F6E /* SelectedParticipantView.swift in Sources */,

--- a/StreamVideoSwiftUI.podspec
+++ b/StreamVideoSwiftUI.podspec
@@ -1,26 +1,25 @@
 Pod::Spec.new do |spec|
-  spec.name = "StreamVideoSwiftUI"
-  spec.version = "1.0.0"
-  spec.summary = "StreamVideo SwiftUI Video Components"
-  spec.description = "StreamVideoSwiftUI SDK offers flexible SwiftUI components able to display data provided by StreamVideo SDK."
+  spec.name = 'StreamVideoSwiftUI'
+  spec.version = '0.0.21'
+  spec.summary = 'StreamVideo SwiftUI Video Components'
+  spec.description = 'StreamVideoSwiftUI SDK offers flexible SwiftUI components able to display data provided by StreamVideo SDK.'
 
-  spec.homepage = "https://getstream.io/video/"
-  spec.license = { type: "BSD-3", file: "LICENSE" }
-  spec.author = { "getstream.io" => "support@getstream.io" }
-  spec.social_media_url = "https://getstream.io"
+  spec.homepage = 'https://getstream.io/video/'
+  spec.license = { type: 'BSD-3', file: 'LICENSE' }
+  spec.author = { 'getstream.io' => 'support@getstream.io' }
+  spec.social_media_url = 'https://getstream.io'
 
-  spec.swift_version = "5.2"
-  spec.platform = :ios, "14.0"
+  spec.swift_version = '5.3'
+  spec.platform = :ios, '13.0'
   spec.requires_arc = true
 
-  spec.framework = "Foundation", "SwiftUI"
+  spec.framework = 'Foundation', 'SwiftUI'
   spec.module_name = spec.name
-  spec.source = { git: "https://github.com/GetStream/stream-video-swift.git", tag: spec.version }
+  spec.source = { git: 'https://github.com/GetStream/stream-video-swift.git', tag: spec.version }
   spec.source_files = ["Sources/#{spec.name}/**/*.swift"]
   spec.exclude_files = ["Sources/#{spec.name}/**/*_Tests.swift", "Sources/#{spec.name}/**/*_Mock.swift"]
   spec.resource_bundles = { spec.name => ["Sources/#{spec.name}/Resources/**/*"] }
 
-  spec.dependency("StreamVideo", spec.version)
-  spec.dependency("Nuke", "10.7.1")
-  spec.dependency("NukeUI", "0.8.0")
+  spec.dependency('StreamVideo', "#{spec.version}")
+  spec.dependency('NukeUI', '0.8.0')
 end

--- a/StreamVideoUIKit.podspec
+++ b/StreamVideoUIKit.podspec
@@ -1,25 +1,25 @@
 Pod::Spec.new do |spec|
-  spec.name = "StreamVideoUIKit"
-  spec.version = "1.0.0"
-  spec.summary = "StreamVideo UIKit Video Components"
-  spec.description = "StreamVideoUIKit SDK offers flexible UIKit components able to display data provided by StreamVideo SDK."
+  spec.name = 'StreamVideoUIKit'
+  spec.version = '0.0.21'
+  spec.summary = 'StreamVideo UIKit Video Components'
+  spec.description = 'StreamVideoUIKit SDK offers flexible UIKit components able to display data provided by StreamVideo SDK.'
 
-  spec.homepage = "https://getstream.io/video/"
-  spec.license = { type: "BSD-3", file: "LICENSE" }
-  spec.author = { "getstream.io" => "support@getstream.io" }
-  spec.social_media_url = "https://getstream.io"
+  spec.homepage = 'https://getstream.io/video/'
+  spec.license = { type: 'BSD-3', file: 'LICENSE' }
+  spec.author = { 'getstream.io' => 'support@getstream.io' }
+  spec.social_media_url = 'https://getstream.io'
 
-  spec.swift_version = "5.2"
-  spec.platform = :ios, "14.0"
+  spec.swift_version = '5.3'
+  spec.platform = :ios, '13.0'
   spec.requires_arc = true
 
-  spec.framework = "Foundation", "UIKit"
+  spec.framework = 'Foundation', 'UIKit'
   spec.module_name = spec.name
-  spec.source = { git: "https://github.com/GetStream/stream-video-swift.git", tag: spec.version }
+  spec.source = { git: 'https://github.com/GetStream/stream-video-swift.git', tag: spec.version }
   spec.source_files = ["Sources/#{spec.name}/**/*.swift"]
   spec.exclude_files = ["Sources/#{spec.name}/**/*_Tests.swift", "Sources/#{spec.name}/**/*_Mock.swift"]
 
-  spec.dependency("StreamVideo", spec.version)
-  spec.dependency("Nuke", "10.7.1")
-  spec.dependency("NukeUI", "0.8.0")
+  spec.dependency('StreamVideo', "#{spec.version}")
+  spec.dependency('StreamVideoSwiftUI', "#{spec.version}")
+  spec.dependency('NukeUI', '0.8.0')
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,7 @@ import 'Allurefile'
 
 xcode_version = ENV['XCODE_VERSION'] || '14.2'
 xcode_project = 'StreamVideo.xcodeproj'
-sdk_names = ['StreamVideo', 'StreamVideoSwiftUI']
+sdk_names = ['StreamVideo', 'StreamVideoSwiftUI', 'StreamVideoUIKit']
 github_repo = ENV['GITHUB_REPOSITORY'] || 'GetStream/stream-video-swift'
 sinatra_port = 4567
 video_buddy_port = 5678
@@ -17,7 +17,7 @@ before_all do |lane|
   if is_ci
     setup_ci
     ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '180'
-    xcodes(version: xcode_version, select_for_current_build_only: true) unless [:publish_release, :allure_launch].include?(lane)
+    xcodes(version: xcode_version, select_for_current_build_only: true) unless [:allure_launch].include?(lane)
   end
 end
 
@@ -35,8 +35,19 @@ lane :release do |options|
     bump_type: options[:type],
     sdk_names: sdk_names,
     github_repo: github_repo,
-    pod_sync: options[:pod_sync],
-    skip_pod_list: true # This argument needs to be removed after first release
+    update_version_numbers: true,
+    publish_release: true, # TODO: delete this once we have a develop branch
+    create_pull_request: false # TODO: create pull request once we have a develop branch
+  )
+end
+
+desc "Publish a new release to GitHub and CocoaPods"
+lane :publish_release do |options|
+  release_ios_sdk(
+    version: options[:version],
+    sdk_names: sdk_names,
+    github_repo: github_repo,
+    publish_release: true
   )
 end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,3 +1,3 @@
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-emerge'
-gem 'fastlane-plugin-stream_actions', '0.2.4'
+gem 'fastlane-plugin-stream_actions', '0.3.4'


### PR DESCRIPTION
### 🎯 Goal

Test the release pipeline

### 📝 Summary

- `publish-release.yml` is disabled in [GitHub Actions UI](https://github.com/GetStream/stream-video-swift/actions/workflows/publish-release.yml) until we implement a `develop` branch, i.e. currently **releasing is only possible locally**.
- This [release action](https://github.com/GetStream/fastlane-plugin-stream_actions/blob/main/lib/fastlane/plugin/stream_actions/actions/release_ios_sdk.rb) is shared across all iOS SDKs
- `LazyImage` is extended to support both SPM and CocoaPods distribution

### ✅ Testing

- [x] Release pipeline passes locally
- [x] [Release pipeline passes on GitHub Actions](https://github.com/GetStream/stream-video-swift/actions/runs/5014753972/jobs/8990080447)
- [x] SPM integration works fine
- [x] CocoaPods integration works fine
- [x] All test releases are deleted from GitHub and CocoaPods

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

![giphy-downsized-large](https://github.com/GetStream/stream-video-swift/assets/20794991/0768a89a-2435-4d86-8183-7e856d4938a9)

