### PR TITLE
Fix ChatView disappearing when call events happening

### DIFF
--- a/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
@@ -13,10 +13,13 @@ internal struct DemoCallContainerView: View {
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.appearance) var appearance
     @StateObject var viewModel: CallViewModel
+    @StateObject var chatViewModel: DemoChatViewModel
     @ObservedObject var appState = AppState.shared
 
     internal init(callId: String) {
-        _viewModel = StateObject(wrappedValue: CallViewModel())
+        let callViewModel = CallViewModel()
+        _viewModel = StateObject(wrappedValue: callViewModel)
+        _chatViewModel = StateObject(wrappedValue: .init(callViewModel))
         self.callId = callId
     }
 
@@ -26,7 +29,7 @@ internal struct DemoCallContainerView: View {
                 DemoCallModifier(
                     viewFactory: DemoAppViewFactory.shared,
                     viewModel: viewModel,
-                    chatViewModel: .init(viewModel)
+                    chatViewModel: chatViewModel
                 )
             )
             .onContinueUserActivity(

--- a/DemoApp/Sources/Views/CallView/DemoCallView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallView.swift
@@ -10,6 +10,7 @@ import EffectsLibrary
 struct DemoCallView<ViewFactory: DemoAppViewFactory>: View {
 
     @Injected(\.appearance) var appearance
+    @Injected(\.chatViewModel) var chatViewModel
 
     var microphoneChecker: MicrophoneChecker
 
@@ -74,6 +75,7 @@ struct DemoCallView<ViewFactory: DemoAppViewFactory>: View {
             .onAppear {
                 updateMicrophoneChecker()
             }
+            .chat(viewModel: viewModel, chatViewModel: chatViewModel)
     }
 
     private func updateMicrophoneChecker() {

--- a/DemoApp/Sources/Views/CallView/DemoChatModifier.swift
+++ b/DemoApp/Sources/Views/CallView/DemoChatModifier.swift
@@ -1,0 +1,47 @@
+//
+//  DemoChatModifier.swift
+//  DemoApp
+//
+//  Created by Ilias Pavlidakis on 10/10/23.
+//
+
+import Foundation
+import SwiftUI
+import StreamVideoSwiftUI
+
+struct ChatModifier: ViewModifier {
+
+    @ObservedObject var viewModel: CallViewModel
+    @ObservedObject var chatViewModel: DemoChatViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .halfSheetIfAvailable(
+                isPresented: $chatViewModel.isChatVisible,
+                onDismiss: {}
+            ) {
+                if let channelController = chatViewModel.channelController {
+                    VStack {
+                        ChatControlsHeader(viewModel: viewModel)
+                        ChatView(
+                            channelController: channelController,
+                            chatViewModel: chatViewModel,
+                            callViewModel: viewModel
+                        )
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+
+    @ViewBuilder
+    func chat(viewModel: CallViewModel, chatViewModel: DemoChatViewModel?) -> some View {
+        if let chatViewModel {
+            self.modifier(ChatModifier(viewModel: viewModel, chatViewModel: chatViewModel))
+        } else {
+            self
+        }
+    }
+}

--- a/DemoApp/Sources/Views/Controls/DemoControls.swift
+++ b/DemoApp/Sources/Views/Controls/DemoControls.swift
@@ -21,7 +21,6 @@ struct AppControlsWithChat: View {
 
     @ObservedObject var reactionsHelper = AppState.shared.reactionsHelper
     @ObservedObject var viewModel: CallViewModel
-    @State private var isChatVisible = false
 
     init(viewModel: CallViewModel, canOpenChat: Bool = true) {
         self.viewModel = viewModel
@@ -61,22 +60,9 @@ struct AppControlsWithChat: View {
             }
             .offset(y: -15)
         )
-        .onReceive(chatViewModel?.$isChatVisible) { isChatVisible = canOpenChat && $0 }
         .onReceive(viewModel.$call, perform: { call in
             reactionsHelper.call = call
         })
-        .halfSheetIfAvailable(isPresented: $isChatVisible, onDismiss: { chatViewModel?.isChatVisible = false }) {
-            if let chatViewModel = chatViewModel, let channelController = chatViewModel.channelController {
-                VStack {
-                    ChatControlsHeader(viewModel: viewModel)
-                    ChatView(
-                        channelController: channelController,
-                        chatViewModel: chatViewModel,
-                        callViewModel: viewModel
-                    )
-                }
-            }
-        }
     }
 }
 

--- a/DemoApp/Sources/Views/WaitingLocalUserView/DemoWaitingLocalUserView.swift
+++ b/DemoApp/Sources/Views/WaitingLocalUserView/DemoWaitingLocalUserView.swift
@@ -14,11 +14,13 @@ struct DemoWaitingLocalUserView<Factory: DemoAppViewFactory>: View {
     @ObservedObject var viewModel: CallViewModel
 
     @State private var isSharePresented = false
-    @State private var isChatVisible = false
 
     private let viewFactory: Factory
 
-    internal init(viewFactory: Factory, viewModel: CallViewModel) {
+    internal init(
+        viewFactory: Factory,
+        viewModel: CallViewModel
+    ) {
         self.viewFactory = viewFactory
         self.viewModel = viewModel
     }
@@ -28,7 +30,7 @@ struct DemoWaitingLocalUserView<Factory: DemoAppViewFactory>: View {
             viewFactory
                 .makeInnerWaitingLocalUserView(viewModel: viewModel)
 
-            if !isChatVisible {
+            if chatViewModel?.isChatVisible == true {
                 VStack {
                     Spacer()
                     VStack {
@@ -82,7 +84,7 @@ struct DemoWaitingLocalUserView<Factory: DemoAppViewFactory>: View {
                 }
             }
         }
-        .onReceive(chatViewModel?.$isChatVisible) { isChatVisible = $0 }
+        .chat(viewModel: viewModel, chatViewModel: chatViewModel)
     }
 
     private var callLink: String {

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4046DEEE2A9F404300CA6D2F /* GDPerformanceView-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 4046DEED2A9F404300CA6D2F /* GDPerformanceView-Swift */; };
 		4046DEF02A9F469100CA6D2F /* GDPerformanceView-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 4046DEEF2A9F469100CA6D2F /* GDPerformanceView-Swift */; settings = {ATTRIBUTES = (Required, ); }; };
 		4046DEF22A9F510C00CA6D2F /* DebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */; };
+		404A5CFB2AD5648100EF1C62 /* DemoChatModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
 		406A8E8D2AA1D78C001F598A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		406A8E8E2AA1D79D001F598A /* UserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F445AD2A9DFC34004BE3DA /* UserState.swift */; };
@@ -898,6 +899,7 @@
 		4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		4046DEEA2A9E38DC00CA6D2F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenu.swift; sourceTree = "<group>"; };
+		404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatModifier.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
 		407D5D3C2ACEF0C500B5044E /* VisibilityThresholdModifier_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityThresholdModifier_Tests.swift; sourceTree = "<group>"; };
 		409386192AA09E4A00FF5AF4 /* MemoryLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryLogDestination.swift; sourceTree = "<group>"; };
@@ -1925,6 +1927,7 @@
 				40D946442AA5F67E00C8861B /* DemoCallingTopView.swift */,
 				40F445DA2A9E2276004BE3DA /* DemoCallContentView.swift */,
 				40F446012A9E2C23004BE3DA /* DemoCallView.swift */,
+				404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */,
 			);
 			path = CallView;
 			sourceTree = "<group>";
@@ -2113,7 +2116,6 @@
 				82FF40B62A17C6CD00B4D95E /* ReconnectionView_Tests.swift */,
 				82FF40B82A17C6D600B4D95E /* RecordingView_Tests.swift */,
 				82FF40BA2A17C6DF00B4D95E /* ScreenSharingView_Tests.swift */,
-				407D5D3C2ACEF0C500B5044E /* VisibilityThresholdModifier_Tests.swift */,
 				40D6ADDC2ACDB51C00EF5336 /* VideoRenderer_Tests.swift */,
 				407D5D3C2ACEF0C500B5044E /* VisibilityThresholdModifier_Tests.swift */,
 			);
@@ -3801,6 +3803,7 @@
 				847B47B72A260CF1000714CE /* CustomCallView.swift in Sources */,
 				40F445EA2A9E297B004BE3DA /* CallStateResponseFields+Identifiable.swift in Sources */,
 				40F445CC2A9E1FC9004BE3DA /* DemoChatViewFactory.swift in Sources */,
+				404A5CFB2AD5648100EF1C62 /* DemoChatModifier.swift in Sources */,
 				842D8BDA2865B37800801910 /* DemoApp.swift in Sources */,
 				40F445E82A9E2824004BE3DA /* Call+Identifiable.swift in Sources */,
 				40F445FE2A9E2B46004BE3DA /* DemoWaitingLocalUserView.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/577

### 📝 Summary

ChatView was disappearing when call events where happening. 

### 🛠 Implementation

The issue is that the ChatViewModel we rely on wasn't hold as StateObject somewhere, which causing the creation of multiple instances that were then affecting the ChatView presentation.

### 🧪 Manual Testing Notes

- Join a call
- Open chat
- Start sharing from another paricipant

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)
