### PR TITLE
[Fix]Deeplink handling

### DIFF
--- a/DemoApp/Resources/Entitlements/DemoApp-Debug.entitlements
+++ b/DemoApp/Resources/Entitlements/DemoApp-Debug.entitlements
@@ -6,8 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:staging.getstream.io</string>
-		<string>applinks:getstream.io</string>
+        <string>applinks:getstream.io</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/DemoApp/Resources/Entitlements/DemoApp.entitlements
+++ b/DemoApp/Resources/Entitlements/DemoApp.entitlements
@@ -6,7 +6,6 @@
 	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:staging.getstream.io</string>
 		<string>applinks:getstream.io</string>
 	</array>
 	<key>com.apple.security.application-groups</key>

--- a/DemoApp/Sources/AppDelegate.swift
+++ b/DemoApp/Sources/AppDelegate.swift
@@ -8,7 +8,7 @@ import UIKit
 import GDPerformanceView_Swift
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
-    
+
     @Injected(\.streamVideo) var streamVideo
 
     func application(
@@ -21,11 +21,25 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         return true
     }
 
+    /// Method used to handle custom URL schemes
     func application(
         _ app: UIApplication,
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey : Any] = [:]
     ) -> Bool {
+        Router.shared.handle(url: url)
+        return true
+    }
+
+    /// Method used to handle universal deeplinks
+    func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?
+        ) -> Void) -> Bool {
+        guard let url = userActivity.webpageURL else {
+            return false
+        }
         Router.shared.handle(url: url)
         return true
     }
@@ -37,7 +51,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let deviceToken = deviceToken.map { String(format: "%02x", $0) }.joined()
         AppState.shared.pushToken = deviceToken
     }
-    
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,

--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -229,7 +229,7 @@ extension AppEnvironment {
         case .debug:
             return [.staging, .pronto, .production]
         case .test:
-            return [.staging]
+            return [.staging, .pronto, .production]
         case .release:
             return [.production]
         }

--- a/DemoApp/Sources/Components/MemoryLogDestination/OSLogDestination.swift
+++ b/DemoApp/Sources/Components/MemoryLogDestination/OSLogDestination.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamVideo
+import OSLog
+
+final class OSLogDestination: BaseLogDestination {
+
+    override func write(message: String) {
+        os_log("%@", message)
+    }
+}

--- a/DemoApp/Sources/Components/MemoryLogDestination/OSLogDestination.swift
+++ b/DemoApp/Sources/Components/MemoryLogDestination/OSLogDestination.swift
@@ -9,6 +9,6 @@ import OSLog
 final class OSLogDestination: BaseLogDestination {
 
     override func write(message: String) {
-        os_log("%@", message)
+        os_log("%{public}s", message)
     }
 }

--- a/DemoApp/Sources/Components/Router.swift
+++ b/DemoApp/Sources/Components/Router.swift
@@ -50,14 +50,17 @@ final class Router: ObservableObject {
     // MARK: - Handle URL
 
     func handle(url: URL) {
+        log.debug("Request to handle deeplink \(url)")
         let (deeplinkInfo, _) = deeplinkAdapter.handle(url: url)
 
         guard
             deeplinkInfo != .empty
         else {
+            log.warning("Request to handle deeplink \(url) denied ❌")
             return
         }
 
+        log.debug("Request to handle deeplink \(url) accepted ✅")
         if streamVideoUI != nil {
             appState.deeplinkInfo = deeplinkInfo
         } else {

--- a/DemoApp/Sources/Extensions/DemoApp+Sentry.swift
+++ b/DemoApp/Sources/Extensions/DemoApp+Sentry.swift
@@ -21,14 +21,15 @@ extension DemoApp {
             }
 
             LogConfig.destinationTypes = [
-                ConsoleLogDestination.self,
                 SentryLogDestination.self,
-                MemoryLogDestination.self
+                MemoryLogDestination.self,
+                OSLogDestination.self
             ]
         } else {
+            LogConfig.level = .debug
             LogConfig.destinationTypes = [
-                ConsoleLogDestination.self,
-                MemoryLogDestination.self
+                MemoryLogDestination.self,
+                OSLogDestination.self
             ]
         }
     }

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -107,7 +107,6 @@ struct DetailedCallingView: View {
             .alignedToReadableContentGuide()
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        //        .navigationBarHidden(true)
         .onAppear() {
             CallService.shared.registerForIncomingCalls()
         }

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -140,7 +140,7 @@ struct DetailedCallingView: View {
             self.callId = callId
             viewModel.joinCall(callType: .default, callId: callId)
         }
-        .onChange(of: appState.deeplinkInfo) { deeplinkInfo in
+        .onReceive(appState.$deeplinkInfo) { deeplinkInfo in
             self.callId = deeplinkInfo.callId
             joinCallIfNeeded(with: deeplinkInfo.callId, callType: deeplinkInfo.callType)
         }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		409BFA402A9F79D2003341EF /* View+OptionalPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409BFA3F2A9F79D2003341EF /* View+OptionalPublisher.swift */; };
 		409BFA432A9F7BBB003341EF /* ReadableContentGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409BFA422A9F7BBB003341EF /* ReadableContentGuide.swift */; };
 		40AB31262A49838000C270E1 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB31252A49838000C270E1 /* EventTests.swift */; };
