### PR TITLE
Use the shared call types page

### DIFF
--- a/docusaurus/docs/iOS/03-guides/05-call-types.mdx
+++ b/docusaurus/docs/iOS/03-guides/05-call-types.mdx
@@ -3,24 +3,6 @@ title: Call Types
 description: How Call Types control features and permissions
 ---
 
-When you start a call, you also need to provide the call type. Call types come with some predefined settings and permissions, depending on the video calling use-case they represent.
+import CallTypesPage from '../../../shared/video/_call-types.md';
 
-#### Development
-
-The `development` call type has all the permissions enabled, and can be used during development. It's not recommended to use this call type in production, since all the participants in the calls would be able to do everything (blocking, muting everyone, etc).
-
-For these call types, backstage is not enabled, therefore you don't have to explicitly call `goLive` in order for the call to be started.
-
-#### Default
-
-The `default` call type can be used for different video-calling apps, such as 1-1 calls, group calls or meetings with multiple people. Both video and audio are enabled, and backstage is disabled. It has permissions settings in place, where admins and hosts have elevated permissions over other types of users.
-
-#### Audio Room
-
-The `audio_room` call type is suitable for apps like Clubhouse or Twitter Spaces. It has pre-configured workflow around requesting permissions to speak for regular listeners. Backstage is enabled, and new calls are going to the backstage mode when created. You will need to explicitly call the `goLive` method to make the call active for all participants.
-
-You can find a guide on how to handle this [here](../../tutorials/audio-room).
-
-#### Livestream
-
-The `livestream` call type is configured to be used for livestreaming apps. Access to calls is granted to all authenticated users, and backstage is enabled by default.
+<CallTypesPage />


### PR DESCRIPTION
### 🎯 Goal

Use the shared page we have for call types.

### 📝 Summary

The content of the call types page is similar across SDKs so we created a shared one (with content that is not yet complete). This PR uses that shared page. Once the content of the shared page is finalized it will automatically be distributed across SDKs (including iOS).

### 🛠 Implementation

If interested, the page can be found [here](https://github.com/GetStream/stream-chat-docusaurus-cli/blob/staging/shared/video/_call-types.md).

### 🎨 Showcase

![Call Types | Stream Video - iOS SDK Docs](https://github.com/GetStream/stream-video-swift/assets/12433593/3cb6e3dd-c985-402d-a37a-3d5f86bd23a8)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

I don't like fun.
