### PR TITLE
Use single instance for the microphoneChecker

### DIFF
--- a/DemoApp/Sources/Components/DemoAppViewFactory.swift
+++ b/DemoApp/Sources/Components/DemoAppViewFactory.swift
@@ -12,7 +12,6 @@ final class DemoAppViewFactory: ViewFactory {
     static let shared = DemoAppViewFactory()
 
     @Injected(\.colors) var colors
-    @Injected(\.microphoneChecker) var microphoneChecker
 
     func makeWaitingLocalUserView(viewModel: CallViewModel) -> some View {
         DemoWaitingLocalUserView(viewFactory: self, viewModel: viewModel)
@@ -45,7 +44,6 @@ final class DemoAppViewFactory: ViewFactory {
     func makeCallView(viewModel: CallViewModel) -> DemoCallView<DemoAppViewFactory> {
         DemoCallView(
             viewFactory: self,
-            microphoneChecker: microphoneChecker,
             viewModel: viewModel
         )
     }

--- a/DemoApp/Sources/Components/DemoAppViewFactory.swift
+++ b/DemoApp/Sources/Components/DemoAppViewFactory.swift
@@ -12,6 +12,7 @@ final class DemoAppViewFactory: ViewFactory {
     static let shared = DemoAppViewFactory()
 
     @Injected(\.colors) var colors
+    @Injected(\.microphoneChecker) var microphoneChecker
 
     func makeWaitingLocalUserView(viewModel: CallViewModel) -> some View {
         DemoWaitingLocalUserView(viewFactory: self, viewModel: viewModel)
@@ -44,7 +45,7 @@ final class DemoAppViewFactory: ViewFactory {
     func makeCallView(viewModel: CallViewModel) -> DemoCallView<DemoAppViewFactory> {
         DemoCallView(
             viewFactory: self,
-            microphoneChecker: MicrophoneChecker(),
+            microphoneChecker: microphoneChecker,
             viewModel: viewModel
         )
     }

--- a/DemoApp/Sources/Views/CallView/DemoCallView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallView.swift
@@ -79,7 +79,12 @@ struct DemoCallView<ViewFactory: DemoAppViewFactory>: View {
     }
 
     private func updateMicrophoneChecker() {
-        if viewModel.call != nil, !viewModel.callSettings.audioOn {
+        guard viewModel.call != nil else {
+            microphoneChecker.stopListening()
+            return
+        }
+
+        if viewModel.callSettings.audioOn {
             microphoneChecker.startListening()
         } else {
             microphoneChecker.stopListening()

--- a/DemoApp/Sources/Views/CallView/DemoCallView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallView.swift
@@ -12,10 +12,10 @@ struct DemoCallView<ViewFactory: DemoAppViewFactory>: View {
     @Injected(\.appearance) var appearance
     @Injected(\.chatViewModel) var chatViewModel
 
-    var microphoneChecker: MicrophoneChecker
 
     @ObservedObject var viewModel: CallViewModel
     @ObservedObject var reactionsHelper: ReactionsHelper = AppState.shared.reactionsHelper
+    @ObservedObject var microphoneChecker = InjectedValues[\.microphoneChecker]
 
     @State var mutedIndicatorShown = false
 
@@ -23,11 +23,9 @@ struct DemoCallView<ViewFactory: DemoAppViewFactory>: View {
 
     init(
         viewFactory: ViewFactory,
-        microphoneChecker: MicrophoneChecker,
         viewModel: CallViewModel
     ) {
         self.viewFactory = viewFactory
-        self.microphoneChecker = microphoneChecker
         self.viewModel = viewModel
     }
 

--- a/DemoApp/Sources/Views/CustomCallView.swift
+++ b/DemoApp/Sources/Views/CustomCallView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 struct CustomCallView<Factory: ViewFactory>: View {
     
     @Injected(\.colors) var colors
+    @Injected(\.microphoneChecker) var microphoneChecker
     
     var viewFactory: Factory
     @ObservedObject var viewModel: CallViewModel
-    
-    @StateObject var microphoneChecker = MicrophoneChecker()
+
     @State var mutedIndicatorShown = false
     
     var body: some View {

--- a/DemoApp/Sources/Views/CustomCallView.swift
+++ b/DemoApp/Sources/Views/CustomCallView.swift
@@ -12,8 +12,8 @@ struct CustomCallView<Factory: ViewFactory>: View {
 
     var viewFactory: Factory
     @ObservedObject var viewModel: CallViewModel
+    @ObservedObject var microphoneChecker = InjectedValues[\.microphoneChecker]
 
-    @StateObject var microphoneChecker = InjectedValues[\.microphoneChecker]
     @State var mutedIndicatorShown = false
     
     var body: some View {

--- a/DemoApp/Sources/Views/CustomCallView.swift
+++ b/DemoApp/Sources/Views/CustomCallView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 struct CustomCallView<Factory: ViewFactory>: View {
     
     @Injected(\.colors) var colors
-    @Injected(\.microphoneChecker) var microphoneChecker
-    
+
     var viewFactory: Factory
     @ObservedObject var viewModel: CallViewModel
 
+    @StateObject var microphoneChecker = InjectedValues[\.microphoneChecker]
     @State var mutedIndicatorShown = false
     
     var body: some View {

--- a/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
@@ -10,7 +10,7 @@ import StreamVideo
 public struct LocalParticipantViewModifier: ViewModifier {
 
     private let localParticipant: CallParticipant
-    @Injected(\.microphoneChecker) var microphoneChecker
+    @StateObject var microphoneChecker = InjectedValues[\.microphoneChecker]
     @Binding private var callSettings: CallSettings
 
     @State private var audioLevels: [Float] = []

--- a/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
@@ -10,16 +10,18 @@ import StreamVideo
 public struct LocalParticipantViewModifier: ViewModifier {
 
     private let localParticipant: CallParticipant
-    @StateObject private var microphoneChecker: MicrophoneChecker
+    @Injected(\.microphoneChecker) var microphoneChecker
     @Binding private var callSettings: CallSettings
+
+    @State private var audioLevels: [Float] = []
 
     public init(
         localParticipant: CallParticipant,
         callSettings: Binding<CallSettings>
     ) {
         self.localParticipant = localParticipant
-        _microphoneChecker = .init(wrappedValue: .init())
         self._callSettings = callSettings
+        self.audioLevels = microphoneChecker.audioLevels
     }
 
     public func body(content: Content) -> some View {
@@ -30,8 +32,7 @@ public struct LocalParticipantViewModifier: ViewModifier {
                     microphoneOn: callSettings.audioOn,
                     isSilent: microphoneChecker.isSilent
                 )
-                .onAppear { microphoneChecker.startListening() }
-                .onDisappear { microphoneChecker.stopListening() }
+                .onReceive(microphoneChecker.$audioLevels) { audioLevels = $0 }
             )
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
@@ -10,7 +10,7 @@ import StreamVideo
 public struct LocalParticipantViewModifier: ViewModifier {
 
     private let localParticipant: CallParticipant
-    @StateObject var microphoneChecker = InjectedValues[\.microphoneChecker]
+    @ObservedObject var microphoneChecker = InjectedValues[\.microphoneChecker]
     @Binding private var callSettings: CallSettings
 
     @State private var audioLevels: [Float] = []

--- a/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
@@ -42,7 +42,7 @@ public struct LocalParticipantViewModifier: ViewModifier {
 public struct LocalParticipantViewModifier_iOS13: ViewModifier {
 
     private let localParticipant: CallParticipant
-    @BackportStateObject private var microphoneChecker: MicrophoneChecker
+    @ObservedObject private var microphoneChecker: MicrophoneChecker
     @Binding private var callSettings: CallSettings
 
     init(

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -181,7 +181,7 @@ public struct MicrophoneCheckerKey: InjectionKey {
 
 extension InjectedValues {
 
-    public var microphoneChecker: MicrophoneChecker {
+    var microphoneChecker: MicrophoneChecker {
         get {
             Self[MicrophoneCheckerKey.self]
         }

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -173,3 +173,20 @@ protocol AudioSessionProtocol {
 }
 
 extension AVAudioSession: AudioSessionProtocol {}
+
+/// Provides the default value of the `ThermalStateObserving` protocol.
+public struct MicrophoneCheckerKey: InjectionKey {
+    public static var currentValue: MicrophoneChecker = MicrophoneChecker()
+}
+
+extension InjectedValues {
+
+    public var microphoneChecker: MicrophoneChecker {
+        get {
+            Self[MicrophoneCheckerKey.self]
+        }
+        set {
+            Self[MicrophoneCheckerKey.self] = newValue
+        }
+    }
+}

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -181,7 +181,7 @@ public struct MicrophoneCheckerKey: InjectionKey {
 
 extension InjectedValues {
 
-    var microphoneChecker: MicrophoneChecker {
+    public var microphoneChecker: MicrophoneChecker {
         get {
             Self[MicrophoneCheckerKey.self]
         }

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -12,16 +12,18 @@ public class MicrophoneChecker: ObservableObject {
     
     /// Returns the last three decibel values.
     @Published public var audioLevels: [Float]
-    
-    private var timer: Timer?
-    
+
     private let valueLimit: Int
     private let audioSession: AudioSessionProtocol
     private let notificationCenter: NotificationCenter
 
+    private var isListening: Bool { audioRecorder != nil }
     private var audioRecorder: AVAudioRecorder?
-
+    private var timer: Timer?
     private var callEndedCancellable: AnyCancellable?
+    private var isAudioSessionActive = false {
+        didSet { try? audioSession.setActive(isAudioSessionActive, options: []) }
+    }
 
     private let audioFilename: URL = {
         let documentPath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
@@ -55,6 +57,17 @@ public class MicrophoneChecker: ObservableObject {
         subscribeToCallEnded()
     }
 
+    deinit {
+        stopTimer()
+        stopAudioRecorder()
+        do {
+            try FileManager.default.removeItem(at: audioFilename)
+            log.debug("Successfully deleted audio filename")
+        } catch {
+            log.error("Error deleting audio filename: \(error.localizedDescription)", error: error)
+        }
+    }
+
     /// Checks if there are audible values available.
     public var isSilent: Bool {
         for audioLevel in audioLevels {
@@ -67,11 +80,15 @@ public class MicrophoneChecker: ObservableObject {
     
     /// Starts listening to audio updates.
     public func startListening() {
+        guard !isListening else { return }
+        isAudioSessionActive = true
         captureAudio()
     }
     
     /// Stops listening to audio updates.
     public func stopListening() {
+        guard isListening else { return }
+        isAudioSessionActive = false
         stopTimer()
         stopAudioRecorder()
     }
@@ -81,24 +98,21 @@ public class MicrophoneChecker: ObservableObject {
     private func subscribeToCallEnded() {
         callEndedCancellable = notificationCenter
             .publisher(for: Notification.Name(CallNotification.callEnded))
-            .sink { [audioSession] _ in try? audioSession.setActive(false, options: []) }
+            .sink { [weak self] _ in self?.stopListening() }
     }
 
     private func setUpAudioCapture() {
         do {
             try audioSession.setCategory(.playAndRecord)
-            try audioSession.setActive(true, options: [])
             audioSession.requestRecordPermission { result in
                 guard result else { return }
             }
-            captureAudio()
         } catch {
             log.error("Failed to set up recording session", error: error)
         }
     }
     
     private func captureAudio() {
-        guard audioRecorder == nil else { return }
         // `kAudioFormatLinearPCM` is being used to be able to support multiple
         // instances of AVAudioRecorders. (useful when using MicrophoneChecker
         // during a Call).
@@ -147,16 +161,7 @@ public class MicrophoneChecker: ObservableObject {
         audioRecorder = nil
     }
 
-    deinit {
-        stopTimer()
-        stopAudioRecorder()
-        do {
-            try FileManager.default.removeItem(at: audioFilename)
-            log.debug("Successfully deleted audio filename")
-        } catch {
-            log.error("Error deleting audio filename: \(error.localizedDescription)", error: error)
-        }
-    }
+
 }
 
 /// A simple protocol that abstracts the usage of AVAudioSession.

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -120,7 +120,11 @@ struct LobbyContentView: View {
         }
         .background(colors.lobbyBackground.edgesIgnoringSafeArea(.all))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { viewModel.startCamera(front: true) }
+        .onAppear {
+            viewModel.startCamera(front: true)
+            if callSettings.audioOn { microphoneChecker.startListening() }
+            else { microphoneChecker.stopListening() }
+        }
         .onDisappear {
             viewModel.stopCamera()
             viewModel.cleanUp()

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 public struct LobbyView: View {
     
     @StateObject var viewModel: LobbyViewModel
-    @StateObject var microphoneChecker = MicrophoneChecker()
-    
+    @Injected(\.microphoneChecker) var microphoneChecker
+
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct LobbyView: View {
     
     @StateObject var viewModel: LobbyViewModel
-    @Injected(\.microphoneChecker) var microphoneChecker
+    @StateObject var microphoneChecker = InjectedValues[\.microphoneChecker]
 
     var callId: String
     var callType: String

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct LobbyView: View {
     
     @StateObject var viewModel: LobbyViewModel
-    @StateObject var microphoneChecker = InjectedValues[\.microphoneChecker]
+    @ObservedObject var microphoneChecker = InjectedValues[\.microphoneChecker]
 
     var callId: String
     var callType: String

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct LobbyView_iOS13: View {
     
     @ObservedObject var callViewModel: CallViewModel
-    @ObservedObject var microphoneManager = InjectedValues[\.microphoneChecker]
+    @ObservedObject var microphoneChecker = InjectedValues[\.microphoneChecker]
     @BackportStateObject var viewModel: LobbyViewModel
 
     var callId: String

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -11,8 +11,8 @@ struct LobbyView_iOS13: View {
     
     @ObservedObject var callViewModel: CallViewModel
     @BackportStateObject var viewModel: LobbyViewModel
-    @Injected(\.microphoneChecker) var microphoneChecker: MicrophoneChecker
-    
+    @BackportStateObject var microphoneManager = InjectedValues[\.microphoneManager]
+
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -11,7 +11,7 @@ struct LobbyView_iOS13: View {
     
     @ObservedObject var callViewModel: CallViewModel
     @BackportStateObject var viewModel: LobbyViewModel
-    @BackportStateObject var microphoneChecker = MicrophoneChecker()
+    @Injected(\.microphoneChecker) var microphoneChecker: MicrophoneChecker
     
     var callId: String
     var callType: String

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct LobbyView_iOS13: View {
     
     @ObservedObject var callViewModel: CallViewModel
+    @ObservedObject var microphoneManager = InjectedValues[\.microphoneChecker]
     @BackportStateObject var viewModel: LobbyViewModel
-    @BackportStateObject var microphoneManager = InjectedValues[\.microphoneManager]
 
     var callId: String
     var callType: String

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -32,8 +32,8 @@ final class MicrophoneChecker_Tests: XCTestCase {
     // MARK: - init
 
     func test_startListening_audioSessionIsActiveWasCalled() {
-        _ = subject
-        
+        subject.startListening()
+
         XCTAssertTrue(audioSession.setActiveWasCalledWithIsActive ?? false)
     }
 
@@ -44,7 +44,7 @@ final class MicrophoneChecker_Tests: XCTestCase {
 
         subject.stopListening()
 
-        XCTAssertTrue(audioSession.setActiveWasCalledWithIsActive ?? false)
+        XCTAssertFalse(audioSession.setActiveWasCalledWithIsActive ?? false)
     }
 
     // MARK: - CallNotification.callEnded notification


### PR DESCRIPTION
### 🎯 Goal

MicrophoneChecker's operations to startListening(create new recording file), update volume meters and stop recording (delete recording file) can be quite expensive when occuring multiple times per second. 

### 📝 Summary

We are using our injection system to create an instance for the MicrophoneChecker that can be overriden.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)