### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -51,10 +51,10 @@ jobs:
           #   os: macos-13
           #   device: "iPhone 14 Pro Max"
           #   setup_runtime: false
-          - ios: 16.4
-            xcode: 14.3.1
+          - ios: 16.2
+            xcode: 14.2
             os: macos-13
-            device: "iPhone 14 Pro Max"
+            device: "iPhone 11 Pro"
             setup_runtime: false
           - ios: 15.4
             xcode: 14.2

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -53,7 +53,7 @@ jobs:
           #   setup_runtime: false
           - ios: 16.2
             xcode: 14.2
-            os: macos-13
+            os: macos-12
             device: "iPhone 11 Pro"
             setup_runtime: false
           - ios: 15.4

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -204,7 +204,7 @@ jobs:
 
   test-e2e-debug:
     name: Test E2E UI (Debug)
-    runs-on: macos-13
+    runs-on: macos-12
     if: ${{ github.event_name != 'push' && github.event.inputs.swiftui_snapshots != 'true' && github.event.inputs.uikit_snapshots != 'true' }}
     needs:
       - allure_testops_launch
@@ -239,8 +239,8 @@ jobs:
         STREAM_SDK_TEST_ACCOUNT_PASSWORD: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_PASSWORD }}
         STREAM_SDK_TEST_ACCOUNT_OTP_SECRET: ${{ secrets.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET }}
         STREAM_VIDEO_SECRET: ${{ secrets.STREAM_VIDEO_SECRET }}
-        IOS_SIMULATOR_DEVICE: "iPhone 14 Pro (16.4)" # TODO: delete this line as soon as Xcode 15 is stable on CI
-        XCODE_VERSION: "14.3.1" # TODO: delete this line as soon as Xcode 15 is stable on CI
+        IOS_SIMULATOR_DEVICE: "iPhone 11 (16.2)" # TODO: delete this line as soon as Xcode 15 is stable on CI
+        XCODE_VERSION: "14.2" # TODO: delete this line as soon as Xcode 15 is stable on CI
     - name: Allure TestOps Upload
       if: env.LAUNCH_ID != '' && (success() || failure())
       run: bundle exec fastlane allure_upload launch_id:$LAUNCH_ID

--- a/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
@@ -227,7 +227,7 @@ extension UserRobot {
     
     @discardableResult
     func assertParticipantsAreVisible(count: Int) -> Self {
-        XCTAssertEqual(count, CallPage.participantView.waitCount(count, timeout: UserRobot.defaultTimeout).count)
+        XCTAssertEqual(count, CallPage.participantView.waitCount(count, timeout: UserRobot.defaultTimeout, exact: true).count)
         return self
     }
     

--- a/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/DeeplinkTests.swift
@@ -21,7 +21,7 @@ final class DeeplinkTests: StreamTestCase {
     }
 
     private enum MockDeeplink {
-        static let production: URL = .init(string: "https://getstream.io/video/demos?id=test-call")!
+        static let deeplinkUrl: URL = .init(string: "\(Sinatra().baseUrl)/deeplink?id=test-call")!
         static let customScheme: URL = .init(string: "streamvideo://video/demos?id=test-call")!
     }
 
@@ -44,8 +44,8 @@ final class DeeplinkTests: StreamTestCase {
         
         WHEN("user navigates to the app through deeplink") {
             Safari()
-                .open(MockDeeplink.production)
-                .alertHandler()
+                .open(MockDeeplink.deeplinkUrl)
+                .tapOnDeeplinkButton()
                 .tapOnOpenButton()
         }
         THEN("user joins the the specified call") {

--- a/TestTools/Robots/Sinatra.swift
+++ b/TestTools/Robots/Sinatra.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public class Sinatra {
-    private let baseUrl = "http://localhost:4567"
+    let baseUrl = "http://localhost:4567"
     
     enum ConnectionState: String {
         case on

--- a/TestTools/UITests/Safari.swift
+++ b/TestTools/UITests/Safari.swift
@@ -11,6 +11,7 @@ struct Safari {
 
     init() {}
 
+    @discardableResult
     private func go(to url: URL) -> Self {
         safari.textFields["Address"].tap()
         safari.typeText(url.absoluteString)
@@ -26,18 +27,19 @@ struct Safari {
     func open(_ url: URL) -> Self {
         safari.launch()
         _ = safari.wait(for: .runningForeground, timeout: 5)
+        
         if #available(iOS 16.4, *) {
             safari.open(url)
-            return self
         } else {
-            // Type the deeplink and execute it
             let firstLaunchContinueButton = safari.buttons["Continue"]
             if firstLaunchContinueButton.exists {
                 firstLaunchContinueButton.tap()
             }
-
-            return go(to: url)
+            // Type the deeplink and execute it
+            go(to: url)
         }
+        
+        return self
     }
     
     @discardableResult
@@ -46,20 +48,23 @@ struct Safari {
         if safari.alerts.count > 0 {
             while safari.alerts.count > 0 {
                 safari.alerts.buttons["Allow"].safeTap()
+                sleep(UInt32(0.5))
             }
         }
         return self
     }
+    
+    @discardableResult
+    func tapOnDeeplinkButton(_ timeout: Double = 5) -> Self {
+        safari.buttons["Open deeplink"].wait(timeout: timeout).tap()
+        return self
+    }
 
     @discardableResult
-    func tapOnOpenButton(_ timeout: TimeInterval = 5) -> Self {
-        safari
-            .buttons
-            .matching(NSPredicate(format: "label LIKE 'OPEN' OR label LIKE 'Open'"))
-            .firstMatch
-            .wait(timeout: timeout)
-            .tap()
-
+    func tapOnOpenButton(_ timeout: Double = 5) -> Self {
+//        safari.buttons.matching(NSPredicate(format: "label LIKE 'Open'")).firstMatch.wait(timeout: timeout).safeTap()
+        
+        safari.buttons["Open"].wait(timeout: timeout).tap()
         return self
     }
 }

--- a/fastlane/sinatra.rb
+++ b/fastlane/sinatra.rb
@@ -13,6 +13,21 @@ post '/connection/:state' do
   end
 end
 
+get '/deeplink' do
+  deeplink = "streamvideo://getstream.io/video/demos/?id=#{params['id']}"
+
+  <<-HTML
+    <!DOCTYPE html>
+    <html>
+      <body style="text-align: center;">
+        <div style="margin-top: 50%;">
+          <button style="font-size: 50px; padding: 20px 40px;" onclick="window.location.href = '#{deeplink}'">Open deeplink</button>
+        </div>
+      </body>
+    </html>
+  HTML
+end
+
 post '/record_video/:udid/:test_name' do
   recordings_dir = 'recordings'
   video_base_name = "#{recordings_dir}/#{params['test_name']}"


### PR DESCRIPTION
Downgrading the macos version from 13 to 12 seems to improve a lot the stability and speed. For now, let's run it there and take another look at tests' performance after Xcode 15.1 is available on CI.