### PR TITLE
Update app version as part of Testflight upload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,8 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.3.7)
+    fastlane-plugin-stream_actions (0.3.17)
+      xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.5.1)
     ffi (1.15.5)
     fourflusher (2.3.1)
@@ -405,7 +406,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-emerge
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.3.7)
+  fastlane-plugin-stream_actions (= 0.3.17)
   fastlane-plugin-versioning
   jazzy
   json

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,3 +1,3 @@
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-emerge'
-gem 'fastlane-plugin-stream_actions', '0.3.7'
+gem 'fastlane-plugin-stream_actions', '0.3.17'


### PR DESCRIPTION
Testflight upload fails if release to App Store was done manually. This PR should solve [this](https://github.com/GetStream/stream-video-swift/actions/runs/5587921433). 

All magic here: https://github.com/GetStream/fastlane-plugin-stream_actions/commit/8e7ad3d5317320fa655fa0ade112270ea646afcb