### PR TITLE
Add E2E JWT tests

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -64,6 +64,7 @@ jobs:
         STREAM_SDK_TEST_ACCOUNT_EMAIL: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_EMAIL }}
         STREAM_SDK_TEST_ACCOUNT_PASSWORD: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_PASSWORD }}
         STREAM_SDK_TEST_ACCOUNT_OTP_SECRET: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET }}
+        STREAM_VIDEO_SECRET: ${{ secrets.STREAM_VIDEO_SECRET }}
     - name: Allure TestOps Upload
       if: success() || failure()
       run: bundle exec fastlane allure_upload launch_id:$LAUNCH_ID

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -139,7 +139,7 @@ jobs:
           fastlane/test_output/snapshots
 
   build-apps:
-    name: Build Demo App
+    name: Build Demo Apps
     runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     env:
@@ -184,6 +184,7 @@ jobs:
         STREAM_SDK_TEST_ACCOUNT_EMAIL: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_EMAIL }}
         STREAM_SDK_TEST_ACCOUNT_PASSWORD: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_PASSWORD }}
         STREAM_SDK_TEST_ACCOUNT_OTP_SECRET: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET }}
+        STREAM_VIDEO_SECRET: ${{ secrets.STREAM_VIDEO_SECRET }}
     - name: Allure TestOps Upload
       if: env.LAUNCH_ID != '' && (success() || failure())
       run: bundle exec fastlane allure_upload launch_id:$LAUNCH_ID

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,6 +1,7 @@
 coverage_service: sonarqube_xml
 xcodeproj: StreamVideo.xcodeproj
 scheme: StreamVideo
+configuration: Test
 source_directory: Sources/
 output_directory: reports
 ignore:

--- a/DemoApp/CallView.swift
+++ b/DemoApp/CallView.swift
@@ -64,11 +64,11 @@ struct CallHomeView: View {
     @ObservedObject var viewModel: CallViewModel
     
     var body: some View {
-        if ProcessInfo.processInfo.arguments.contains("STREAM_E2E_TESTS") {
+        #if STREAM_E2E_TESTS
             HomeView(viewModel: viewModel)
-        } else {
+        #else
             StreamCallingView(viewModel: viewModel)
-        }
+        #endif
     }
     
 }

--- a/DemoApp/LocalStorage.swift
+++ b/DemoApp/LocalStorage.swift
@@ -97,5 +97,4 @@ class UnsecureUserRepository: UserRepository, VoipTokenHandler, PushTokenHandler
         defaults.set(nil, forKey: pushTokenKey)
     }
     
-    
 }

--- a/DemoApp/StreamVideoSwiftUIApp.swift
+++ b/DemoApp/StreamVideoSwiftUIApp.swift
@@ -118,6 +118,12 @@ struct StreamVideoSwiftUIApp: App {
     }
     
     private func checkLoggedInUser() {
+        #if STREAM_E2E_TESTS
+        if ProcessInfo.processInfo.arguments.contains("MOCK_JWT") {
+            return
+        }
+        #endif
+        
         if let userCredentials = userRepository.loadCurrentUser() {
             appState.currentUser = userCredentials.userInfo
             appState.userState = .loggedIn

--- a/DemoApp/TokenService.swift
+++ b/DemoApp/TokenService.swift
@@ -48,6 +48,12 @@ class TokenService {
     }
 
     func fetchToken(for userId: String, callIds: [String] = []) async throws -> UserToken {
+        #if STREAM_E2E_TESTS
+        if ProcessInfo.processInfo.arguments.contains("MOCK_JWT") {
+            return fetchTestToken(for: userId)
+        }
+        #endif
+        
         var parameters: [String: String] = [
             "user_id": userId,
             "api_key": Config.apiKey
@@ -75,4 +81,12 @@ struct Config {
     static let apiKeyLocal = "892s22ypvt6m"
     static let baseURL = URL(string: "https://staging.getstream.io/")!
     static let appURLScheme = "streamvideo"
+}
+
+extension TokenService {
+    
+    func fetchTestToken(for userId: String) -> UserToken {
+        let expiration = Int(ProcessInfo.processInfo.environment["JWT_EXPIRATION"] ?? "100")!
+        return TokenGenerator.shared.fetchToken(for: userId, expiration: expiration)!
+    }
 }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		4351AEAD2A40588D00D32D0D /* IntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4351AEAC2A40588D00D32D0D /* IntegrationTest.swift */; };
 		4351AEAF2A40591800D32D0D /* CallCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4351AEAE2A40591800D32D0D /* CallCRUDTests.swift */; };
 		435F01B32A501148009CD0BD /* OwnCapability+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435F01B22A501148009CD0BD /* OwnCapability+Identifiable.swift */; };
+		82010CAC2A851BD6005C125D /* Credentials.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */; };
+		82010CAE2A851C16005C125D /* TokenGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822257892A42F93600CFFD96 /* TokenGenerator.swift */; };
 		8202215F2A24BB7100F7BAED /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8202215E2A24BB7100F7BAED /* LaunchArgument.swift */; };
 		820221602A24BB7100F7BAED /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8202215E2A24BB7100F7BAED /* LaunchArgument.swift */; };
 		820221612A24BB7100F7BAED /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8202215E2A24BB7100F7BAED /* LaunchArgument.swift */; };
