### PR TITLE
Fix current user overlay view size when camera is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Factory method for creating `LocalParticipantViewModifier`
 - `availableSize` has been replaced by `availableFrame` in most Views.
 
+### 🐞 Fixed
+- Current user overlay view size when camera is off
+
 # [0.3.0](https://github.com/GetStream/stream-video-swift/releases/tag/0.3.0)
 _August 25, 2023_
 

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -195,7 +195,7 @@ public struct VideoCallParticipantView: View {
                 name: participant.name,
                 imageURL: participant.profileImageURL
             )
-            .frame(width: availableFrame.size.width)
+            .frame(maxWidth: .infinity)
             .opacity(showVideo ? 0 : 1)
         )
     }


### PR DESCRIPTION
### 🔗 Issue Links

Fixes this:
![Screenshot 2023-10-09 at 12 49 25](https://github.com/GetStream/stream-video-swift/assets/2971717/ac10ce02-b563-4499-99de-97cec7a4042b)

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
