### PR TITLE
Align participants sorting with Web

### DIFF
--- a/DemoApp/Sources/Views/Login/GoogleHelper.swift
+++ b/DemoApp/Sources/Views/Login/GoogleHelper.swift
@@ -37,6 +37,11 @@ enum GoogleHelper {
                     [directoryScope],
                     presenting: rootViewController
                 ) { result, error in
+                    guard result != nil else {
+                        struct NoGoogleUserFound: Error {}
+                        continuation.resume(throwing: NoGoogleUserFound())
+                        return
+                    }
                     Task {
                         do {
                             let credentials = try await userCredentials(for: userProfile)

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -20,7 +20,8 @@ public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
     dominantSpeaker,
     ifInvisible(isSpeaking),
     ifInvisible(publishingVideo),
-    ifInvisible(publishingAudio)
+    ifInvisible(publishingAudio),
+    userId
 ]
 
 /// The set of comparators used for sorting `CallParticipant` objects during livestreams.

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -166,9 +166,6 @@ public func conditional<T>(_ predicate: @escaping (T, T) -> Bool) -> (@escaping 
     }
 }
 
-/// Returns a comparator that always deems two elements "equal" regardless of their actual values.
-public func noop<T>() -> StreamSortComparator<T> { { _, _ in .orderedSame } }
-
 /// A specific conditional comparator for CallParticipant that checks if either participant's track is not visible.
 public let ifInvisible = conditional { (rhs: CallParticipant, lhs: CallParticipant) -> Bool in
     !rhs.showTrack || !lhs.showTrack
@@ -183,12 +180,13 @@ public var dominantSpeaker: StreamSortComparator<CallParticipant> = { comparison
 public var isSpeaking: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.isSpeaking) }
 
 /// Comparator which prioritizes participants who are pinned.
+/// - Note: Remote pins has higher priority than local.
 public var pinned: StreamSortComparator<CallParticipant> = { a, b in
     switch (a.pin, b.pin) {
     case (nil, _?): return .orderedDescending
     case (_?, nil): return .orderedAscending
-    case (let aPin?, let bPin?) where !aPin.isLocal && bPin.isLocal: return .orderedAscending
-    case (let aPin?, let bPin?) where aPin.isLocal && !bPin.isLocal: return .orderedDescending
+    case (let aPin?, let bPin?) where aPin.isLocal && !bPin.isLocal: return .orderedAscending
+    case (let aPin?, let bPin?) where !aPin.isLocal && bPin.isLocal: return .orderedDescending
     case (let aPin?, let bPin?) where aPin.pinnedAt > bPin.pinnedAt: return .orderedAscending
     case (let aPin?, let bPin?) where aPin.pinnedAt < bPin.pinnedAt: return .orderedDescending
     default: return .orderedSame

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -4,110 +4,229 @@
 
 import Foundation
 
+/// A type representing a comparator function that compares two `Value` objects and returns a `ComparisonResult`.
 public typealias StreamSortComparator<Value> = (Value, Value) -> ComparisonResult
 
+/// The default set of comparators used for sorting `CallParticipant` objects.
+/// - `pinned`: Prioritizes participants who are pinned.
+/// - `screensharing`: Sorts participants based on their screen sharing status.
+/// - `dominantSpeaker`: Sorts participants based on whether they are the dominant speaker or not.
+/// - `ifInvisible(isSpeaking)`: Sorts participants based on whether they are speaking, but only if they are not visible.
+/// - `ifInvisible(publishingVideo)`: Sorts participants based on their video status, but only if they are not visible.
+/// - `ifInvisible(publishingAudio)`: Sorts participants based on their audio status, but only if they are not visible.
 public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
-    pinned, screensharing, dominantSpeaker, publishingVideo, publishingAudio, joinedAt, userId
+    pinned,
+    screensharing,
+    dominantSpeaker,
+    ifInvisible(isSpeaking),
+    ifInvisible(publishingVideo),
+    ifInvisible(publishingAudio)
 ]
 
+/// The set of comparators used for sorting `CallParticipant` objects during livestreams.
+/// - `ifInvisible(dominantSpeaker)`: Sorts participants based on whether they are the dominant speaker or not, but only if they are not visible.
+/// - `ifInvisible(isSpeaking)`: Sorts participants based on whether they are speaking, but only if they are not visible.
+/// - `ifInvisible(publishingVideo)`: Sorts participants based on their video status, but only if they are not visible.
+/// - `ifInvisible(publishingAudio)`: Sorts participants based on their audio status, but only if they are not visible.
+/// - `roles()`: Sorts participants based on their assigned roles.
 public let livestreamComparators: [StreamSortComparator<CallParticipant>] = [
-    dominantSpeaker, isSpeaking, publishingVideo, publishingAudio, roles, userId
+    ifInvisible(dominantSpeaker),
+    ifInvisible(isSpeaking),
+    ifInvisible(publishingVideo),
+    ifInvisible(publishingAudio),
+    roles()
 ]
 
-public var pinned: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    if p1.pin == nil && p2.pin == nil { return .orderedSame }
-    if p1.pin == nil && p2.pin != nil { return .orderedAscending }
-    if p1.pin != nil && p2.pin == nil { return .orderedDescending }
-    let result = booleanComparison(first: p1, second: p2, \.pin?.isLocal, preferredValue: false)
-    if result == .orderedSame {
-        return dateComparison(first: p1.pin?.pinnedAt, second: p2.pin?.pinnedAt)
-    } else {
-        return result
-    }
-}
+// MARK: - Sort Sequence
 
-public var screensharing: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    booleanComparison(first: p1, second: p2, \.isScreensharing)
-}
+/// Represents the possible orders for sorting.
+public enum SortOrder { case ascending, descending }
 