@@ -29,6 +31,8 @@
 		8206D8532A5FF3260099F5EC /* SystemEnvironment+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8206D8522A5FF3260099F5EC /* SystemEnvironment+Version.swift */; };
 		820784EF29FA8123006DD4F7 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 820784EE29FA8123006DD4F7 /* WebRTC */; };
 		820784F129FA8156006DD4F7 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 820784F029FA8156006DD4F7 /* WebRTC */; };
+		820BD5F72A72C851003A7B8F /* TokenGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822257892A42F93600CFFD96 /* TokenGenerator.swift */; };
+		820BD5FB2A73C654003A7B8F /* Credentials.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */; };
 		822257922A431F3200CFFD96 /* TokenGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822257892A42F93600CFFD96 /* TokenGenerator.swift */; };
 		82392D542993C9E100941435 /* StreamTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D532993C9E100941435 /* StreamTestCase.swift */; };
 		82392D5F2993CCB300941435 /* ParticipantRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82392D5E2993CCB300941435 /* ParticipantRobot.swift */; };
@@ -114,6 +118,7 @@
 		82E3BA552A0BAF4B001AB93E /* WebSocketClientEnvironment_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E3BA522A0BAF4B001AB93E /* WebSocketClientEnvironment_Mock.swift */; };
 		82E3BA562A0BAF64001AB93E /* WebSocketEngine_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F58B8A29EEACAD00010C4C /* WebSocketEngine_Mock.swift */; };
 		82E3BA572A0BAF65001AB93E /* WebSocketEngine_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F58B8A29EEACAD00010C4C /* WebSocketEngine_Mock.swift */; };
+		82FB89372A702A9200AC16A1 /* Authentication_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FB89362A702A9200AC16A1 /* Authentication_Tests.swift */; };
 		82FF40B52A17C6C200B4D95E /* CallControlsView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FF40B42A17C6C200B4D95E /* CallControlsView_Tests.swift */; };
 		82FF40B72A17C6CD00B4D95E /* ReconnectionView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FF40B62A17C6CD00B4D95E /* ReconnectionView_Tests.swift */; };
 		82FF40B92A17C6D600B4D95E /* RecordingView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FF40B82A17C6D600B4D95E /* RecordingView_Tests.swift */; };
@@ -814,6 +819,7 @@
 		82E2F90D2A0559E60012C037 /* sun.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sun.png; sourceTree = "<group>"; };
 		82E2F90E2A0559E60012C037 /* skin.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = skin.png; sourceTree = "<group>"; };
 		82E3BA522A0BAF4B001AB93E /* WebSocketClientEnvironment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClientEnvironment_Mock.swift; sourceTree = "<group>"; };
+		82FB89362A702A9200AC16A1 /* Authentication_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication_Tests.swift; sourceTree = "<group>"; };
 		82FF40B42A17C6C200B4D95E /* CallControlsView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallControlsView_Tests.swift; sourceTree = "<group>"; };
 		82FF40B62A17C6CD00B4D95E /* ReconnectionView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectionView_Tests.swift; sourceTree = "<group>"; };
 		82FF40B82A17C6D600B4D95E /* RecordingView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView_Tests.swift; sourceTree = "<group>"; };
@@ -1427,7 +1433,6 @@
 			children = (
 				4351AEAC2A40588D00D32D0D /* IntegrationTest.swift */,
 				4351AEAE2A40591800D32D0D /* CallCRUDTests.swift */,
-				8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */,
 			);
 			path = IntegrationTests;
 			sourceTree = "<group>";
@@ -1455,6 +1460,7 @@
 		82392D5C2993CBE200941435 /* TestTools */ = {
 			isa = PBXGroup;
 			children = (
+				8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */,
 				8251E6292A17BE9F00E7257A /* TestData */,
 				82CE900229FC3A7B00770EF6 /* Resources */,
 				824DBAA129F93DA1005ACD09 /* SnapshotTesting */,
@@ -1491,6 +1497,7 @@
 				82B8C0FB29E80A2A001F816C /* CallLifecycleTests.swift */,
 				82D858B729EDAE0A00CF9F8B /* ParticipantActionsTests.swift */,
 				824DBA9F29F6D77B005ACD09 /* ReconnectionTests.swift */,
+				82FB89362A702A9200AC16A1 /* Authentication_Tests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -2627,6 +2634,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 842D8BD12865B31D00801910 /* Build configuration list for PBXNativeTarget "DemoApp" */;
 			buildPhases = (
+				82DE10C72A827B010057BDA8 /* ShellScript */,
 				842D8BBF2865B31B00801910 /* Sources */,
 				842D8BC02865B31B00801910 /* Frameworks */,
 				842D8BC12865B31B00801910 /* Resources */,
@@ -2673,6 +2681,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8493225D2908378B0013C029 /* Build configuration list for PBXNativeTarget "DemoAppUIKit" */;
 			buildPhases = (
+				82010CAD2A851C06005C125D /* ShellScript */,
 				84932248290837890013C029 /* Sources */,
 				84932249290837890013C029 /* Frameworks */,
 				8493224A290837890013C029 /* Resources */,
@@ -2933,6 +2942,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				842D8BDC2865B37800801910 /* Preview Assets.xcassets in Resources */,
+				820BD5FB2A73C654003A7B8F /* Credentials.xcconfig in Resources */,
 				842C7EBF28A2B3FA00C2AB7F /* Assets.xcassets in Resources */,
 				842D8BDB2865B37800801910 /* Assets.xcassets in Resources */,
 			);
@@ -2949,6 +2959,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82010CAC2A851BD6005C125D /* Credentials.xcconfig in Resources */,
 				8493225B2908378B0013C029 /* LaunchScreen.storyboard in Resources */,
 				849322582908378B0013C029 /* Assets.xcassets in Resources */,
 			);
@@ -3026,6 +3037,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		82010CAD2A851C06005C125D /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "touch TestTools/Credentials.xcconfig\n";
+		};
 		827297E42A4585EA00774306 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -3042,8 +3071,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "touch StreamVideoTests/IntegrationTests/Credentials.xcconfig\n";
+			shellScript = "touch TestTools/Credentials.xcconfig\n";
 			showEnvVarsInLog = 0;
+		};
+		82DE10C72A827B010057BDA8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "touch TestTools/Credentials.xcconfig\n";
 		};
 		8434C53A289BBDF30001490A /* SwiftGen */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3082,6 +3129,7 @@
 				82B8C0F829E80933001F816C /* LobbyTests.swift in Sources */,
 				82392D6F2994027C00941435 /* Sinatra.swift in Sources */,
 				82392D6D2993CE7200941435 /* StreamVideoUITests.swift in Sources */,