+		40B499CA2AC1A5E100A53B60 /* OSLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */; };
+		40B499CC2AC1A90F00A53B60 /* DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */; };
+		40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		40B713692A275F1400D1FE67 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8456E6C5287EB55F004E180E /* AppState.swift */; };
 		40D7E7962AB1C9590017095E /* ThermalStateViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D7E7952AB1C9580017095E /* ThermalStateViewModifier.swift */; };
 		40D946412AA5ECEF00C8861B /* CodeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D946402AA5ECEF00C8861B /* CodeScanner.swift */; };
@@ -894,6 +897,8 @@
 		409BFA3F2A9F79D2003341EF /* View+OptionalPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+OptionalPublisher.swift"; sourceTree = "<group>"; };
 		409BFA422A9F7BBB003341EF /* ReadableContentGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadableContentGuide.swift; sourceTree = "<group>"; };
 		40AB31252A49838000C270E1 /* EventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
+		40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogDestination.swift; sourceTree = "<group>"; };
+		40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkTests.swift; sourceTree = "<group>"; };
 		40D7E7952AB1C9580017095E /* ThermalStateViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateViewModifier.swift; sourceTree = "<group>"; };
 		40D946402AA5ECEF00C8861B /* CodeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeScanner.swift; sourceTree = "<group>"; };
 		40D946422AA5F65300C8861B /* DemoQRCodeScannerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoQRCodeScannerButton.swift; sourceTree = "<group>"; };
@@ -1772,6 +1777,7 @@
 			isa = PBXGroup;
 			children = (
 				409386192AA09E4A00FF5AF4 /* MemoryLogDestination.swift */,
+				40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */,
 				4093861B2AA0A11500FF5AF4 /* LogQueue.swift */,
 				4093861E2AA0A21800FF5AF4 /* MemoryLogViewer.swift */,
 			);
@@ -2038,6 +2044,7 @@
 				82D858B729EDAE0A00CF9F8B /* ParticipantActionsTests.swift */,
 				824DBA9F29F6D77B005ACD09 /* ReconnectionTests.swift */,
 				82FB89362A702A9200AC16A1 /* Authentication_Tests.swift */,
+				40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -3694,6 +3701,7 @@
 				82C837E229A532C000CB6B0E /* LoginPage.swift in Sources */,
 				82392D542993C9E100941435 /* StreamTestCase.swift in Sources */,
 				82C837E029A531ED00CB6B0E /* CallPage.swift in Sources */,
+				40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */,
 				82B8C0FA29E80997001F816C /* RingProcessTests.swift in Sources */,
 				82392D6B2993CDF500941435 /* UserRobot.swift in Sources */,
 				82D858B829EDAE0A00CF9F8B /* ParticipantActionsTests.swift in Sources */,