-public var dominantSpeaker: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    booleanComparison(first: p1, second: p2, \.isDominantSpeaker)
-}
+extension Sequence where Element == CallParticipant {
 
-public var isSpeaking: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    booleanComparison(first: p1, second: p2, \.isSpeaking)
-}
-
-public var publishingVideo: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    booleanComparison(first: p1, second: p2, \.hasVideo)
-}
-
-public var publishingAudio: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    booleanComparison(first: p1, second: p2, \.hasAudio)
-}
-
-public var roles: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    if p1.roles == p2.roles { return .orderedSame }
-    let prioRoles = ["admin", "host", "speaker"]
-    for role in prioRoles {
-        if p1.roles.contains(role) && !p2.roles.contains(role) {
-            return .orderedDescending
-        }
-        if p2.roles.contains(role) && !p1.roles.contains(role) {
-            return .orderedAscending
-        }
-    }
-    return .orderedSame
-}
-
-public var userId: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    p1.id >= p2.id ? .orderedDescending : .orderedAscending
-}
-
-public var joinedAt: StreamSortComparator<CallParticipant> = { (p1, p2) in
-    p1.joinedAt <= p2.joinedAt ? .orderedDescending : .orderedAscending
-}
-
-public extension Sequence {
-    func sorted(using comparators: [StreamSortComparator<Element>], order: SortOrder = .descending) -> [Element] {
-        sorted { valueA, valueB in
-            for comparator in comparators {
-                let result = comparator(valueA, valueB)
-
-                switch result {
-                case .orderedSame:
-                    break
-                case .orderedAscending:
-                    return order == .ascending
-                case .orderedDescending:
-                    return order == .descending
-                }
+    /// Sorts the sequence's elements using a specified comparator and order.
+    ///
+    /// - Parameters:
+    ///   - comparator: The comparator function used to determine the order of two elements.
+    ///   - order: The desired sort order, either `.ascending` (default) or `.descending`.
+    /// - Returns: A sorted array of `CallParticipant`.
+    public func sorted(
+        by comparator: StreamSortComparator<Element>,
+        order: SortOrder = .ascending
+    ) -> [Element] {
+        sorted {
+            switch order {
+            case .ascending:
+                return comparator($0, $1) == .orderedAscending
+            case .descending:
+                return comparator($0, $1) == .orderedDescending
             }
+        }
+    }
 
-            return false
+    /// Sorts the sequence's elements using multiple comparators and a specified order.
+    /// The comparators are applied in the order they are provided.
+    ///
+    /// - Parameters:
+    ///   - comparators: An array of comparator functions used to determine the order of two elements.
+    ///   - order: The desired sort order, either `.ascending` (default) or `.descending`.
+    /// - Returns: A sorted array of `CallParticipant`.
+    public func sorted(
+        by comparators: [StreamSortComparator<Element>],
+        order: SortOrder = .ascending
+    ) -> [Element] { sorted(by: combineComparators(comparators), order: order) }
+}
+
+// MARK: - Comparison operations
+
+/// Compares two `Value` objects based on a specified property (via `KeyPath`) that conforms to `Comparable`.
+/// Returns a `ComparisonResult` indicating the ordering of the two objects based on that property.
+///
+/// - Parameters:
+///   - lhs: The left-hand side object for comparison.
+///   - rhs: The right-hand side object for comparison.
+///   - keyPath: The key path to a property of `Value` that should be used for comparison.
+/// - Returns: A `ComparisonResult` value indicating the ordering of `lhs` and `rhs` based on the property.
+func comparison<Value, T: Comparable>(
+    _ lhs: Value,
+    _ rhs: Value,
+    keyPath: KeyPath<Value, T>
+) -> ComparisonResult {
+    let lhsValue = lhs[keyPath: keyPath]
+    let rhsValue = rhs[keyPath: keyPath]
+
+    if lhsValue < rhsValue {
+        return .orderedAscending
+    } else if lhsValue > rhsValue {
+        return .orderedDescending
+    } else {
+        return .orderedSame
+    }
+}
+
+/// Compares two `Value` objects based on a specified boolean property (via `KeyPath`).
+/// Returns a `ComparisonResult` indicating the ordering of the two objects based on that property.
+/// Note: `true` is considered less than `false`.
+///
+/// - Parameters:
+///   - lhs: The left-hand side object for comparison.
+///   - rhs: The right-hand side object for comparison.
+///   - keyPath: The key path to a boolean property of `Value` that should be used for comparison.
+/// - Returns: A `ComparisonResult` value indicating the ordering of `lhs` and `rhs` based on the property.
+func comparison<Value>(
+    _ lhs: Value,
+    _ rhs: Value,
+    keyPath: KeyPath<Value, Bool>
+) -> ComparisonResult {
+    let lhsValue = lhs[keyPath: keyPath]
+    let rhsValue = rhs[keyPath: keyPath]
+
+    switch (lhsValue, rhsValue) {
+    case (true, false):
+        return .orderedAscending
+    case (false, true):
+        return .orderedDescending
+    default:
+        return .orderedSame
+    }
+}
+
+// MARK: - Comparators
+// MARK: Aggregators
+
+/// Combines multiple comparators into a single comparator.
+/// It uses the first comparator to compare two elements. If they are deemed "equal" (i.e., orderedSame),
+/// it moves to the next comparator, and so on, until a decision can be made or all comparators have been exhausted.
+public func combineComparators<T>(_ comparators: [StreamSortComparator<T>]) -> StreamSortComparator<T> {
+    return { a, b in
+        for comparator in comparators {
+            let result = comparator(a, b)
+            if result != .orderedSame {
+                return result
+            }
+        }
+        return .orderedSame
+    }
+}
+
+/// Returns a comparator that sorts elements in descending order based on the provided comparator.
+public func descending<T>(_ comparator: @escaping StreamSortComparator<T>) -> StreamSortComparator<T> { { comparator($0, $1) } }
+
+/// Returns a new comparator that only applies the given comparator if the predicate returns true.
+/// If the predicate returns false, it deems the two elements "equal" (i.e., orderedSame).
+public func conditional<T>(_ predicate: @escaping (T, T) -> Bool) -> (@escaping StreamSortComparator<T>) -> StreamSortComparator<T> {
+    return { comparator in
+        return { a, b in
+            if !predicate(a, b) {
+                return .orderedSame
+            }
+            return comparator(a, b)
         }
     }
 }
 
-public enum SortOrder {
-    case ascending
-    case descending
+/// Returns a comparator that always deems two elements "equal" regardless of their actual values.
+public func noopComparator<T>() -> StreamSortComparator<T> { { _, _ in .orderedSame } }
+
+/// A specific conditional comparator for CallParticipant that checks if either participant's track is not visible.
+public let ifInvisible = conditional { (rhs: CallParticipant, lhs: CallParticipant) -> Bool in
+    !rhs.showTrack || !lhs.showTrack
 }
 
-func booleanComparison<Value, T>(
-    first: Value,
-    second: Value,
-    _ keyPath: KeyPath<Value, T>,
-    preferredValue: Bool = true
-) -> ComparisonResult {
-    let boolFirst = first[keyPath: keyPath] as? Bool
-    let boolSecond = second[keyPath: keyPath] as? Bool
-    if boolFirst == boolSecond { return .orderedSame }
-    if boolFirst == preferredValue { return .orderedDescending }
-    if boolSecond == preferredValue { return .orderedAscending }
-    return .orderedSame
+// MARK: Instance
+
+/// Comparator which sorts participants by the fact that they are the dominant speaker or not.
+public var dominantSpeaker: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.isDominantSpeaker) }
+
+/// Comparator which sorts participants by the fact that they are speaking or not.
+public var isSpeaking: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.isSpeaking) }
+
+/// Comparator which prioritizes participants who are pinned.
+public var pinned: StreamSortComparator<CallParticipant> = { a, b in
+    switch (a.pin, b.pin) {
+    case (nil, _?): return .orderedDescending
+    case (_?, nil): return .orderedAscending
+    case (let aPin?, let bPin?) where !aPin.isLocal && bPin.isLocal: return .orderedAscending
+    case (let aPin?, let bPin?) where aPin.isLocal && !bPin.isLocal: return .orderedDescending
+    case (let aPin?, let bPin?) where aPin.pinnedAt > bPin.pinnedAt: return .orderedAscending
+    case (let aPin?, let bPin?) where aPin.pinnedAt < bPin.pinnedAt: return .orderedDescending
+    default: return .orderedSame
+    }
 }
 
-func dateComparison(first: Date?, second: Date?) -> ComparisonResult {
-    (first ?? Date()) >= (second ?? Date()) ? .orderedDescending : .orderedAscending
+/// Comparator which sorts participants by screen sharing status.
+public var screensharing: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.isScreensharing) }
+
+/// Comparator which sorts participants by video status.
+public var publishingVideo: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.hasVideo) }
+
+/// Comparator which sorts participants by audio status.
+public var publishingAudio: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.hasAudio) }
+
+/// Comparator which sorts participants by name.
+public var name: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.name) }
+
+/// A comparator creator which will set up a comparator which prioritizes participants who have a specific role.
+public func roles(_ priorityRoles: [String] = ["admin", "host", "speaker"]) -> StreamSortComparator<CallParticipant> {
+    return { (p1, p2) in
+        if p1.roles == p2.roles { return .orderedSame }
+        for role in priorityRoles {
+            if p1.roles.contains(role) && !p2.roles.contains(role) {
+                return .orderedDescending
+            }
+            if p2.roles.contains(role) && !p1.roles.contains(role) {
+                return .orderedAscending
+            }
+        }
+        return .orderedSame
+    }
 }
+
+/// Comparator for sorting `CallParticipant` objects based on their `id` property
+public var id: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.id) }
+
+/// Comparator for sorting `CallParticipant` objects based on their `userId` property
+public var userId: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.userId) }
+
+/// Comparator for sorting `CallParticipant` objects based on the date and time (`joinedAt`) they joined the call
+public var joinedAt: StreamSortComparator<CallParticipant> = { comparison($0, $1, keyPath: \.joinedAt) }

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -20,9 +20,7 @@ public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
     dominantSpeaker,
     ifInvisible(isSpeaking),
     ifInvisible(publishingVideo),
-    ifInvisible(publishingAudio),
-    joinedAt,
-    userId
+    ifInvisible(publishingAudio)
 ]
 
 /// The set of comparators used for sorting `CallParticipant` objects during livestreams.
@@ -167,8 +165,8 @@ public func conditional<T>(_ predicate: @escaping (T, T) -> Bool) -> (@escaping 
 }
 
 /// A specific conditional comparator for CallParticipant that checks if either participant's track is not visible.
-public let ifInvisible = conditional { (rhs: CallParticipant, lhs: CallParticipant) -> Bool in
-    !rhs.showTrack || !lhs.showTrack
+public let ifInvisible = conditional { (lhs: CallParticipant, rhs: CallParticipant) -> Bool in
+    !lhs.showTrack || !rhs.showTrack
 }
 
 // MARK: Instance

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -21,7 +21,7 @@ public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
     ifInvisible(isSpeaking),
     ifInvisible(publishingVideo),
     ifInvisible(publishingAudio),
-    userId
+    ifInvisible(userId)
 ]
 
 /// The set of comparators used for sorting `CallParticipant` objects during livestreams.

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -174,7 +174,23 @@ open class CallViewModel: ObservableObject {
         )
     }
     
-    public var participants: [CallParticipant] { call?.state.participants ?? [] }
+    public var participants: [CallParticipant] {
+        let updateParticipants = call?.state.participants ?? []
+        return updateParticipants.filter {
+            // In Grid layout with less than 3 participants the local user
+            // will be presented on the floating video track view. For this
+            // reason we filter out the participant to avoid showing them twice.
+            if
+                participantsLayout == .grid,
+                updateParticipants.count <= 3,
+                (call?.state.screenSharingSession == nil || call?.state.isCurrentUserScreensharing == true)
+            {
+                return $0.id != call?.state.sessionId
+            } else {
+                return true
+            }
+        }
+    }
 
     private var automaticLayoutHandling = true
     

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
 		406303462AD9432D0091AE77 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 406303442AD942ED0091AE77 /* GoogleSignInSwift */; };
 		406303472AD943B60091AE77 /* GoogleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADA682AD3F78F00769F6A /* GoogleHelper.swift */; };