+				82FB89372A702A9200AC16A1 /* Authentication_Tests.swift in Sources */,
 				82AD932529E6FCCF00D4D295 /* LobbyPage.swift in Sources */,
 				824DBAA029F6D77B005ACD09 /* ReconnectionTests.swift in Sources */,
 				828DE5BD299521EF00F93197 /* UserRobot+Asserts.swift in Sources */,
@@ -3123,6 +3171,7 @@
 				842D8BDA2865B37800801910 /* StreamVideoSwiftUIApp.swift in Sources */,
 				845C573228DDC57B00D38FCC /* DemoAppUtils.swift in Sources */,
 				84BD8FF429B0F208002CFBA0 /* HTTPClient.swift in Sources */,
+				820BD5F72A72C851003A7B8F /* TokenGenerator.swift in Sources */,
 				847B47B52A249E7E000714CE /* Examples.swift in Sources */,
 				84D6493E29E7F75E002CA428 /* CallsViewModel.swift in Sources */,
 				847B47B12A23EE44000714CE /* CustomWaitingUserView.swift in Sources */,
@@ -3153,6 +3202,7 @@
 				84BD8FF829B0F97B002CFBA0 /* TokenService.swift in Sources */,
 				84E4F7922947476400DD4CE3 /* CallViewHelper.swift in Sources */,
 				849322512908378A0013C029 /* SceneDelegate.swift in Sources */,
+				82010CAE2A851C16005C125D /* TokenGenerator.swift in Sources */,
 				84BD8FFB29B0FA5B002CFBA0 /* LoginView.swift in Sources */,
 				849322612908385C0013C029 /* HomeViewController.swift in Sources */,
 				84BD8FF729B0F964002CFBA0 /* LoginViewModel.swift in Sources */,
@@ -3768,6 +3818,416 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		820EB3112A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG STREAM_TESTS";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Test;
+		};
+		820EB3122A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Sources/StreamVideo/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = "";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideo;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Test;
+		};
+		820EB3132A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TESTS";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
+		820EB3142A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Sources/StreamVideoSwiftUI/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = "";
+				OTHER_SWIFT_FLAGS = "-DSTREAM_SNAPSHOT_TESTS -DSTREAM_E2E_TESTS";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoSwiftUI;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Test;
+		};
+		820EB3152A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoSwiftUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "";
+			};
+			name = Test;
+		};
+		820EB3162A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Sources/StreamVideoUIKit/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = "";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoUIKit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Test;
+		};
+		820EB3172A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-DSTREAM_SNAPSHOT_TESTS";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoUIKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
+		820EB3182A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DemoApp/DemoApp-Debug.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_ASSET_PATHS = "\"DemoApp/Preview Content\"";
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				GENERATE_PKGINFO_FILE = YES;
+				INFOPLIST_FILE = DemoApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Video Sample";
+				INFOPLIST_KEY_NSCameraUsageDescription = "DemoApp requires camera access in order to capture and transmit video";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Atlantis would use Bonjour Service to discover Proxyman app from your local network.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "DemoApp requires microphone access in order to capture and transmit audio";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)/usr/lib/swift",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-DSTREAM_E2E_TESTS";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.VideoDemoApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
+		820EB3192A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = DemoAppUIKit/DemoAppUIKit.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = NO;
+				GENERATE_PKGINFO_FILE = YES;
+				INFOPLIST_FILE = DemoAppUIKit/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Video Sample UIKit";
+				INFOPLIST_KEY_NSCameraUsageDescription = "DemoApp requires camera access in order to capture and transmit video";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Atlantis would use Bonjour Service to discover Proxyman app from your local network.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "DemoApp requires microphone access in order to capture and transmit audio";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = "";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)/usr/lib/swift",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.DemoAppUIKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
+		820EB31A2A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.SwiftUIDemoAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DemoApp;
+			};
+			name = Test;
+		};
+		820EB31B2A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = NO;
+				GENERATE_PKGINFO_FILE = YES;
+				INFOPLIST_FILE = CallIntent/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = CallIntent;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.VideoDemoApp.CallIntent;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
+		820EB31C2A7A8A56009FDCA5 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = ScreenSharing/ScreenSharing.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ScreenSharing/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0.1;
+				OTHER_LDFLAGS = (
+					"-Xlinker",
+					"-no_application_extension",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.VideoDemoApp.ScreenSharing;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
 		82392D592993C9E100941435 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3927,7 +4387,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG STREAM_TESTS STREAM_E2E_TESTS STREAM_SNAPSHOT_TESTS";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG STREAM_TESTS";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -3995,6 +4455,7 @@
 		};
 		842D8BD22865B31D00801910 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -4028,6 +4489,7 @@
 					"$(SDKROOT)/usr/lib/swift",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.VideoDemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4382,6 +4844,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = "";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoSwiftUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4552,6 +5015,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-DSTREAM_SNAPSHOT_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoUIKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -4585,6 +5049,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				82392D592993C9E100941435 /* Debug */,