@@ -3704,6 +3712,7 @@
 				82AD932529E6FCCF00D4D295 /* LobbyPage.swift in Sources */,
 				824DBAA029F6D77B005ACD09 /* ReconnectionTests.swift in Sources */,
 				828DE5BD299521EF00F93197 /* UserRobot+Asserts.swift in Sources */,
+				40B499CC2AC1A90F00A53B60 /* DeeplinkTests.swift in Sources */,
 				82B8C0FC29E80A2A001F816C /* CallLifecycleTests.swift in Sources */,
 				82392D71299403B200941435 /* CallViewsTests.swift in Sources */,
 				820221622A24BB7100F7BAED /* LaunchArgument.swift in Sources */,
@@ -3779,6 +3788,7 @@
 				847B47B52A249E7E000714CE /* Examples.swift in Sources */,
 				40F445F72A9E2AAC004BE3DA /* ReactionsViewModifier.swift in Sources */,
 				4093861F2AA0A21800FF5AF4 /* MemoryLogViewer.swift in Sources */,
+				40B499CA2AC1A5E100A53B60 /* OSLogDestination.swift in Sources */,
 				84D6493E29E7F75E002CA428 /* CallsViewModel.swift in Sources */,
 				401A64AB2A9DF7EC00534ED1 /* DemoChatAdapter.swift in Sources */,
 				4093861A2AA09E4A00FF5AF4 /* MemoryLogDestination.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		40F446022A9E2C23004BE3DA /* DemoCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446012A9E2C23004BE3DA /* DemoCallView.swift */; };
 		40F446042A9E2C78004BE3DA /* MicrophoneChecker+MicrophoneChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446032A9E2C78004BE3DA /* MicrophoneChecker+MicrophoneChecking.swift */; };
 		40F446062A9E2CB8004BE3DA /* CallViewModel+CallSettingsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446052A9E2CB8004BE3DA /* CallViewModel+CallSettingsPublisher.swift */; };
+		40FBEF492AC30343007CFF17 /* Safari.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF482AC30343007CFF17 /* Safari.swift */; };
+		40FBEF4B2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */; };
 		43217A0C2A44A28B002B5857 /* ConnectionErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43217A0B2A44A28B002B5857 /* ConnectionErrorEvent.swift */; };
 		4351AEAD2A40588D00D32D0D /* IntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4351AEAC2A40588D00D32D0D /* IntegrationTest.swift */; };
 		4351AEAF2A40591800D32D0D /* CallCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4351AEAE2A40591800D32D0D /* CallCRUDTests.swift */; };
