### PR TITLE
Fix View Change button not clickable when participant image contains …

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/CallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallView.swift
@@ -59,26 +59,24 @@ public struct CallView<Factory: ViewFactory>: View {
                     }
                 }
                                 
-                TopRightView {
-                    VStack(alignment: .trailing, spacing: padding) {
-                        viewFactory.makeCallTopView(viewModel: viewModel)
-                        
-                        if viewModel.screensharingSession == nil, viewModel.participantsLayout == .grid {
-                            CornerDragableView(
-                                content: contentDragableView(size: reader.size),
-                                proxy: reader
-                            ) {
-                                withAnimation {
-                                    if participants.count == 1 {
-                                        viewModel.localVideoPrimary.toggle()
-                                    }
+                VStack(alignment: .trailing, spacing: padding) {
+                    viewFactory.makeCallTopView(viewModel: viewModel)
+
+                    if viewModel.screensharingSession == nil, viewModel.participantsLayout == .grid {
+                        CornerDragableView(
+                            content: contentDragableView(size: reader.size),
+                            proxy: reader
+                        ) {
+                            withAnimation {
+                                if participants.count == 1 {
+                                    viewModel.localVideoPrimary.toggle()
                                 }
                             }
-                            .accessibility(identifier: "cornerDragableView")
                         }
+                        .accessibility(identifier: "cornerDragableView")
                     }
-                    .padding(.top, 4)
                 }
+                .padding(.top, 4)
                 .opacity(viewModel.hideUIElements ? 0 : 1)
                 
                 if viewModel.participantsShown {

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
@@ -53,7 +53,6 @@ struct CallParticipantBackground<Background: View>: View {
         ZStack {
             if #available(iOS 14.0, *), let imageURL = imageURL {
                 StreamLazyImage(imageURL: imageURL)
-                    .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .blur(radius: 8)
                     .clipped()

--- a/Sources/StreamVideoSwiftUI/Utils/LazyImageExtensions.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/LazyImageExtensions.swift
@@ -42,6 +42,7 @@ struct StreamLazyImage: View {
            imageURL.isFileURL,
            let image = UIImage(contentsOfFile: imageURL.path)  {
             Image(image)
+                .aspectRatio(contentMode: .fill)
         } else {
             LazyImage(imageURL: imageURL)
         }


### PR DESCRIPTION
### 🎯 Goal

- View button should be clickable when non primary participant thumbnail's location is topTrailing and the thumbnail contains an image.
- Minimize(back) button should be clickable when non primary participant thumbnail's location is topLeading and the thumbnail contains an image.

### 🛠 Implementation

Calling `.aspectRatio(contentMode: .fill)` was causing the view to extend outside its bounds and overlap with topBar's button areas. Additionally, setting the contentMode of a view doesn't produce the same effect as setting the contentMode of an Image.

The right way to do it by calling the following:
```swift
Image(url: ...)
    .resizable()
    .aspectRation(contentMode: .fill)
```

In our case, it seems like this wasn't event necessary as we are using LazyImage instead of Image and we are already setting the resizingMode to aspectFill.

### 🎨 Showcase

https://github.com/GetStream/stream-video-swift/assets/472467/0bd2ea53-20f6-40ed-a79b-a96ff93585bf

https://github.com/GetStream/stream-video-swift/assets/472467/3b8d3bcf-57a6-478d-b167-d7c9d50f3824

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)