+				820EB31A2A7A8A56009FDCA5 /* Test */,
 				82392D5A2993C9E100941435 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4594,6 +5059,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8427FF6D2A03D1D100AFD2C3 /* Debug */,
+				820EB31B2A7A8A56009FDCA5 /* Test */,
 				8427FF6E2A03D1D100AFD2C3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4603,6 +5069,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				842D8BCF2865B31D00801910 /* Debug */,
+				820EB3112A7A8A56009FDCA5 /* Test */,
 				842D8BD02865B31D00801910 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4612,6 +5079,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				842D8BD22865B31D00801910 /* Debug */,
+				820EB3182A7A8A56009FDCA5 /* Test */,
 				842D8BD32865B31D00801910 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4621,6 +5089,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				848C46AD2A6ABF7E00E5AC09 /* Debug */,
+				820EB31C2A7A8A56009FDCA5 /* Test */,
 				848C46AE2A6ABF7E00E5AC09 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4630,6 +5099,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8493225E2908378B0013C029 /* Debug */,
+				820EB3192A7A8A56009FDCA5 /* Test */,
 				8493225F2908378B0013C029 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4639,6 +5109,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				84F737FD287C13AD00A363F4 /* Debug */,
+				820EB3122A7A8A56009FDCA5 /* Test */,
 				84F737FE287C13AD00A363F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4648,6 +5119,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				84F73800287C13AD00A363F4 /* Debug */,
+				820EB3132A7A8A56009FDCA5 /* Test */,
 				84F73801287C13AD00A363F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4657,6 +5129,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				84F7381D287C141000A363F4 /* Debug */,
+				820EB3142A7A8A56009FDCA5 /* Test */,
 				84F7381E287C141000A363F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4666,6 +5139,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				84F73821287C141000A363F4 /* Debug */,
+				820EB3152A7A8A56009FDCA5 /* Test */,
 				84F73822287C141000A363F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4675,6 +5149,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				84F73838287C146D00A363F4 /* Debug */,
+				820EB3162A7A8A56009FDCA5 /* Test */,
 				84F73839287C146D00A363F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4684,6 +5159,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				84F7383B287C146D00A363F4 /* Debug */,
+				820EB3172A7A8A56009FDCA5 /* Test */,
 				84F7383C287C146D00A363F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/DemoAppUIKit.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/DemoAppUIKit.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideo.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideo.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideoSwiftUI.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideoSwiftUI.xcscheme
