### PR TITLE
Implemented fast reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add support for pre-built XCFrameworks
+- Fast reconnection
 
 ### 🔄 Changed
 - You can now focus on a desired point in the local video stream. [#221](https://github.com/GetStream/stream-video-swift/pull/221)

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 
 ### 0.5.0 milestone
 
+- [x] Tap to focus
+- [x] Complete reconnection flows
 - [ ] Video UIKit tutorial
 - [ ] Improve logging / Sentry integration
 - [ ] Camera controls
-- [x] Tap to focus
-- [ ] Complete reconnection flows
 - [ ] Complete Livestreaming APIs and Tutorials for hosting & watching
 - [ ] Dynascale 2.0
 - [ ] Buttons to simulate ice-restart and SFU switching

--- a/Sources/StreamVideo/WebRTC/PeerConnection.swift
+++ b/Sources/StreamVideo/WebRTC/PeerConnection.swift
@@ -32,6 +32,10 @@ class PeerConnection: NSObject, RTCPeerConnectionDelegate, @unchecked Sendable {
     var onStreamRemoved: ((RTCMediaStream) -> Void)?
 
     var paused = false
+    
+    var connectionState: RTCPeerConnectionState {
+        pc.connectionState
+    }
 
     init(
         sessionId: String,
@@ -166,6 +170,10 @@ class PeerConnection: NSObject, RTCPeerConnectionDelegate, @unchecked Sendable {
             return
         }
         try await add(candidate: iceCandidate)
+    }
+    
+    func restartIce() {
+        pc.restartIce()
     }
 
     func close() {

--- a/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
+++ b/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
@@ -14,7 +14,7 @@ class SfuMiddleware: EventMiddleware {
     var signalService: Stream_Video_Sfu_Signal_SignalServer
     private var subscriber: PeerConnection?
     private var publisher: PeerConnection?
-    var onSocketConnected: (() -> Void)?
+    var onSocketConnected: ((Bool) -> Void)?
     var onParticipantCountUpdated: ((UInt32) -> ())?
     var onSessionMigrationEvent: (() -> Void)?
     var onPinsChanged: (([Stream_Video_Sfu_Models_Pin]) -> ())?
@@ -71,7 +71,7 @@ class SfuMiddleware: EventMiddleware {
             case .dominantSpeakerChanged(let event):
                 await handleDominantSpeakerChanged(event)
             case .joinResponse(let event):
-                onSocketConnected?()
+                onSocketConnected?(event.reconnected)
                 await loadParticipants(from: event)
             case .healthCheckResponse(let event):
                 onParticipantCountUpdated?(event.participantCount.total)


### PR DESCRIPTION
### 🎯 Goal

Implement fast reconnect on iOS. Fast reconnect means you try to re-join without leaving the call. Other users will notice a brief freeze of you.

Check the spec on notion for more details.

### 🛠 Implementation

Mostly updated the WebRTC client.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

It's a bit tricky to test, and the success of fast reconnect depends on many factors.

However, what's important is - even if fast reconnect fails, there's a full reconnect as a fallback.

Testing steps:
- join a call on WiFi
- quickly switch to 5g / other Wifi
- you should reconnect to the call without leaving the call

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

![ALT_TEXT](https://media.giphy.com/media/QvGCMeHuP1vLYl2hLb/giphy.gif?cid=ecf05e4799wjh60bc7r3tffjpk79532do55d09pcc130i1y7&ep=v1_gifs_search&rid=giphy.gif&ct=g)