@@ -936,6 +938,8 @@
 		40F446012A9E2C23004BE3DA /* DemoCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCallView.swift; sourceTree = "<group>"; };
 		40F446032A9E2C78004BE3DA /* MicrophoneChecker+MicrophoneChecking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MicrophoneChecker+MicrophoneChecking.swift"; sourceTree = "<group>"; };
 		40F446052A9E2CB8004BE3DA /* CallViewModel+CallSettingsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallViewModel+CallSettingsPublisher.swift"; sourceTree = "<group>"; };
+		40FBEF482AC30343007CFF17 /* Safari.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Safari.swift; sourceTree = "<group>"; };
+		40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+KeyboardIntroduction.swift"; sourceTree = "<group>"; };
 		43217A0B2A44A28B002B5857 /* ConnectionErrorEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionErrorEvent.swift; sourceTree = "<group>"; };
 		4351AEAC2A40588D00D32D0D /* IntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTest.swift; sourceTree = "<group>"; };
 		4351AEAE2A40591800D32D0D /* CallCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCRUDTests.swift; sourceTree = "<group>"; };
@@ -1974,6 +1978,15 @@
 			path = WaitingLocalUserView;
 			sourceTree = "<group>";
 		};
+		40FBEF472AC3030C007CFF17 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				40FBEF482AC30343007CFF17 /* Safari.swift */,
+				40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */,
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
 		4351AEAB2A40586B00D32D0D /* IntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2006,6 +2019,7 @@
 		82392D5C2993CBE200941435 /* TestTools */ = {
 			isa = PBXGroup;
 			children = (
+				40FBEF472AC3030C007CFF17 /* UITests */,
 				8206D84F2A5DB9300099F5EC /* Credentials.xcconfig */,
 				8251E6292A17BE9F00E7257A /* TestData */,
 				82CE900229FC3A7B00770EF6 /* Resources */,
@@ -3704,6 +3718,7 @@
 				40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */,
 				82B8C0FA29E80997001F816C /* RingProcessTests.swift in Sources */,
 				82392D6B2993CDF500941435 /* UserRobot.swift in Sources */,
+				40FBEF4B2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift in Sources */,
 				82D858B829EDAE0A00CF9F8B /* ParticipantActionsTests.swift in Sources */,
 				82B8C0F829E80933001F816C /* LobbyTests.swift in Sources */,
 				82392D6F2994027C00941435 /* Sinatra.swift in Sources */,
@@ -3716,6 +3731,7 @@
 				82B8C0FC29E80A2A001F816C /* CallLifecycleTests.swift in Sources */,
 				82392D71299403B200941435 /* CallViewsTests.swift in Sources */,
 				820221622A24BB7100F7BAED /* LaunchArgument.swift in Sources */,
+				40FBEF492AC30343007CFF17 /* Safari.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
@@ -1,8 +1,5 @@
 //
-//  DeeplinkTests.swift
-//  SwiftUIDemoAppUITests
-//
-//  Created by Ilias Pavlidakis on 25/9/23.
+// Copyright © 2023 Stream.io Inc. All rights reserved.
 //
 
 import XCTest
@@ -60,88 +57,5 @@ final class DeeplinkTests: StreamTestCase {
                 .assertCallControls()
                 .assertParticipantsAreVisible(count: 1)
         }
-    }
-}
-
-extension XCUIDevice {
-
-    fileprivate func open(_ url: URL) {
-        DispatchQueue.main.async {
-            // Need to async this because XCUIDevice.shared.system.open
-            // synchronously waits for a button to be pressed the first time.
-            self.system.open(url)
-        }
-    }
-}
-
-enum Safari {
-
-    private static let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
-
-    fileprivate static func go(to url: URL) {
-        safari.textFields["Address"].tap()
-        safari.typeText(url.absoluteString)
-        let goButton = safari.buttons["Go"]
-        if goButton.waitForExistence(timeout: 5) {
-            safari.tapKeyboardKey("Go")
-        }
-    }
-
-    fileprivate static func open(_ url: URL) {
-        safari.launch()
-
-        _ = safari.wait(for: .runningForeground, timeout: 5)
-
-        // Type the deeplink and execute it
-        let firstLaunchContinueButton = safari.buttons["Continue"]
-        if firstLaunchContinueButton.exists {
-            firstLaunchContinueButton.tap()
-        }
-
-        go(to: url)
-    }
-
-    fileprivate static func openApp(_ url: URL) {
-        open(url)
-
-        let openButton = safari.buttons["Open"]
-        if openButton.waitForExistence(timeout: 5) {
-            openButton.tap()
-        }
-    }
-
-    fileprivate static func openUniversalLinkFromSmartBanner(_ url: URL) {
-        open(url)
-
-        let allowButton1 = safari.alerts.buttons["Allow"]
-        if allowButton1.waitForExistence(timeout: 5) {
-            allowButton1.tap()
-            let allowButton2 = safari.alerts.buttons["Allow"]
-            if allowButton2.waitForExistence(timeout: 5) {
-                allowButton2.tap()
-            }
-        }
-
-        let openButton = safari.buttons["OPEN"]
-        if openButton.waitForExistence(timeout: 5) {
-            openButton.tap()
-        }
-    }
-}
-
-extension XCUIApplication {
-    /// Taps the specified keyboard key while handling the
-    /// keyboard onboarding interruption, if it exists.
-    /// - Parameter key: The keyboard key to tap.
-    fileprivate func tapKeyboardKey(_ key: String) {
-        let key = self.keyboards.buttons[key]
-
-        if key.isHittable == false {
-            // Attempt to find and tap the Continue button
-            // of the keyboard onboarding screen.
-            self.buttons["Continue"].tap()
-        }
-
-        key.tap()
     }
 }

--- a/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
@@ -39,7 +39,9 @@ final class DeeplinkTests: StreamTestCase {
 
     func test_universalLink_production_joinsExpectedCall() {
         WHEN("") {
-            Safari.openUniversalLinkFromSmartBanner(MockDeeplink.production)
+            Safari()
+                .open(MockDeeplink.production)
+                .tapButton("OPEN")
         }
         THEN("user joins the the specified call") {
             userRobot
@@ -50,7 +52,9 @@ final class DeeplinkTests: StreamTestCase {
 
     func test_customSchemeURL_joinsExpectedCall() {
         WHEN("User opens a URL that contains a custom scheme") {
-            Safari.openApp(MockDeeplink.customScheme)
+            Safari()
+                .open(MockDeeplink.customScheme)
+                .tapButton("Open")
         }
         THEN("user joins the the specified call") {
             userRobot

--- a/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
@@ -1,0 +1,40 @@
+//
+//  DeeplinkTests.swift
+//  SwiftUIDemoAppUITests
+//
+//  Created by Ilias Pavlidakis on 25/9/23.
+//
+
+import XCTest
+
+final class DeeplinkTests: StreamTestCase {
+
+    private enum MockDeeplink {
+        static let production: URL = .init(string: "https://getstream.io/video/demos?id=test-call")!
+        static let pronto: URL = .init(string: "https://pronto.getstream.io/video/demos?id=test-call")!
+        static let staging: URL = .init(string: "https://staging.getstream.io/video/demos?id=test-call")!
+        static let customScheme: URL = .init(string: "streamvideo://video/demos?id=test-call")!
+    }
+
+    func test_customSchemeURL_joinsTheSpecifiedCall() {
+        WHEN("User opens a URL that contains a custom scheme") {
+            XCUIDevice.shared.open(MockDeeplink.customScheme)
+        }
+        THEN("user joins the the specified call") {
+            userRobot
+                .assertCallControls()
+                .assertParticipantsAreVisible(count: 1)
+        }
+    }
+}
+
+extension XCUIDevice {
+
+    fileprivate func open(_ url: URL) {
+        DispatchQueue.main.async {
+            // Need to async this because XCUIDevice.shared.system.open
+            // synchronously waits for a button to be pressed the first time.
+            self.system.open(url)
+        }
+    }
+}

--- a/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
@@ -28,6 +28,18 @@ final class DeeplinkTests: StreamTestCase {
         static let customScheme: URL = .init(string: "streamvideo://video/demos?id=test-call")!
     }
 
+    func test_associationFile_validationWasSuccessful() throws {
+        let contentData = try Data(contentsOf: .init(string: "https://getstream.io/.well-known/apple-app-site-association")!)
+        let content = try XCTUnwrap(String(data: contentData, encoding: .utf8))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        XCTAssertEqual(content, """
+        {"applinks":{"apps":[],"details":[{"appID":"EHV7XZLAHA.io.getstream.iOS.VideoDemoApp","paths":["/video/demos/*","/video/demos"]}]}}
+        """)
+    }
+
     func test_universalLink_production_joinsExpectedCall() {
         WHEN("") {
             Safari.openUniversalLinkFromSmartBanner(MockDeeplink.production)
@@ -40,9 +52,6 @@ final class DeeplinkTests: StreamTestCase {
     }
 
     func test_customSchemeURL_joinsExpectedCall() {
-        GIVEN("") {
-            app.terminate()
-        }
         WHEN("User opens a URL that contains a custom scheme") {
             Safari.openApp(MockDeeplink.customScheme)
         }

--- a/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
@@ -9,16 +9,42 @@ import XCTest
 
 final class DeeplinkTests: StreamTestCase {
 
+    static override func setUp() {
+        super.setUp()
+
+        // We are launching and terminating the app to ensure the executable
+        // has been installed.
+        app.launch()
+        app.terminate()
+    }
+
+    override func setUpWithError() throws {
+        launchApp = false
+        try super.setUpWithError()
+    }
+
     private enum MockDeeplink {
         static let production: URL = .init(string: "https://getstream.io/video/demos?id=test-call")!
-        static let pronto: URL = .init(string: "https://pronto.getstream.io/video/demos?id=test-call")!
-        static let staging: URL = .init(string: "https://staging.getstream.io/video/demos?id=test-call")!
         static let customScheme: URL = .init(string: "streamvideo://video/demos?id=test-call")!
     }
 
-    func test_customSchemeURL_joinsTheSpecifiedCall() {
+    func test_universalLink_production_joinsExpectedCall() {
+        WHEN("") {
+            Safari.openUniversalLinkFromSmartBanner(MockDeeplink.production)
+        }
+        THEN("user joins the the specified call") {
+            userRobot
+                .assertCallControls()
+                .assertParticipantsAreVisible(count: 1)
+        }
+    }
+
+    func test_customSchemeURL_joinsExpectedCall() {
+        GIVEN("") {
+            app.terminate()
+        }
         WHEN("User opens a URL that contains a custom scheme") {
-            XCUIDevice.shared.open(MockDeeplink.customScheme)
+            Safari.openApp(MockDeeplink.customScheme)
         }
         THEN("user joins the the specified call") {
             userRobot
@@ -36,5 +62,77 @@ extension XCUIDevice {
             // synchronously waits for a button to be pressed the first time.
             self.system.open(url)
         }
+    }
+}
+
+enum Safari {
+
+    private static let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+
+    fileprivate static func go(to url: URL) {
+        safari.textFields["Address"].tap()
+        safari.typeText(url.absoluteString)
+        let goButton = safari.buttons["Go"]
+        if goButton.waitForExistence(timeout: 5) {
+            safari.tapKeyboardKey("Go")
+        }
+    }
+
+    fileprivate static func open(_ url: URL) {
+        safari.launch()
+
+        _ = safari.wait(for: .runningForeground, timeout: 5)
+
+        // Type the deeplink and execute it
+        let firstLaunchContinueButton = safari.buttons["Continue"]
+        if firstLaunchContinueButton.exists {
+            firstLaunchContinueButton.tap()
+        }
+
+        go(to: url)
+    }
+
+    fileprivate static func openApp(_ url: URL) {
+        open(url)
+
+        let openButton = safari.buttons["Open"]
+        if openButton.waitForExistence(timeout: 5) {
+            openButton.tap()
+        }
+    }
+
+    fileprivate static func openUniversalLinkFromSmartBanner(_ url: URL) {
+        open(url)
+
+        let allowButton1 = safari.alerts.buttons["Allow"]
+        if allowButton1.waitForExistence(timeout: 5) {
+            allowButton1.tap()
+            let allowButton2 = safari.alerts.buttons["Allow"]
+            if allowButton2.waitForExistence(timeout: 5) {
+                allowButton2.tap()
+            }
+        }
+
+        let openButton = safari.buttons["OPEN"]
+        if openButton.waitForExistence(timeout: 5) {
+            openButton.tap()
+        }
+    }
+}
+
+extension XCUIApplication {
+    /// Taps the specified keyboard key while handling the
+    /// keyboard onboarding interruption, if it exists.
+    /// - Parameter key: The keyboard key to tap.
+    fileprivate func tapKeyboardKey(_ key: String) {
+        let key = self.keyboards.buttons[key]
+
+        if key.isHittable == false {
+            // Attempt to find and tap the Continue button
+            // of the keyboard onboarding screen.
+            self.buttons["Continue"].tap()
+        }
+
+        key.tap()
     }
 }

--- a/TestTools/UITests/Safari.swift
+++ b/TestTools/UITests/Safari.swift
@@ -1,0 +1,56 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+enum Safari {
+
+    private static let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+
+    static func go(to url: URL) {
+        safari.textFields["Address"].tap()
+        safari.typeText(url.absoluteString)
+        let goButton = safari.buttons["Go"]
+        if goButton.waitForExistence(timeout: 5) {
+            safari.tapKeyboardKey("Go")
+        }
+    }
+
+    static func open(_ url: URL) {
+        safari.launch()
+
+        _ = safari.wait(for: .runningForeground, timeout: 5)
+
+        // Type the deeplink and execute it
+        let firstLaunchContinueButton = safari.buttons["Continue"]
+        if firstLaunchContinueButton.exists {
+            firstLaunchContinueButton.tap()
+        }
+
+        go(to: url)
+    }
+
+    static func openApp(_ url: URL) {
+        open(url)
+
+        safari
+            .buttons["Open"]
+            .wait(timeout: 5)
+            .tap()
+    }
+
+    static func openUniversalLinkFromSmartBanner(_ url: URL) {
+        open(url)
+
+        let allowButton = safari.alerts.buttons["Allow"]
+        allowButton.wait(timeout: 5).tap()
+        allowButton.wait(timeout: 5).tap()
+
+        safari
+            .buttons["OPEN"]
+            .wait(timeout: 5)
+            .tap()
+    }
+}

--- a/TestTools/UITests/Safari.swift
+++ b/TestTools/UITests/Safari.swift
@@ -5,52 +5,45 @@
 import Foundation
 import XCTest
 
-enum Safari {
+struct Safari {
 
-    private static let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+    private let application = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
 
-    static func go(to url: URL) {
-        safari.textFields["Address"].tap()
-        safari.typeText(url.absoluteString)
-        let goButton = safari.buttons["Go"]
+    init() {}
+
+    private func go(to url: URL) -> Self {
+        application.textFields["Address"].tap()
+        application.typeText(url.absoluteString)
+        let goButton = application.buttons["Go"]
         if goButton.waitForExistence(timeout: 5) {
-            safari.tapKeyboardKey("Go")
+            application.tapKeyboardKey("Go")
         }
+
+        return self
     }
 
-    static func open(_ url: URL) {
-        safari.launch()
+    @discardableResult
+    func open(_ url: URL) -> Self {
+        application.launch()
 
-        _ = safari.wait(for: .runningForeground, timeout: 5)
+        _ = application.wait(for: .runningForeground, timeout: 5)
 
         // Type the deeplink and execute it
-        let firstLaunchContinueButton = safari.buttons["Continue"]
+        let firstLaunchContinueButton = application.buttons["Continue"]
         if firstLaunchContinueButton.exists {
             firstLaunchContinueButton.tap()
         }
 
-        go(to: url)
+        return go(to: url)
     }
 
-    static func openApp(_ url: URL) {
-        open(url)
-
-        safari
-            .buttons["Open"]
-            .wait(timeout: 5)
+    @discardableResult
+    func tapButton(_ label: String, _ timeout: TimeInterval = 5) -> Self {
+        application
+            .buttons[label]
+            .wait(timeout: timeout)
             .tap()
-    }
 
-    static func openUniversalLinkFromSmartBanner(_ url: URL) {
-        open(url)
-
-        let allowButton = safari.alerts.buttons["Allow"]
-        allowButton.wait(timeout: 5).tap()
-        allowButton.wait(timeout: 5).tap()
-
-        safari
-            .buttons["OPEN"]
-            .wait(timeout: 5)
-            .tap()
+        return self
     }
 }

--- a/TestTools/UITests/XCUIApplication+KeyboardIntroduction.swift
+++ b/TestTools/UITests/XCUIApplication+KeyboardIntroduction.swift
@@ -1,0 +1,23 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIApplication {
+    /// Taps the specified keyboard key while handling the
+    /// keyboard onboarding interruption, if it exists.
+    /// - Parameter key: The keyboard key to tap.
+    func tapKeyboardKey(_ key: String) {
+        let key = self.keyboards.buttons[key]
+
+        if key.isHittable == false {
+            // Attempt to find and tap the Continue button
+            // of the keyboard onboarding screen.
+            self.buttons["Continue"].tap()
+        }
+
+        key.tap()
+    }
+}


### PR DESCRIPTION
### Issue
Resolves https://github.com/GetStream/ios-issues-tracking/issues/571

### 🎯 Goal

Ensure deeplinks are working consistently

### 📝 Summary

A few issues discovered:
- Association file was broken
- Missing the implementation method that iOS seems to call for universal links but not for custom schemes

### 🛠 Implementation

Implemented UITests that validate deeplink handling for 
- Universal links (via the smart banner open button)
- Custom URL schemes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)