@@ -37,7 +37,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideoUIKit.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideoUIKit.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/StreamVideoTests/IntegrationTests/IntegrationTest.swift
+++ b/StreamVideoTests/IntegrationTests/IntegrationTest.swift
@@ -13,7 +13,7 @@ class IntegrationTest: XCTestCase {
     
     public var client: StreamVideo = {
         let userId = "thierry"
-        let token = TokenGenerator.shared.fetchToken(for: userId, expiration: 10)!
+        let token = TokenGenerator.shared.fetchToken(for: userId, expiration: 100)!
         return StreamVideo(
             apiKey: testApiKey,
             user: User(id: userId),
@@ -23,7 +23,7 @@ class IntegrationTest: XCTestCase {
     }()
 
     public func getUserClient(id: String) -> StreamVideo {
-        let token = TokenGenerator.shared.fetchToken(for: id, expiration: 10)!
+        let token = TokenGenerator.shared.fetchToken(for: id, expiration: 100)!
         return StreamVideo(
             apiKey: Self.testApiKey,
             user: User(id: id),

--- a/SwiftUIDemoAppUITests/Pages/CallDetailsPage.swift
+++ b/SwiftUIDemoAppUITests/Pages/CallDetailsPage.swift
@@ -25,4 +25,7 @@ enum CallDetailsPage {
         }
     }
     static var participants: XCUIElementQuery { participantList.buttons }
+    static var connectionErrorAlert: XCUIElement {
+        app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'StreamVideo.APIError'")).firstMatch
+    }
 }

--- a/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
@@ -235,6 +235,12 @@ extension UserRobot {
         }
         return self
     }
+    
+    @discardableResult
+    func assertConnectionErrorAlert() -> Self {
+        XCTAssertTrue(CallDetailsPage.connectionErrorAlert.wait().exists)
+        return self
+    }
 }
 
 extension XCUIElement {

--- a/SwiftUIDemoAppUITests/Robots/UserRobot.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot.swift
@@ -277,7 +277,7 @@ extension UserRobot {
     }
     
     @discardableResult
-    func waitForParticipantsToJoin(_ participantCount: Int, timeout: Double = defaultTimeout) -> Self {
+    func waitForParticipantsToJoin(_ participantCount: Int = 1, timeout: Double = defaultTimeout) -> Self {
         CallPage.participantMenu.wait(timeout: timeout).tap()
         let user = 1
         let expectedCount = participantCount + user

--- a/SwiftUIDemoAppUITests/Robots/UserRobot.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot.swift
@@ -288,6 +288,12 @@ extension UserRobot {
         return self
     }
     
+    @discardableResult
+    func waitCallControllsToAppear(timeout: Double = defaultTimeout) -> Self {
+        XCTAssertTrue(CallPage.hangUpButton.wait(timeout: timeout).exists, "Can't join the call")
+        return self
+    }
+    
     private func safelyCloseParticipantsMenu() {
         var retries = 0
         let closeButton = CallPage.ParticipantMenu.closeButton

--- a/SwiftUIDemoAppUITests/SwiftUIDemoApp.xctestplan
+++ b/SwiftUIDemoAppUITests/SwiftUIDemoApp.xctestplan
@@ -9,7 +9,17 @@
     }
   ],
   "defaultOptions" : {
-
+    "environmentVariableEntries" : [
+      {
+        "key" : "STREAM_VIDEO_SECRET",
+        "value" : "$(STREAM_VIDEO_SECRET)"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:StreamVideo.xcodeproj",
+      "identifier" : "842D8BC22865B31B00801910",
+      "name" : "DemoApp"
+    }
   },
   "testTargets" : [
     {

--- a/SwiftUIDemoAppUITests/Tests/Authentication_Tests.swift
+++ b/SwiftUIDemoAppUITests/Tests/Authentication_Tests.swift
@@ -1,0 +1,130 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+final class Authentication_Tests: StreamTestCase {
+    
+    let participants = 1
+    let jwtExpirationTimeoutInSeconds = TestRunnerEnvironment.isCI ? "10" : "2"
+    
+    override func setUpWithError() throws {
+        launchApp = false
+        app.setLaunchArguments(.mockJwt)
+        try super.setUpWithError()
+    }
+    
+    override class func tearDown() {
+        app.launch()
+        userRobot.logout()
+        sleep(1) // to make sure jwt mocking is turned off
+        super.tearDown()
+    }
+    
+    func waitForJwtToExpire() {
+        sleep(UInt32(jwtExpirationTimeoutInSeconds)!)
+    }
+    
+    func test_tokenExpiriesBeforeUserLogsIn() throws {
+        linkToScenario(withId: 2562)
+        
+        GIVEN("token expires") {
+            app.setLaunchArguments(.invalidateJwt)
+            app.launch()
+            waitForJwtToExpire()
+        }
+        WHEN("user logs in") {
+            userRobot
+                .logout()
+                .login(waitForLoginPage: true)
+                .startCall(callId)
+        }
+        THEN("app requests a token refresh") {}
+        WHEN("participant joins the call") {
+            participantRobot.joinCall(callId)
+        }
+        THEN("there are \(participants) participants on the call") {
+            userRobot
+                .waitForParticipantsToJoin(participants)
+                .assertCallControls()
+                .assertGridView(with: participants)
+        }
+    }
+    
+    func test_tokenExpiriesAfterUserLoggedIn() {
+        linkToScenario(withId: 2563)
+
+        GIVEN("user logs in") {
+            app.setEnvironmentVariables([.jwtExpiration: jwtExpirationTimeoutInSeconds])
+            app.launch()
+            
+            userRobot
+                .logout()
+                .login(waitForLoginPage: true)
+                .startCall(callId)
+        }
+        WHEN("token expires") {}
+        THEN("app requests a token refresh") {}
+        WHEN("participant joins the call") {
+            participantRobot.joinCall(callId)
+        }
+        THEN("there are \(participants) participants on the call") {
+            userRobot
+                .waitForParticipantsToJoin(participants)
+                .assertCallControls()
+                .assertGridView(with: participants)
+        }
+    }
+
+    func test_tokenExpiriesWhenUserIsInBackground() {
+        linkToScenario(withId: 2564)
+
+        GIVEN("user logs in") {
+            app.setEnvironmentVariables([.jwtExpiration: jwtExpirationTimeoutInSeconds])
+            app.launch()
+            
+            userRobot
+                .logout()
+                .login(waitForLoginPage: true)
+                .startCall(callId)
+        }
+        AND("user goes to background") {
+            deviceRobot.moveApplication(to: .background)
+        }
+        AND("participant joins the call") {
+            participantRobot.joinCall(callId)
+        }
+        WHEN("token expires") {
+            waitForJwtToExpire()
+        }
+        AND("user comes back to foreground") {
+            deviceRobot.moveApplication(to: .foreground)
+        }
+        THEN("there are \(participants) participants on the call") {
+            userRobot
+                .waitForParticipantsToJoin(participants)
+                .assertCallControls()
+                .assertGridView(with: participants)
+        }
+    }
+
+    func test_tokenGenerationFails() {
+        linkToScenario(withId: 2566)
+
+        GIVEN("JWT generation breaks on server side") {
+            app.setLaunchArguments(.breakJwt)
+            app.launch()
+        }
+        AND("user tries to log in") {
+            userRobot
+                .logout()
+                .login(waitForLoginPage: true)
+                .startCall(callId, waitForCompletion: false)
+        }
+        WHEN("app requests a token refresh") {}
+        THEN("app shows a connection error alert") {
+            userRobot.assertConnectionErrorAlert()
+        }
+    }
+}

--- a/SwiftUIDemoAppUITests/Tests/CallLifecycleTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/CallLifecycleTests.swift
@@ -82,12 +82,14 @@ final class CallLifecycleTests: StreamTestCase {
     func testUserReentersTheCall() {
         linkToScenario(withId: 1780)
         
+        let participants = 1
+        
         GIVEN("user starts a call") {
             userRobot.login().startCall(callId)
         }
         AND("participant joins the call") {
             participantRobot.joinCall(callId)
-            userRobot.waitForParticipantsToJoin(1)
+            userRobot.waitForParticipantsToJoin(participants)
         }
         WHEN("user re-enters the call as the same user") {
             userRobot
@@ -97,12 +99,14 @@ final class CallLifecycleTests: StreamTestCase {
         THEN("there is one participant on the call") {
             userRobot
                 .assertCallControls()
-                .assertParticipantsAreVisible(count: 1)
+                .assertParticipantsAreVisible(count: participants)
         }
     }
     
     func testUserReentersTheCallAsTheSameUserAfterLoggingOut() {
         linkToScenario(withId: 1781)
+        
+        let participants = 1
         
         GIVEN("user starts a call") {
             userRobot
@@ -112,7 +116,7 @@ final class CallLifecycleTests: StreamTestCase {
         }
         AND("participant joins the call") {
             participantRobot.joinCall(callId)
-            userRobot.waitForParticipantsToJoin(1)
+            userRobot.waitForParticipantsToJoin(participants)
         }
         WHEN("user re-enters the call as the same user") {
             userRobot
@@ -124,12 +128,14 @@ final class CallLifecycleTests: StreamTestCase {
         THEN("there is one participant on the call") {
             userRobot
                 .assertCallControls()
-                .assertParticipantsAreVisible(count: 1)
+                .assertParticipantsAreVisible(count: participants)
         }
     }
     
     func testUserReentersTheCallAsAnotherUser() {
         linkToScenario(withId: 1782)
+        
+        let participants = 1
         
         GIVEN("user starts a call") {
             userRobot
@@ -139,7 +145,7 @@ final class CallLifecycleTests: StreamTestCase {
         }
         AND("participant joins the call") {
             participantRobot.joinCall(callId)
-            userRobot.waitForParticipantsToJoin(1)
+            userRobot.waitForParticipantsToJoin(participants)
         }
         WHEN("user re-enters the call as another user") {
             userRobot
@@ -151,7 +157,7 @@ final class CallLifecycleTests: StreamTestCase {
         THEN("there is one participant on the call") {
             userRobot
                 .assertCallControls()
-                .assertParticipantsAreVisible(count: 1)
+                .assertParticipantsAreVisible(count: participants)
         }
     }
     

--- a/SwiftUIDemoAppUITests/Tests/CallViewsTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/CallViewsTests.swift
@@ -34,13 +34,13 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId, options: [.withCamera])
+            userRobot.waitForParticipantsToJoin(participants)
         }
         AND("user enables grid view") {
             userRobot.setView(mode: .grid)
         }
         THEN("there are \(participants) participants on the call") {
             userRobot
-                .waitForParticipantsToJoin(participants)
                 .assertCallControls()
                 .assertGridView(with: participants)
         }
@@ -77,13 +77,13 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId, options: [.withCamera])
+            userRobot.waitForParticipantsToJoin(participants)
         }
         AND("user enables grid view") {
             userRobot.setView(mode: .grid)
         }
         THEN("there are \(participants) participants on the call") {
             userRobot
-                .waitForParticipantsToJoin(participants)
                 .assertCallControls()
                 .assertGridView(with: participants)
         }
@@ -122,13 +122,13 @@ final class CallViewsTests: StreamTestCase {
                 .setUserCount(participants)
                 .setCallDuration(timeout)
                 .joinCall(callId, options: [.withCamera])
+            userRobot.waitForParticipantsToJoin(participants)
         }
         AND("user enables grid view") {
             userRobot.setView(mode: .grid)
         }
         THEN("there are \(participants) participants on the call") {
             userRobot
-                .waitForParticipantsToJoin(participants)
                 .assertCallControls()
                 .assertGridView(with: participants)
         }
@@ -162,14 +162,13 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId)
+            userRobot.waitForParticipantsToJoin(participants)
         }
         WHEN("user enables grid view") {
             userRobot.setView(mode: .grid)
         }
         AND("user minimizes video view") {
-            userRobot
-                .waitForParticipantsToJoin(participants)
-                .minimizeVideoView()
+            userRobot.minimizeVideoView()
         }
         THEN("video view is minimized for the user") {
             userRobot
@@ -236,6 +235,7 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId)
+            userRobot.waitForParticipantsToJoin(participants)
         }
         WHEN("user enables grid view") {
             userRobot.setView(mode: .grid)
@@ -266,6 +266,7 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId)
+            userRobot.waitForParticipantsToJoin(participants)
         }
         WHEN("user minimizes video view") {
             userRobot.minimizeVideoView()
@@ -295,10 +296,10 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId, actions: [.shareScreen])
+            userRobot.waitForParticipantsToJoin(participants, timeout: UserRobot.defaultTimeout * 1.5)
         }
         THEN("user observers participant's screen") {
             userRobot
-                .waitForParticipantsToJoin(participants, timeout: UserRobot.defaultTimeout * 1.5)
                 .assertParticipantStartSharingScreen()
                 .assertScreenSharingParticipantListVisibity(percent: 0)
         }
@@ -321,13 +322,13 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId)
+            userRobot.waitForParticipantsToJoin(participants, timeout: UserRobot.defaultTimeout * 1.5)
         }
         WHEN("user enables grid view") {
             userRobot.setView(mode: .grid)
         }
         THEN("user observers the list of participants") {
             userRobot
-                .waitForParticipantsToJoin(participants, timeout: UserRobot.defaultTimeout * 1.5)
                 .assertGridView(with: participants)
                 .assertGridViewParticipantListVisibity(percent: 0)
         }
@@ -350,11 +351,10 @@ final class CallViewsTests: StreamTestCase {
             participantRobot
                 .setUserCount(participants)
                 .joinCall(callId)
+            userRobot.waitForParticipantsToJoin(participants, timeout: UserRobot.defaultTimeout * 1.5)
         }
         WHEN("user enables spotlight view") {
-            userRobot
-                .waitForParticipantsToJoin(participants, timeout: UserRobot.defaultTimeout * 1.5)
-                .setView(mode: .spotlight)
+            userRobot.setView(mode: .spotlight)
         }
         THEN("user observers the list of participants") {
             userRobot

--- a/SwiftUIDemoAppUITests/Tests/ParticipantActionsTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/ParticipantActionsTests.swift
@@ -17,6 +17,7 @@ final class ParticipantActionsTests: StreamTestCase {
         }
         AND("participant joins the call and turns on mic") {
             participantRobot.joinCall(callId, options: [.withMicrophone])
+            userRobot.waitForParticipantsToJoin()
         }
         for view in allViews {
             WHEN("user turns on \(view.rawValue) view") {
@@ -39,6 +40,7 @@ final class ParticipantActionsTests: StreamTestCase {
         }
         AND("participant joins the call and turns off mic") {
             participantRobot.joinCall(callId, options: [.withCamera])
+            userRobot.waitForParticipantsToJoin()
         }
         for view in allViews {
             WHEN("user turns on \(view.rawValue) view") {
@@ -61,6 +63,7 @@ final class ParticipantActionsTests: StreamTestCase {
         }
         AND("participant joins the call and turns camera on") {
             participantRobot.joinCall(callId, options: [.withCamera, .withMicrophone])
+            userRobot.waitForParticipantsToJoin()
         }
         for view in allViews {
             WHEN("user turns on \(view.rawValue) view") {
@@ -83,6 +86,7 @@ final class ParticipantActionsTests: StreamTestCase {
         }
         AND("participant joins the call and turns camera off") {
             participantRobot.joinCall(callId, options: [.withMicrophone])
+            userRobot.waitForParticipantsToJoin()
         }
         for view in allViews {
             WHEN("user turns on \(view.rawValue) view") {
@@ -105,6 +109,7 @@ final class ParticipantActionsTests: StreamTestCase {
         }
         AND("participant joins the call") {
             participantRobot.joinCall(callId, options: [.withCamera])
+            userRobot.waitForParticipantsToJoin()
         }
         for view in allViews {
             WHEN("user turns on \(view.rawValue) view") {
@@ -118,8 +123,6 @@ final class ParticipantActionsTests: StreamTestCase {
     
     func testParticipantRecordsCall() throws {
         linkToScenario(withId: 1769)
-        
-        throw XCTSkip("Recording the call is broken on the backend")
                 
         GIVEN("user starts a call") {
             userRobot.login().startCall(callId)
@@ -128,6 +131,7 @@ final class ParticipantActionsTests: StreamTestCase {
             participantRobot
                 .setCallRecordingDuration(35)
                 .joinCall(callId, actions: [.recordCall])
+            userRobot.waitForParticipantsToJoin()
         }
         for view in allViews {
             WHEN("user turns on \(view.rawValue) view") {
@@ -159,6 +163,7 @@ final class ParticipantActionsTests: StreamTestCase {
             participantRobot
                 .setScreenSharingDuration(10)
                 .joinCall(callId, actions: [.shareScreen])
+            userRobot.waitForParticipantsToJoin(participants)
         }
         THEN("user observers participant's screen") {
             userRobot

--- a/SwiftUIDemoAppUITests/Tests/StreamTestCase.swift
+++ b/SwiftUIDemoAppUITests/Tests/StreamTestCase.swift
@@ -5,14 +5,15 @@
 import XCTest
 
 let app = XCUIApplication()
+var userRobot = UserRobot()
 
 class StreamTestCase: XCTestCase {
     
     let deviceRobot = DeviceRobot(app)
-    var userRobot = UserRobot()
     var participantRobot = ParticipantRobot()
     var sinatra = Sinatra()
-    var recordVideo = true
+    var recordVideo = false
+    var launchApp = true
     let callId = randomCallId
     let allViews: [UserRobot.View] = [.grid, .fullscreen, .spotlight]
 
@@ -24,7 +25,9 @@ class StreamTestCase: XCTestCase {
         alertHandler()
         ipadSetup()
         startVideo()
-        app.launch()
+        if launchApp {
+            app.launch()
+        }
     }
 
     override func tearDownWithError() throws {
@@ -49,7 +52,8 @@ extension StreamTestCase {
 extension StreamTestCase {
     
     private func setLaunchArguments() {
-        app.setLaunchArguments(.streamE2ETests)
+        let secret = ProcessInfo.processInfo.environment[EnvironmentVariable.streamVideoSecret.rawValue] ?? ""
+        app.setEnvironmentVariables([.streamVideoSecret: secret])
     }
 
     private func attachElementTree() {

--- a/TestTools/TestData/LaunchArgument.swift
+++ b/TestTools/TestData/LaunchArgument.swift
@@ -5,10 +5,15 @@
 import Foundation
 import XCTest
 
+public enum EnvironmentVariable: String {
+    case jwtExpiration = "JWT_EXPIRATION"
+    case streamVideoSecret = "STREAM_VIDEO_SECRET"
+}
+
 public enum LaunchArgument: String {
-    case streamTests = "STREAM_TESTS"
-    case streamE2ETests = "STREAM_E2E_TESTS"
-    case streamSnapshotTests = "STREAM_SNAPSHOT_TESTS"
+    case mockJwt = "MOCK_JWT"
+    case invalidateJwt = "INVALIDATE_JWT"
+    case breakJwt = "BREAK_JWT"
 }
 
 public extension ProcessInfo {
@@ -20,5 +25,11 @@ public extension ProcessInfo {
 public extension XCUIApplication {
     func setLaunchArguments(_ args: LaunchArgument...) {
         launchArguments.append(contentsOf: args.map { $0.rawValue })
+    }
+    
+    func setEnvironmentVariables(_ envVars: [EnvironmentVariable: String]) {
+        envVars.forEach { envVar in
+            launchEnvironment[envVar.key.rawValue] = envVar.value
+        }
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,6 +12,7 @@ sdk_names = ['StreamVideo', 'StreamVideoSwiftUI', 'StreamVideoUIKit']
 github_repo = ENV['GITHUB_REPOSITORY'] || 'GetStream/stream-video-swift'
 sinatra_port = 4567
 video_buddy_port = 5678
+app_secret = ENV.fetch('STREAM_VIDEO_SECRET', nil)
 
 before_all do |lane|
   if is_ci
@@ -87,6 +88,7 @@ end
 
 private_lane :upload_beta do |options|
   match_me
+  create_credentials_config
   testflight_build(
     api_key: appstore_api_key,
     xcode_project: xcode_project,
@@ -106,14 +108,18 @@ private_lane :appstore_api_key do
   )
 end
 
-desc 'Runs LLC tests in Debug config'
+lane :create_credentials_config do
+  # Make sure xcconfig exists even though it won't be used on CI
+  sh('touch ../TestTools/Credentials.xcconfig')
+end
+
+desc 'Runs LLC tests'
 lane :test do |options|
   next unless is_check_required(sources: sources_matrix[:unit])
 
   update_testplan_on_ci(path: 'StreamVideoTests/StreamVideo.xctestplan')
 
-  # Make sure xcconfig exists even though it won't be used
-  sh('touch ../StreamVideoTests/IntegrationTests/Credentials.xcconfig')
+  create_credentials_config
 
   scan(
     project: xcode_project,
@@ -121,16 +127,16 @@ lane :test do |options|
     testplan: 'StreamVideo',
     clean: true,
     devices: options[:device],
-    xcargs: is_ci ? "STREAM_VIDEO_SECRET=#{ENV.fetch('STREAM_VIDEO_SECRET', nil)}" : ''
+    xcargs: is_ci ? "STREAM_VIDEO_SECRET=#{app_secret}" : ''
   )
 end
 
-desc 'Runs SwiftUI tests in Debug config'
+desc 'Runs SwiftUI tests'
 lane :test_swiftui do |options|
   test_ui(scheme: 'StreamVideoSwiftUI', source: :swiftui, device: options[:device], record: options[:record])
 end
 
-desc 'Runs UIKit tests in Debug config'
+desc 'Runs UIKit tests'
 lane :test_uikit do |options|
   test_ui(scheme: 'StreamVideoUIKit', source: :uikit, device: options[:device], record: options[:record])
 end
@@ -173,12 +179,13 @@ lane :stop_video_buddy do
   sh("lsof -t -i:#{video_buddy_port} | xargs kill -9")
 end
 
-desc 'Runs e2e ui tests in Debug config'
+desc 'Runs e2e ui tests'
 lane :test_e2e do |options|
   next unless is_check_required(sources: sources_matrix[:e2e])
 
   update_testplan_on_ci(path: 'SwiftUIDemoAppUITests/SwiftUIDemoApp.xctestplan')
 
+  create_credentials_config
   start_sinatra
   start_video_buddy
 
@@ -191,7 +198,8 @@ lane :test_e2e do |options|
     testplan: 'SwiftUIDemoApp',
     result_bundle: true,
     devices: device,
-    number_of_retries: 2
+    number_of_retries: 2,
+    xcargs: is_ci ? "STREAM_VIDEO_SECRET=#{app_secret}" : ''
   }
 
   build_for_testing = is_ci && options[:cron].nil?
@@ -253,6 +261,8 @@ private_lane :build_example_app do |options|
     end
   next unless is_check_required(sources: sources_matrix[app_sources])
 
+  create_credentials_config
+
   scan(
     project: xcode_project,
     scheme: options[:scheme],
@@ -275,6 +285,8 @@ end
 
 desc 'Build and upload DemoApp to Emerge'
 private_lane :emerge_upload do |options|
+  create_credentials_config
+
   gym(
     export_method: 'ad-hoc',
     project: xcode_project,

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -9,7 +9,7 @@ devices(["iPhone 12"])
 # Needed for Sonar
 code_coverage(true)
 
-configuration("Debug")
+configuration("Test")
 
 result_bundle(true)
 


### PR DESCRIPTION
## Changes
- Add E2E JWT tests
- Create new configuration `Test` to make it easier to use environment variables and macros across all test targets
- Moved `Credentials.xcconfig` to a shared place

## Required actions locally:
- Move `StreamVideoTests/IntegrationTests/Credentials.xcconfig` to `TestTools/Credentials.xcconfig`