+		4063033F2AD847EC0091AE77 /* CallState_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4063033E2AD847EC0091AE77 /* CallState_Tests.swift */; };
+		406303422AD848000091AE77 /* CallParticipant_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406303412AD848000091AE77 /* CallParticipant_Mock.swift */; };
 		406A8E8D2AA1D78C001F598A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		406A8E8E2AA1D79D001F598A /* UserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F445AD2A9DFC34004BE3DA /* UserState.swift */; };
 		406A8E922AA1D7B3001F598A /* CallKitState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F445AF2A9DFC58004BE3DA /* CallKitState.swift */; };
@@ -908,6 +910,8 @@
 		4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenu.swift; sourceTree = "<group>"; };
 		404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatModifier.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
+		4063033E2AD847EC0091AE77 /* CallState_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallState_Tests.swift; sourceTree = "<group>"; };
+		406303412AD848000091AE77 /* CallParticipant_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipant_Mock.swift; sourceTree = "<group>"; };
 		407D5D3C2ACEF0C500B5044E /* VisibilityThresholdModifier_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityThresholdModifier_Tests.swift; sourceTree = "<group>"; };
 		409386192AA09E4A00FF5AF4 /* MemoryLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryLogDestination.swift; sourceTree = "<group>"; };
 		4093861B2AA0A11500FF5AF4 /* LogQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogQueue.swift; sourceTree = "<group>"; };
@@ -1802,6 +1806,14 @@
 			path = Examples;
 			sourceTree = "<group>";
 		};
+		4063033D2AD847E60091AE77 /* CallState */ = {
+			isa = PBXGroup;
+			children = (
+				4063033E2AD847EC0091AE77 /* CallState_Tests.swift */,
+			);
+			path = CallState;
+			sourceTree = "<group>";
+		};
 		409386182AA09E3900FF5AF4 /* MemoryLogDestination */ = {
 			isa = PBXGroup;
 			children = (
@@ -2585,6 +2597,7 @@
 				84F58B9229EEB53E00010C4C /* EventMiddleware_Mock.swift */,
 				842747F229EED8D900E063AD /* InternetConnection_Mock.swift */,
 				82E3BA522A0BAF4B001AB93E /* WebSocketClientEnvironment_Mock.swift */,
+				406303412AD848000091AE77 /* CallParticipant_Mock.swift */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -3058,6 +3071,7 @@
 		84F737F8287C13AD00A363F4 /* StreamVideoTests */ = {
 			isa = PBXGroup;
 			children = (
+				4063033D2AD847E60091AE77 /* CallState */,
 				40AB31232A49836800C270E1 /* WebSockets */,
 				4351AEAB2A40586B00D32D0D /* IntegrationTests */,
 				84932245290831DB0013C029 /* StreamVideo.xctestplan */,
@@ -4159,6 +4173,7 @@
 				84F58B9529EEBA3900010C4C /* EquatableEvent.swift in Sources */,
 				842747FA29EEEC5A00E063AD /* EventLogger.swift in Sources */,
 				8414080F29F2838F00FF2D7C /* RawJSON_Tests.swift in Sources */,
+				406303422AD848000091AE77 /* CallParticipant_Mock.swift in Sources */,
 				841FF5032A5D6FEC00809BBB /* CallsController_Tests.swift in Sources */,
 				4351AEAD2A40588D00D32D0D /* IntegrationTest.swift in Sources */,
 				845E31082A712389004DC470 /* BroadcastUtils_Tests.swift in Sources */,
@@ -4213,6 +4228,7 @@
 				84BB570E2A20D7BB0002C123 /* Mapping_Tests.swift in Sources */,
 				8251E62F2A17BEEF00E7257A /* ImageFactory.swift in Sources */,
 				846D162B2A52F62B0036CE4C /* CameraManager_Tests.swift in Sources */,
+				4063033F2AD847EC0091AE77 /* CallState_Tests.swift in Sources */,
 				843DAB9C29E6FFCD00E0EB63 /* StreamVideo_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -40,10 +40,12 @@
 		4046DEF22A9F510C00CA6D2F /* DebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */; };
 		404A5CFB2AD5648100EF1C62 /* DemoChatModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
-		406303462AD9432D0091AE77 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 406303442AD942ED0091AE77 /* GoogleSignInSwift */; };
-		406303472AD943B60091AE77 /* GoogleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADA682AD3F78F00769F6A /* GoogleHelper.swift */; };
 		4063033F2AD847EC0091AE77 /* CallState_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4063033E2AD847EC0091AE77 /* CallState_Tests.swift */; };
 		406303422AD848000091AE77 /* CallParticipant_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406303412AD848000091AE77 /* CallParticipant_Mock.swift */; };
+		406303462AD9432D0091AE77 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 406303442AD942ED0091AE77 /* GoogleSignInSwift */; };
+		406303472AD943B60091AE77 /* GoogleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADA682AD3F78F00769F6A /* GoogleHelper.swift */; };
+		4069A0042AD985D2009A3A06 /* CallParticipant_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406303412AD848000091AE77 /* CallParticipant_Mock.swift */; };
+		4069A0052AD985D3009A3A06 /* CallParticipant_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406303412AD848000091AE77 /* CallParticipant_Mock.swift */; };
 		406A8E8D2AA1D78C001F598A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		406A8E8E2AA1D79D001F598A /* UserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F445AD2A9DFC34004BE3DA /* UserState.swift */; };
 		406A8E922AA1D7B3001F598A /* CallKitState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F445AF2A9DFC58004BE3DA /* CallKitState.swift */; };
@@ -4354,6 +4356,7 @@
 				84DCA2122A389167000C3411 /* AssertDelay.swift in Sources */,
 				82FF40C22A17C74600B4D95E /* CallingParticipantView_Tests.swift in Sources */,
 				82E3BA482A0BAE2A001AB93E /* AssertAsync.swift in Sources */,
+				4069A0042AD985D2009A3A06 /* CallParticipant_Mock.swift in Sources */,
 				82FF40BB2A17C6DF00B4D95E /* ScreenSharingView_Tests.swift in Sources */,
 				84D425102AA72F3500473150 /* LivestreamPlayer_Tests.swift in Sources */,
 				82FF40C02A17C73C00B4D95E /* CallingGroupView_Tests.swift in Sources */,
@@ -4415,6 +4418,7 @@
 				824DBAA629F93E1F005ACD09 /* AssertSnapshot.swift in Sources */,
 				8251E62D2A17BEB400E7257A /* StreamVideoTestResources.swift in Sources */,
 				82E3BA492A0BAE2B001AB93E /* AssertAsync.swift in Sources */,
+				4069A0052AD985D3009A3A06 /* CallParticipant_Mock.swift in Sources */,
 				829F7BFB29FABC0E003EBACE /* ViewFactory.swift in Sources */,
 				82E3BA552A0BAF4B001AB93E /* WebSocketClientEnvironment_Mock.swift in Sources */,
 				82E3BA4D2A0BAE41001AB93E /* EquatableEvent.swift in Sources */,

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -1,0 +1,230 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+@MainActor
+final class CallState_Tests: XCTestCase {
+
+    /// Test the `didUpdate(_:)` function by combining existing and newly added participants.
+    func test_didUpdate_combinesExistingAndNewParticipants() {
+        assertParticipantsUpdate(
+            initial: [
+                CallParticipant.dummy(id: "1")
+            ],
+            update: { $0 + [CallParticipant.dummy(id: "2")] },
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function with sorting participants using defaultComparators.
+    func test_didUpdate_sortsParticipantsUsingDefaultComparators() {
+        assertParticipantsUpdate(
+            initial: [
+                CallParticipant.dummy(id: "1", name: "Zane")
+            ],
+            update: { $0 + [CallParticipant.dummy(id: "2", name: "Aaron")] },
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by ensuring that duplicated participants are not added.
+    func test_didUpdate_avoidsDuplicateParticipants() {
+        assertParticipantsUpdate(
+            initial: [
+                CallParticipant.dummy(id: "1")
+            ],
+            update: { $0 },
+            expectedTransformer: { [$0[0]] }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants using the `isSpeaking` property.
+    func test_didUpdate_sortsParticipantsBySpeaking() {
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", isSpeaking: false),
+                .dummy(id: "3", isSpeaking: false)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", isSpeaking: true),
+                    .dummy(id: "4", isSpeaking: true)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[3], updated[0], updated[1]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants using the `hasVideo` property.
+    func test_didUpdate_sortsParticipantsByVideo() {
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", hasVideo: false),
+                .dummy(id: "3", hasVideo: false)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", hasVideo: true),
+                    .dummy(id: "4", hasVideo: true)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[3], updated[0], updated[1]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants using the `hasAudio` property.
+    func test_didUpdate_sortsParticipantsByAudio() {
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", hasAudio: false),
+                .dummy(id: "3", hasAudio: false)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", hasAudio: true),
+                    .dummy(id: "4", hasAudio: true)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[3], updated[0], updated[1]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants using the `joinedAt` property.
+    func test_didUpdate_sortsParticipantsByJoinTime() {
+        let earlierTime = Date().addingTimeInterval(-600)
+        let laterTime = Date()
+
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", joinedAt: laterTime),
+                .dummy(id: "3", joinedAt: laterTime)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", joinedAt: earlierTime),
+                    .dummy(id: "4", joinedAt: earlierTime)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[3], updated[0], updated[1]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants using the `userId` property.
+    func test_didUpdate_sortsParticipantsByUserId() {
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", userId: "B"),
+                .dummy(id: "3", userId: "D")
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", userId: "A"),
+                    .dummy(id: "4", userId: "C")
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[0], updated[3], updated[1]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants based on speaking and video properties.
+    func test_didUpdate_sortsParticipantsBySpeakingAndVideo() {
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", hasVideo: false, isSpeaking: true),
+                .dummy(id: "3", hasVideo: true, isSpeaking: false)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", hasVideo: true, isSpeaking: true),
+                    .dummy(id: "4", hasVideo: false, isSpeaking: false)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[0], updated[1], updated[3]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants based on joined time and audio properties.
+    func test_didUpdate_sortsParticipantsByJoinTimeAndAudio() {
+        let earlierTime = Date().addingTimeInterval(-600)
+        let laterTime = Date()
+
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", hasAudio: true, joinedAt: earlierTime),
+                .dummy(id: "3", hasAudio: false, joinedAt: laterTime)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", hasAudio: true, joinedAt: laterTime),
+                    .dummy(id: "4", hasAudio: false, joinedAt: earlierTime)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[0], updated[2], updated[3], updated[1]]
+            }
+        )
+    }
+
+    /// Test the `didUpdate(_:)` function by sorting participants based on userId and speaking properties.
+    func test_didUpdate_sortsParticipantsByUserIdAndSpeaking() {
+        assertParticipantsUpdate(
+            initial: [
+                .dummy(id: "1", userId: "A", isSpeaking: false),
+                .dummy(id: "3", userId: "D", isSpeaking: true)
+            ],
+            update: { initial in
+                return initial + [
+                    .dummy(id: "2", userId: "B", isSpeaking: true),
+                    .dummy(id: "4", userId: "C", isSpeaking: false)
+                ]
+            },
+            expectedTransformer: { updated in
+                return [updated[2], updated[1], updated[0], updated[3]]
+            }
+        )
+
+    }
+
+    // MARK: - Private helpers
+
+    private func assertParticipantsUpdate(
+        initial: [CallParticipant],
+        update: @escaping (_ initial: [CallParticipant]) -> [CallParticipant],
+        expectedTransformer: @escaping ([CallParticipant]) -> [CallParticipant],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let subject = CallState()
+        subject.participantsMap = initial.reduce([String: CallParticipant]()) {
+            var mutated = $0
+            mutated[$1.id] = $1
+            return mutated
+        }
+
+        let updated = update(initial)
+        let expected = expectedTransformer(updated)
+        subject.participantsMap = updated.reduce([String: CallParticipant]()) {
+            var mutated = $0
+            mutated[$1.id] = $1
+            return mutated
+        }
+
+        XCTAssertEqual(subject.participants, expected, file: file, line: line)
+    }
+}

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -99,28 +99,6 @@ final class CallState_Tests: XCTestCase {
         )
     }
 
-    /// Test the `didUpdate(_:)` function by sorting participants using the `joinedAt` property.
-    func test_didUpdate_sortsParticipantsByJoinTime() {
-        let earlierTime = Date().addingTimeInterval(-600)
-        let laterTime = Date()
-
-        assertParticipantsUpdate(
-            initial: [
-                .dummy(id: "1", joinedAt: laterTime),
-                .dummy(id: "3", joinedAt: laterTime)
-            ],
-            update: { initial in
-                return initial + [
-                    .dummy(id: "2", joinedAt: earlierTime),
-                    .dummy(id: "4", joinedAt: earlierTime)
-                ]
-            },
-            expectedTransformer: { updated in
-                return [updated[2], updated[3], updated[0], updated[1]]
-            }
-        )
-    }
-
     /// Test the `didUpdate(_:)` function by sorting participants using the `userId` property.
     func test_didUpdate_sortsParticipantsByUserId() {
         assertParticipantsUpdate(
@@ -160,23 +138,20 @@ final class CallState_Tests: XCTestCase {
     }
 
     /// Test the `didUpdate(_:)` function by sorting participants based on joined time and audio properties.
-    func test_didUpdate_sortsParticipantsByJoinTimeAndAudio() {
-        let earlierTime = Date().addingTimeInterval(-600)
-        let laterTime = Date()
-
+    func test_didUpdate_sortsParticipantsByUserIdAndAudio() {
         assertParticipantsUpdate(
             initial: [
-                .dummy(id: "1", hasAudio: true, joinedAt: earlierTime),
-                .dummy(id: "3", hasAudio: false, joinedAt: laterTime)
+                .dummy(id: "1", hasAudio: true),
+                .dummy(id: "3", hasAudio: false)
             ],
             update: { initial in
                 return initial + [
-                    .dummy(id: "2", hasAudio: true, joinedAt: laterTime),
-                    .dummy(id: "4", hasAudio: false, joinedAt: earlierTime)
+                    .dummy(id: "2", hasAudio: true),
+                    .dummy(id: "4", hasAudio: false)
                 ]
             },
             expectedTransformer: { updated in
-                return [updated[0], updated[2], updated[3], updated[1]]
+                return [updated[0], updated[2], updated[1], updated[3]]
             }
         )
     }
@@ -247,8 +222,14 @@ final class CallState_Tests: XCTestCase {
             mutated[$1.id] = $1
             return mutated
         }
+        let actualIndexes = subject.participants.map { updated.firstIndex(of: $0) ?? -1 }
 
-        XCTAssertEqual(subject.participants, expected, file: file, line: line)
+        XCTAssertTrue(
+            subject.participants == expected,
+            "Sorting order error. Expected order [\(actualIndexes.map(\.description).joined(separator: ","))]",
+            file: file,
+            line: line
+        )
     }
 
     private func makeCallParticipants(count: Int, nameSuffix: Int = 0) -> [CallParticipant] {

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -206,7 +206,7 @@ final class CallState_Tests: XCTestCase {
         let subject = CallState()
         let cycleCount = 250
 
-        assertDuration(maxDuration: 1) {
+        assertDuration(maxDuration: 5) {
             /// Add 2500 users
             (0..<10).forEach {
                 add(count: cycleCount, namePrefix: $0, in: subject)

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -160,17 +160,17 @@ final class CallState_Tests: XCTestCase {
     func test_didUpdate_sortsParticipantsByUserIdAndSpeaking() {
         assertParticipantsUpdate(
             initial: [
-                .dummy(id: "1", userId: "A", isSpeaking: false),
-                .dummy(id: "3", userId: "D", isSpeaking: true)
+                .dummy(id: "1", userId: "A", showTrack: false, isSpeaking: false),
+                .dummy(id: "3", userId: "D", showTrack: true, isSpeaking: true)
             ],
             update: { initial in
                 return initial + [
-                    .dummy(id: "2", userId: "B", isSpeaking: true),
-                    .dummy(id: "4", userId: "C", isSpeaking: false)
+                    .dummy(id: "2", userId: "B", showTrack: true, isSpeaking: true),
+                    .dummy(id: "4", userId: "C", showTrack: false, isSpeaking: false)
                 ]
             },
             expectedTransformer: { updated in
-                return [updated[2], updated[1], updated[0], updated[3]]
+                return [updated[1], updated[2], updated[0], updated[3]]
             }
         )
 

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -293,7 +293,7 @@ final class CallController_Tests: ControllerTestCase {
         // Given
         let sessionId = "test"
         webRTCClient = makeWebRTCClient()
-        let participant = MockResponseBuilder().makeCallParticipant(id: sessionId)
+        let participant = CallParticipant.dummy(id: sessionId)
         await webRTCClient.state.update(callParticipants: [sessionId: participant])
         let callController = makeCallController()
         let call = streamVideo?.call(callType: callType, callId: callId)
@@ -318,7 +318,7 @@ final class CallController_Tests: ControllerTestCase {
         let sessionId = "test"
         let size = CGSize(width: 100, height: 100)
         webRTCClient = makeWebRTCClient()
-        let participant = MockResponseBuilder().makeCallParticipant(id: sessionId)
+        let participant = CallParticipant.dummy(id: sessionId)
         await webRTCClient.state.update(callParticipants: [sessionId: participant])
         let callController = makeCallController()
         let call = streamVideo?.call(callType: callType, callId: callId)
@@ -342,7 +342,7 @@ final class CallController_Tests: ControllerTestCase {
         // Given
         let sessionId = "test"
         webRTCClient = makeWebRTCClient()
-        let participant = MockResponseBuilder().makeCallParticipant(id: sessionId)
+        let participant = CallParticipant.dummy(id: sessionId)
         await webRTCClient.state.update(callParticipants: [sessionId: participant])
         let callController = makeCallController()
         let call = streamVideo?.call(callType: callType, callId: callId)

--- a/StreamVideoTests/Mock/CallParticipant_Mock.swift
+++ b/StreamVideoTests/Mock/CallParticipant_Mock.swift
@@ -1,0 +1,58 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamVideo
+import WebRTC
+
+extension CallParticipant {
+
+    static func dummy(
+        id: String = .unique,
+        userId: String? = nil,
+        roles: [String] = [],
+        name: String = .unique,
+        profileImageURL: URL? = nil,
+        trackLookupPrefix: String? = nil,
+        hasVideo: Bool = false,
+        hasAudio: Bool = false,
+        isScreenSharing: Bool = false,
+        showTrack: Bool = false,
+        track: RTCVideoTrack? = nil,
+        trackSize: CGSize = CGSize(width: 1024, height: 720),
+        screenshareTrack: RTCVideoTrack? = nil,
+        isSpeaking: Bool = false,
+        isDominantSpeaker: Bool = false,
+        sessionId: String? = nil,
+        connectionQuality: ConnectionQuality = .unknown,
+        joinedAt: Date = .init(timeIntervalSince1970: 0),
+        audioLevel: Float = 0,
+        audioLevels: [Float] = [],
+        pin: PinInfo? = nil
+    ) -> CallParticipant {
+        .init(
+            id: id,
+            userId: userId ?? id,
+            roles: roles,
+            name: name,
+            profileImageURL: profileImageURL,
+            trackLookupPrefix: trackLookupPrefix,
+            hasVideo: hasVideo,
+            hasAudio: hasAudio,
+            isScreenSharing: isScreenSharing,
+            showTrack: showTrack,
+            track: track,
+            trackSize: trackSize,
+            screenshareTrack: screenshareTrack,
+            isSpeaking: isSpeaking,
+            isDominantSpeaker: isDominantSpeaker,
+            sessionId: sessionId ?? id,
+            connectionQuality: connectionQuality,
+            joinedAt: joinedAt,
+            audioLevel: audioLevel,
+            audioLevels: audioLevels,
+            pin: pin
+        )
+    }
+}

--- a/StreamVideoTests/Mock/MockResponseBuilder.swift
+++ b/StreamVideoTests/Mock/MockResponseBuilder.swift
@@ -161,43 +161,6 @@ class MockResponseBuilder {
         )
     }
     
-    func makeCallParticipant(
-        id: String,
-        name: String = "",
-        roles: [String] = [],
-        hasVideo: Bool = false,
-        hasAudio: Bool = false,
-        isScreenSharing: Bool = false,
-        isSpeaking: Bool = false,
-        isDominantSpeaker: Bool = false,
-        pin: PinInfo? = nil
-    ) -> CallParticipant {
-        let participant = CallParticipant(
-            id: id,
-            userId: id,
-            roles: roles,
-            name: name,
-            profileImageURL: nil,
-            trackLookupPrefix: nil,
-            hasVideo: hasVideo,
-            hasAudio: hasAudio,
-            isScreenSharing: isScreenSharing,
-            showTrack: true,
-            track: nil,
-            trackSize: .zero,
-            screenshareTrack: nil,
-            isSpeaking: isSpeaking,
-            isDominantSpeaker: isDominantSpeaker,
-            sessionId: id,
-            connectionQuality: .unknown,
-            joinedAt: Date(),
-            audioLevel: 0,
-            audioLevels: [],
-            pin: pin
-        )
-        return participant
-    }
-    
     func makeCallSessionResponse(
         acceptedBy: [String: Date] = [:],
         rejectedBy: [String: Date] = [:],

--- a/StreamVideoTests/Utils/Sorting_Tests.swift
+++ b/StreamVideoTests/Utils/Sorting_Tests.swift
@@ -4,182 +4,741 @@
 
 @testable import StreamVideo
 import XCTest
+import WebRTC
 
 final class Sorting_Tests: XCTestCase {
-    
-    private let mockResponseBuilder = MockResponseBuilder()
 
-    func testSortByScreensharingAndUserId() {
-        // Given
-        let participant1 = makeCallParticipant(id: "1")
-        let participant2 = makeCallParticipant(id: "2", isScreenSharing: true)
-        let participant3 = makeCallParticipant(id: "3")
-        let participants = [participant1, participant2, participant3]
-        
-        // When
-        let sortedParticipants = participants.sorted(using: [screensharing, userId])
-        
-        // Then
-        XCTAssertEqual(sortedParticipants, [participant2, participant3, participant1])
-    }
-    
-    func testSortByDominantSpeakerAndIsSpeaking() {
-        // Given
-        let participant1 = makeCallParticipant(id: "1", isSpeaking: true, isDominantSpeaker: true)
-        let participant2 = makeCallParticipant(id: "2")
-        let participant3 = makeCallParticipant(id: "3", isSpeaking: true)
-        let participants = [participant1, participant2, participant3]
-        
-        // When
-        let sortedParticipants = participants.sorted(using: [dominantSpeaker, isSpeaking, userId])
-        
-        // Then
-        XCTAssertEqual(sortedParticipants, [participant1, participant3, participant2])
-    }
-    
-    func testMultipleCriteriaSorting() {
-        // Given
-        let p1 = makeCallParticipant(
-            id: "123",
-            name: "Alice",
-            roles: ["speaker"],
-            hasVideo: true,
-            hasAudio: true,
-            isScreenSharing: false,
-            isSpeaking: true,
-            isDominantSpeaker: false
-        )
-        let p2 = makeCallParticipant(
-            id: "234",
-            name: "Bob",
-            roles: ["listener"],
-            hasVideo: false,
-            hasAudio: true,
-            isScreenSharing: true,
-            isSpeaking: false,
-            isDominantSpeaker: false
-        )
-        let p3 = makeCallParticipant(
-            id: "345",
-            name: "Charlie",
-            roles: ["listener"],
-            hasVideo: false,
-            hasAudio: false,
-            isScreenSharing: false,
-            isSpeaking: false,
-            isDominantSpeaker: true
-        )
-        let participants = [p1, p2, p3]
+    // MARK: - pinned
 
-        // When
-        // Sort by user id in ascending order
-        let sorted1 = participants.sorted(using: [userId], order: .ascending)
-        // Then
-        XCTAssertEqual(sorted1.map(\.userId), ["123", "234", "345"])
-
-        // When
-        // Sort by screensharing (false first) and then by user id in descending order
-        let sorted2 = participants.sorted(using: [screensharing, userId], order: .descending)
-        // Then
-        XCTAssertEqual(sorted2.map(\.userId), ["234", "345", "123"])
-
-        // When
-        // Sort by publishing video (true first) and then by publishing audio (true first) in ascending order
-        let sorted3 = participants.sorted(using: [publishingVideo, publishingAudio], order: .ascending)
-        // Then
-        XCTAssertEqual(sorted3.map(\.userId), ["345", "234", "123"])
-
-        // When
-        // Sort by is speaking (true first), dominant speaker (true first), and then user id in descending order
-        let sorted4 = participants.sorted(using: [isSpeaking, dominantSpeaker, userId], order: .descending)
-        // Then
-        XCTAssertEqual(sorted4.map(\.userId), ["123", "345", "234"])
-    }
-    
-    func testSortingRoles() {
-        // Given
-        let participant1 = makeCallParticipant(id: "1", roles: ["user"])
-        let participant2 = makeCallParticipant(id: "2", roles: ["speaker", "host"])
-        let participant3 = makeCallParticipant(id: "3", roles: ["admin", "host"])
-        let participant4 = makeCallParticipant(id: "4", roles: ["speaker"])
-        let participant5 = makeCallParticipant(id: "5")
-        let participants = [participant1, participant2, participant3, participant4, participant5]
-        
-        // When
-        let sorted = participants.sorted(using: [roles, userId])
-        
-        // Then
-        XCTAssertEqual(sorted.map(\.id), ["3", "2", "4", "5", "1"])
-    }
-    
-    func testPinnedLocal() {
-        // Given
-        let participant1 = makeCallParticipant(id: "1")
-        let participant2 = makeCallParticipant(id: "2", pin: PinInfo(isLocal: true, pinnedAt: Date()))
-        let participants = [participant1, participant2]
-        
-        // When
-        let sorted = participants.sorted(using: [pinned])
-        
-        // Then
-        XCTAssertEqual(sorted.map(\.id), ["2", "1"])
-    }
-    
-    func testPinnedLocalAndRemote() {
-        // Given
-        let participant1 = makeCallParticipant(id: "1")
-        let participant2 = makeCallParticipant(id: "2", pin: PinInfo(isLocal: true, pinnedAt: Date()))
-        let participant3 = makeCallParticipant(id: "3", pin: PinInfo(isLocal: false, pinnedAt: Date()))
-        let participants = [participant1, participant2, participant3]
-        
-        // When
-        let sorted = participants.sorted(using: [pinned])
-        
-        // Then
-        XCTAssertEqual(sorted.map(\.id), ["3", "2", "1"])
-    }
-    
-    func testPinnedMultipleLocalAndRemote() {
-        // Given
-        let participant1 = makeCallParticipant(id: "1")
-        let participant2 = makeCallParticipant(id: "2", pin: PinInfo(isLocal: true, pinnedAt: Date()))
-        let participant3 = makeCallParticipant(id: "3", pin: PinInfo(isLocal: false, pinnedAt: Date()))
-        let participant4 = makeCallParticipant(id: "4")
-        let participant5 = makeCallParticipant(id: "5", pin: PinInfo(isLocal: true, pinnedAt: Date().addingTimeInterval(-10)))
-        let participant6 = makeCallParticipant(id: "6", pin: PinInfo(isLocal: false, pinnedAt: Date().addingTimeInterval(-10)))
-        let participants = [participant1, participant2, participant3, participant4, participant5, participant6]
-        
-        // When
-        let sorted = participants.sorted(using: [pinned, userId])
-        
-        // Then
-        XCTAssertEqual(sorted.map(\.id), ["3", "6", "2", "5", "4", "1"])
-    }
-    
-    //MARK: - private
-    
-    private func makeCallParticipant(
-        id: String,
-        name: String = "",
-        roles: [String] = [],
-        hasVideo: Bool = false,
-        hasAudio: Bool = false,
-        isScreenSharing: Bool = false,
-        isSpeaking: Bool = false,
-        isDominantSpeaker: Bool = false,
-        pin: PinInfo? = nil
-    ) -> CallParticipant {
-        mockResponseBuilder.makeCallParticipant(
-            id: id,
-            name: name,
-            roles: roles,
-            hasVideo: hasVideo,
-            hasAudio: hasAudio,
-            isScreenSharing: isScreenSharing,
-            isSpeaking: isSpeaking,
-            isDominantSpeaker: isDominantSpeaker,
-            pin: pin
+    /// Test with only pinned participants.
+    func test_pinned_allPinned() {
+        assertSort(
+            [
+                .dummy(pin: PinInfo(isLocal: true, pinnedAt: Date(timeIntervalSince1970: 100))),
+                .dummy(pin: PinInfo(isLocal: true, pinnedAt: Date(timeIntervalSince1970: 200)))
+            ],
+            comparator: pinned,
+            expectedTransformer: { [$0[1], $0[0]] }
         )
     }
-    
+
+    /// Test with only unpinned participants.
+    func test_pinned_noPinned() {
+        assertSort(
+            [
+                .dummy(),
+                .dummy()
+            ],
+            comparator: pinned,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with a mix of pinned and unpinned participants.
+    func test_pinned_mixedPinned() {
+        assertSort(
+            [
+                .dummy(),
+                .dummy(pin: PinInfo(isLocal: true, pinnedAt: Date(timeIntervalSince1970: 100)))
+            ],
+            comparator: pinned,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    /// Test with pinned participants having different pinnedAt dates.
+    func test_pinned_differentPinnedDates() {
+        assertSort(
+            [
+                .dummy(pin: PinInfo(isLocal: true, pinnedAt: Date(timeIntervalSince1970: 50))),
+                .dummy(pin: PinInfo(isLocal: true, pinnedAt: Date(timeIntervalSince1970: 100)))
+            ],
+            comparator: pinned,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    // MARK: - screenSharing
+
+    /// Test with all participants screen sharing.
+    func test_screenSharing_allSharing() {
+        assertSort(
+            [
+                .dummy(isScreenSharing: true),
+                .dummy(isScreenSharing: true)
+            ],
+            comparator: screensharing,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with no participants screen sharing.
+    func test_screenSharing_noSharing() {
+        assertSort(
+            [
+                .dummy(isScreenSharing: false),
+                .dummy(isScreenSharing: false)
+            ],
+            comparator: screensharing,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with a mix of participants screen sharing and not.
+    func test_screenSharing_mixedSharing() {
+        assertSort(
+            [
+                .dummy(isScreenSharing: false),
+                .dummy(isScreenSharing: true)
+            ],
+            comparator: screensharing,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    // MARK: - isDominantSpeaker
+
+    /// Test with all participants as dominant speakers.
+    func test_dominantSpeaker_allDominant() {
+        assertSort(
+            [
+                .dummy(isDominantSpeaker: true),
+                .dummy(isDominantSpeaker: true)
+            ],
+            comparator: dominantSpeaker,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with no participants as dominant speakers.
+    func test_dominantSpeaker_noDominant() {
+        assertSort(
+            [
+                .dummy(isDominantSpeaker: false),
+                .dummy(isDominantSpeaker: false)
+            ],
+            comparator: dominantSpeaker,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with a mix of dominant speakers and non-dominant speakers.
+    func test_dominantSpeaker_mixedDominant() {
+        assertSort(
+            [
+                .dummy(isDominantSpeaker: false),
+                .dummy(isDominantSpeaker: true)
+            ],
+            comparator: dominantSpeaker,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    // MARK: - isSpeaking
+
+    /// Test with all participants speaking.
+    func test_isSpeaking_allSpeaking() {
+        assertSort(
+            [
+                .dummy(isSpeaking: true),
+                .dummy(isSpeaking: true)
+            ],
+            comparator: isSpeaking,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with no participants speaking.
+    func test_isSpeaking_noSpeaking() {
+        assertSort(
+            [
+                .dummy(isSpeaking: false),
+                .dummy(isSpeaking: false)
+            ],
+            comparator: isSpeaking,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with a mix of participants who are and aren't speaking.
+    func test_isSpeaking_mixedSpeaking() {
+        assertSort(
+            [
+                .dummy(isSpeaking: false),
+                .dummy(isSpeaking: true)
+            ],
+            comparator: isSpeaking,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    // MARK: - publishingVideo
+
+    /// Test with all participants publishing video.
+    func test_publishingVideo_allPublishing() {
+        assertSort(
+            [
+                .dummy(hasVideo: true),
+                .dummy(hasVideo: true)
+            ],
+            comparator: publishingVideo,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with no participants publishing video.
+    func test_publishingVideo_noPublishing() {
+        assertSort(
+            [
+                .dummy(hasVideo: false),
+                .dummy(hasVideo: false)
+            ],
+            comparator: publishingVideo,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with a mix of participants who are and aren't publishing video.
+    func test_publishingVideo_mixedPublishing() {
+        assertSort(
+            [
+                .dummy(hasVideo: false),
+                .dummy(hasVideo: true)
+            ],
+            comparator: publishingVideo,
+            expectedTransformer: { [$0[1], $0[0]] }  // Expecting the one publishing video to be first.
+        )
+    }
+
+    // MARK: - publishingAudio
+
+    /// Test with all participants publishing audio.
+    func test_publishingAudio_allPublishing() {
+        assertSort(
+            [
+                .dummy(hasAudio: true),
+                .dummy(hasAudio: true)
+            ],
+            comparator: publishingAudio,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with no participants publishing audio.
+    func test_publishingAudio_noPublishing() {
+        assertSort(
+            [
+                .dummy(hasAudio: false),
+                .dummy(hasAudio: false)
+            ],
+            comparator: publishingAudio,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with a mix of participants who are and aren't publishing audio.
+    func test_publishingAudio_mixedPublishing() {
+        assertSort(
+            [
+                .dummy(hasAudio: false),
+                .dummy(hasAudio: true)
+            ],
+            comparator: publishingAudio,
+            expectedTransformer: { [$0[1], $0[0]] }  // Expecting the one publishing audio to be first.
+        )
+    }
+
+    // MARK: - name
+
+    /// Test with participants having names in alphabetical order.
+    func test_name_alreadySorted() {
+        assertSort(
+            [
+                .dummy(name: "Adam"),
+                .dummy(name: "Eve")
+            ],
+            comparator: nameComparator,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    /// Test with participants having names in non-alphabetical order.
+    func test_name_unsorted() {
+        assertSort(
+            [
+                .dummy(name: "Zane"),
+                .dummy(name: "Aaron")
+            ],
+            comparator: nameComparator,
+            expectedTransformer: { [$0[1], $0[0]] }  // Expecting the names in alphabetical order.
+        )
+    }
+
+    /// Test with participants having names with varied casing.
+    func test_name_mixedCase() {
+        assertSort(
+            [
+                .dummy(name: "aaron"),
+                .dummy(name: "Aaron"),
+                .dummy(name: "AARON")
+            ],
+            comparator: nameComparator,
+            expectedTransformer: { [$0[2], $0[1], $0[0]] }  // Expecting a case-sensitive alphabetical order.
+        )
+    }
+
+    /// Test with participants having identical names.
+    func test_name_identical() {
+        assertSort(
+            [
+                .dummy(name: "Adam"),
+                .dummy(name: "Adam")
+            ],
+            comparator: nameComparator,
+            expectedTransformer: { [$0[0], $0[1]] }  // Order doesn't matter when names are identical.
+        )
+    }
+
+    // MARK: - roles
+
+    /// Test the `roles` comparator with participants having priority roles.
+    func test_roles_priorityRoles() {
+        let rolesComparator = roles()
+
+        assertSort(
+            [
+                .dummy(roles: ["speaker"]),
+                .dummy(roles: ["host"]),
+                .dummy(roles: ["admin"])
+            ],
+            comparator: rolesComparator,
+            expectedTransformer: { [$0[2], $0[1], $0[0]] }  // Expecting the order: "admin", "host", "speaker".
+        )
+    }
+
+    /// Test the `roles` comparator with one participant having a priority role and the other not.
+    func test_roles_oneWithPriority() {
+        let rolesComparator = roles()
+
+        assertSort(
+            [
+                .dummy(roles: ["speaker"]),
+                .dummy(roles: ["member"])
+            ],
+            comparator: rolesComparator,
+            expectedTransformer: { [$0[0], $0[1]] }  // "speaker" has priority over "member".
+        )
+    }
+
+    /// Test the `roles` comparator with both participants having non-priority roles.
+    func test_roles_noPriority() {
+        let rolesComparator = roles()
+
+        assertSort(
+            [
+                .dummy(roles: ["member"]),
+                .dummy(roles: ["user"])
+            ],
+            comparator: rolesComparator,
+            expectedTransformer: { [$0[0], $0[1]] }  // The order remains unchanged as neither role has priority.
+        )
+    }
+
+    /// Test the `roles` comparator with participants having multiple roles.
+    func test_roles_multipleRoles() {
+        let rolesComparator = roles()
+
+        assertSort(
+            [
+                .dummy(roles: ["member", "admin"]),
+                .dummy(roles: ["host", "user"])
+            ],
+            comparator: rolesComparator,
+            expectedTransformer: { [$0[0], $0[1]] }  // "admin" has the highest priority among all roles in the list.
+        )
+    }
+
+    /// Test with participants having no roles.
+    func test_roles_noRoles() {
+        assertSort(
+            [
+                .dummy(roles: []),
+                .dummy(roles: [])
+            ],
+            comparator: roles(["admin", "host", "speaker", "attendee"]),
+            expectedTransformer: { [$0[0], $0[1]] }  // Order doesn't matter when there are no roles.
+        )
+    }
+
+    // MARK: - id
+
+    /// Test with participants having IDs in alphabetical order.
+    func test_id_alreadySorted() {
+        assertSort(
+            [
+                .dummy(id: "A123"),
+                .dummy(id: "B456"),
+                .dummy(id: "C789")
+            ],
+            comparator: id,
+            expectedTransformer: { [$0[0], $0[1], $0[2]] }
+        )
+    }
+
+    /// Test with participants having IDs in a random order.
+    func test_id_unsorted() {
+        assertSort(
+            [
+                .dummy(id: "B456"),
+                .dummy(id: "A123"),
+                .dummy(id: "C789")
+            ],
+            comparator: id,
+            expectedTransformer: { [$0[1], $0[0], $0[2]] }
+        )
+    }
+
+    /// Test with participants having identical IDs.
+    func test_id_identical() {
+        assertSort(
+            [
+                .dummy(id: "A123"),
+                .dummy(id: "A123")
+            ],
+            comparator: id,
+            expectedTransformer: { [$0[0], $0[1]] }  // Order doesn't matter when IDs are identical.
+        )
+    }
+
+    // MARK: - userId
+
+    /// Test with participants having user IDs in alphabetical order.
+    func test_userId_alreadySorted() {
+        assertSort(
+            [
+                .dummy(userId: "A123"),
+                .dummy(userId: "B456"),
+                .dummy(userId: "C789")
+            ],
+            comparator: userId,
+            expectedTransformer: { [$0[0], $0[1], $0[2]] }
+        )
+    }
+
+    /// Test with participants having user IDs in a random order.
+    func test_userId_unsorted() {
+        assertSort(
+            [
+                .dummy(userId: "B456"),
+                .dummy(userId: "A123"),
+                .dummy(userId: "C789")
+            ],
+            comparator: userId,
+            expectedTransformer: { [$0[1], $0[0], $0[2]] }
+        )
+    }
+
+    /// Test with participants having identical user IDs.
+    func test_userId_identical() {
+        assertSort(
+            [
+                .dummy(userId: "A123"),
+                .dummy(userId: "A123")
+            ],
+            comparator: userId,
+            expectedTransformer: { [$0[0], $0[1]] }  // Order doesn't matter when user IDs are identical.
+        )
+    }
+
+    // MARK: - joinedAt
+
+    /// Test with participants who joined the call in chronological order.
+    func test_joinedAt_alreadySorted() {
+        assertSort(
+            [
+                .dummy(joinedAt: Date(timeIntervalSince1970: 1000)),
+                .dummy(joinedAt: Date(timeIntervalSince1970: 2000)),
+                .dummy(joinedAt: Date(timeIntervalSince1970: 3000))
+            ],
+            comparator: joinedAt,
+            expectedTransformer: { [$0[0], $0[1], $0[2]] }
+        )
+    }
+
+    /// Test with participants who joined the call in a random order.
+    func test_joinedAt_unsorted() {
+        assertSort(
+            [
+                .dummy(joinedAt: Date(timeIntervalSince1970: 2000)),
+                .dummy(joinedAt: Date(timeIntervalSince1970: 1000)),
+                .dummy(joinedAt: Date(timeIntervalSince1970: 3000))
+            ],
+            comparator: joinedAt,
+            expectedTransformer: { [$0[1], $0[0], $0[2]] }
+        )
+    }
+
+    /// Test with participants who joined the call at the same time.
+    func test_joinedAt_identical() {
+        assertSort(
+            [
+                .dummy(joinedAt: Date(timeIntervalSince1970: 1000)),
+                .dummy(joinedAt: Date(timeIntervalSince1970: 1000))
+            ],
+            comparator: joinedAt,
+            expectedTransformer: { [$0[0], $0[1]] }  // Order doesn't matter when join times are identical.
+        )
+    }
+
+    // MARK: - combineComparators
+
+    /// Test with multiple comparators where the `name` comparator determines the order.
+    func test_combineComparators_nameDetermines() {
+        assertSort(
+            [
+                .dummy(id: "1", userId: "A", name: "Zane"),
+                .dummy(id: "2", userId: "B", name: "Aaron")
+            ],
+            comparator: combineComparators([nameComparator, id, userId]),
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    /// Test with multiple comparators where the `id` comparator determines the order because the names are the same.
+    func test_combineComparators_idDetermines() {
+        assertSort(
+            [
+                .dummy(id: "2", userId: "A", name: "Aaron"),
+                .dummy(id: "1", userId: "B", name: "Aaron")
+            ],
+            comparator: combineComparators([nameComparator, id, userId]),
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    /// Test with multiple comparators where the `userId` comparator determines the order because the names and IDs are the same.
+    func test_combineComparators_userIdDetermines() {
+        assertSort(
+            [
+                .dummy(id: "1", userId: "B", name: "Aaron"),
+                .dummy(id: "1", userId: "A", name: "Aaron")
+            ],
+            comparator: combineComparators([nameComparator, id, userId]),
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    /// Test with multiple comparators, all returning .orderedSame because names, IDs, and userIds are identical.
+    func test_combineComparators_allSame() {
+        assertSort(
+            [
+                .dummy(id: "1", userId: "A", name: "Aaron"),
+                .dummy(id: "1", userId: "A", name: "Aaron")
+            ],
+            comparator: combineComparators([nameComparator, id, userId]),
+            expectedTransformer: { [$0[0], $0[1]] }  // Order doesn't matter when all comparators return .orderedSame.
+        )
+    }
+
+    // MARK: - conditional
+
+    /// Test the `name` comparator conditionally based on `id`.
+    func test_conditional_nameBasedOnId() {
+        let condition = conditional { (a: CallParticipant, b: CallParticipant) -> Bool in
+            b.id == "1" && a.id == "2"
+        }
+
+        assertSort(
+            [
+                .dummy(id: "1", name: "Zane"),
+                .dummy(id: "2", name: "Aaron")
+            ],
+            comparator: condition(nameComparator),
+            expectedTransformer: { [$0[1], $0[0]] }  // Aaron should come before Zane based on the condition.
+        )
+    }
+
+    /// Test the `id` comparator conditionally based on `name`.
+    func test_conditional_idBasedOnName() {
+        let condition = conditional { (a: CallParticipant, b: CallParticipant) -> Bool in
+            b.name == "Aaron" && a.name == "Zane"
+        }
+
+        assertSort(
+            [
+                .dummy(id: "2", name: "Aaron"),
+                .dummy(id: "1", name: "Zane")
+            ],
+            comparator: condition(id),
+            expectedTransformer: { [$0[1], $0[0]] }  // ID 1 should come before ID 2 based on the condition.
+        )
+    }
+
+    /// Test the `userId` comparator conditionally based on both `name` and `id`.
+    func test_conditional_userIdBasedOnNameAndId() {
+        let condition = conditional { (a: CallParticipant, b: CallParticipant) -> Bool in
+            b.name == "Aaron" && a.name == "Zane" && b.id == "1" && a.id == "2"
+        }
+
+        assertSort(
+            [
+                .dummy(id: "1", userId: "B", name: "Aaron"),
+                .dummy(id: "2", userId: "A", name: "Zane")
+            ],
+            comparator: condition(userId),
+            expectedTransformer: { [$0[1], $0[0]] }  // UserId A should come before UserId B based on the condition.
+        )
+    }
+
+    // MARK: - noop
+
+    /// Test the `noop` with various `name` values.
+    func test_noop_name() {
+        assertSort(
+            [
+                .dummy(name: "Zane"),
+                .dummy(name: "Aaron")
+            ],
+            comparator: noop(),
+            expectedTransformer: { [$0[0], $0[1]] }  // The order should remain unchanged.
+        )
+    }
+
+    /// Test the `noop` with various `id` values.
+    func test_noop_id() {
+        assertSort(
+            [
+                .dummy(id: "2"),
+                .dummy(id: "1")
+            ],
+            comparator: noop(),
+            expectedTransformer: { [$0[0], $0[1]] }  // The order should remain unchanged.
+        )
+    }
+
+    /// Test the `noop` with mixed properties.
+    func test_noop_mixedProperties() {
+        assertSort(
+            [
+                .dummy(id: "2", userId: "B", name: "Aaron"),
+                .dummy(id: "1", userId: "A", name: "Zane")
+            ],
+            comparator: noop(),
+            expectedTransformer: { [$0[0], $0[1]] }  // The order should remain unchanged.
+        )
+    }
+
+    // MARK: - ifInvisible
+
+    /// Test the `ifInvisible` comparator with one participant invisible based on `name`.
+    func test_ifInvisible_name_oneInvisible() {
+        assertSort(
+            [
+                .dummy(name: "Zane", showTrack: false),
+                .dummy(name: "Aaron", showTrack: true)
+            ],
+            comparator: ifInvisible(nameComparator),
+            expectedTransformer: { [$0[1], $0[0]] }  // Since Zane is invisible, sorting by name is applied.
+        )
+    }
+
+    /// Test the `ifInvisible` comparator with both participants invisible based on `name`.
+    func test_ifInvisible_name_bothInvisible() {
+        assertSort(
+            [
+                .dummy(name: "Zane", showTrack: false),
+                .dummy(name: "Aaron", showTrack: false)
+            ],
+            comparator: ifInvisible(nameComparator),
+            expectedTransformer: { [$0[1], $0[0]] }  // Since both are invisible, sorting by name is applied.
+        )
+    }
+
+    /// Test the `ifInvisible` comparator with both participants visible based on `name`.
+    func test_ifInvisible_name_bothVisible() {
+        assertSort(
+            [
+                .dummy(name: "Zane", showTrack: true),
+                .dummy(name: "Aaron", showTrack: true)
+            ],
+            comparator: ifInvisible(nameComparator),
+            expectedTransformer: { [$0[0], $0[1]] }  // Since both are visible, order remains unchanged.
+        )
+    }
+
+    // MARK: - defaultComparators
+
+    /// Test the `defaultComparators` mixed: considering both `pinned` and `ifInvisible` for `publishingVideo`.
+    func test_defaultComparators_mixed_pinnedAndInvisibleVideo() {
+        let combined = combineComparators(defaultComparators)
+
+        assertSort(
+            [
+                .dummy(hasVideo: false,showTrack: false, pin: PinInfo(isLocal: true, pinnedAt: Date())),
+                .dummy(hasVideo: true, showTrack: false, pin: nil)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[0], $0[1]] }  // Pinned participant should come first even if the other has video, when both are invisible.
+        )
+    }
+
+    /// Test the `defaultComparators` mixed: considering `screensharing`, `dominantSpeaker`, and `ifInvisible` for `isSpeaking`.
+    func test_defaultComparators_mixed_screenshareDominantAndInvisibleSpeaking() {
+        let combined = combineComparators(defaultComparators)
+
+        assertSort(
+            [
+                .dummy(isScreenSharing: true, showTrack: false, isSpeaking: false, isDominantSpeaker: false),
+                .dummy(isScreenSharing: false, showTrack: false, isSpeaking: true, isDominantSpeaker: true)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[0], $0[1]] }  // Participant with screen sharing should come first even if the other is a dominant speaker and is speaking, when both are invisible.
+        )
+    }
+
+    /// Test the `defaultComparators` mixed: considering both `pinned` and `ifInvisible` for `publishingAudio`.
+    func test_defaultComparators_mixed_pinnedAndInvisibleAudio() {
+        let combined = combineComparators(defaultComparators)
+
+        assertSort(
+            [
+                .dummy(hasAudio: true, showTrack: false, pin: nil),
+                .dummy(hasAudio: false, showTrack: false, pin: PinInfo(isLocal: true, pinnedAt: Date()))
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] }  // Pinned participant should come first even if the other has audio, when both are invisible.
+        )
+    }
+
+    /// Test the `defaultComparators` mixed: considering `screensharing`, `dominantSpeaker`, `ifInvisible` for `publishingVideo`, and `ifInvisible` for `publishingAudio`.
+    func test_defaultComparators_mixed_screenshareDominantInvisibleVideoAndAudio() {
+        let combined = combineComparators(defaultComparators)
+
+        assertSort(
+            [
+                .dummy(hasVideo: false, hasAudio: true, isScreenSharing: true, showTrack: false, isDominantSpeaker: false),
+                .dummy(hasVideo: true, hasAudio: false, isScreenSharing: false, showTrack: false, isDominantSpeaker: true)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[0], $0[1]] }  // Participant with screen sharing should come first even if the other is a dominant speaker, has video but no audio, when both are invisible.
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    private func assertSort(
+        _ participants: [CallParticipant],
+        comparator: StreamSortComparator<CallParticipant>,
+        order: StreamSortOrder = .ascending,
+        expectedTransformer: @escaping ([CallParticipant]) -> [CallParticipant],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let expected = expectedTransformer(participants)
+        let actual = participants.sorted(by: comparator, order: order)
+        XCTAssertEqual(actual, expected, file: file, line: line)
+    }
 }
+
+/// This is required as XCTestCase has a `name` property that collides with our `name` comparator
+fileprivate let nameComparator = name

--- a/StreamVideoTests/Utils/Sorting_Tests.swift
+++ b/StreamVideoTests/Utils/Sorting_Tests.swift
@@ -58,6 +58,18 @@ final class Sorting_Tests: XCTestCase {
         )
     }
 
+    /// Test with pinned participants having different pinnedAt dates.
+    func test_pinned_localAndRemote() {
+        assertSort(
+            [
+                .dummy(pin: PinInfo(isLocal: false, pinnedAt: Date(timeIntervalSince1970: 0))),
+                .dummy(pin: PinInfo(isLocal: true, pinnedAt: Date(timeIntervalSince1970: 0)))
+            ],
+            comparator: pinned,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
     // MARK: - screenSharing
 
     /// Test with all participants screen sharing.
@@ -587,44 +599,6 @@ final class Sorting_Tests: XCTestCase {
             ],
             comparator: condition(userId),
             expectedTransformer: { [$0[1], $0[0]] }  // UserId A should come before UserId B based on the condition.
-        )
-    }
-
-    // MARK: - noop
-
-    /// Test the `noop` with various `name` values.
-    func test_noop_name() {
-        assertSort(
-            [
-                .dummy(name: "Zane"),
-                .dummy(name: "Aaron")
-            ],
-            comparator: noop(),
-            expectedTransformer: { [$0[0], $0[1]] }  // The order should remain unchanged.
-        )
-    }
-
-    /// Test the `noop` with various `id` values.
-    func test_noop_id() {
-        assertSort(
-            [
-                .dummy(id: "2"),
-                .dummy(id: "1")
-            ],
-            comparator: noop(),
-            expectedTransformer: { [$0[0], $0[1]] }  // The order should remain unchanged.
-        )
-    }
-
-    /// Test the `noop` with mixed properties.
-    func test_noop_mixedProperties() {
-        assertSort(
-            [
-                .dummy(id: "2", userId: "B", name: "Aaron"),
-                .dummy(id: "1", userId: "A", name: "Zane")
-            ],
-            comparator: noop(),
-            expectedTransformer: { [$0[0], $0[1]] }  // The order should remain unchanged.
         )
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/582

### 🎯 Goal

Avoid moving video tracks when user properties change, especially when that user is currently visible.

### 📝 Summary

Based on React implementation [here](https://github.com/GetStream/stream-video-js/blob/main/packages/client/src/sorting/presets.ts)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)
