### PR TITLE
[Fix]VideoRenderers being added in multiple superviews

### DIFF
--- a/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
+++ b/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
@@ -238,17 +238,23 @@ class SfuMiddleware: EventMiddleware {
         guard let participant = await state.callParticipants[userId] else { return }
         if event.type == .audio {
             let updated = participant.withUpdated(audio: false)
+            if event.cause != .userMuted {
+                await state.removeAudioTrack(id: userId)
+            }
             await state.update(callParticipant: updated)
-            await state.removeAudioTrack(id: userId)
         } else if event.type == .video {
             let updated = participant.withUpdated(video: false)
-            await state.removeTrack(id: updated.trackLookupPrefix ?? updated.id)
+            if event.cause != .userMuted {
+                await state.removeTrack(id: updated.trackLookupPrefix ?? updated.id)
+            }
             await state.update(callParticipant: updated)
         } else if event.type == .screenShare {
             let updated = participant
                 .withUpdated(screensharing: false)
                 .withUpdated(screensharingTrack: nil)
-            await state.removeScreensharingTrack(id: updated.trackLookupPrefix ?? updated.id)
+            if event.cause != .userMuted {
+                await state.removeScreensharingTrack(id: updated.trackLookupPrefix ?? updated.id)
+            }
             await state.update(callParticipant: updated)
         }
     }

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -483,7 +483,10 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     }
     
     func updateTrackSize(_ trackSize: CGSize, for participant: CallParticipant) async {
-        guard let participant = await state.callParticipants[participant.id] else {
+        guard
+            let participant = await state.callParticipants[participant.id],
+            participant.trackSize != trackSize
+        else {
             return
         }
         let updated = participant.withUpdated(trackSize: trackSize)

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/HorizontalParticipantsListView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/HorizontalParticipantsListView.swift
@@ -98,8 +98,7 @@ public struct HorizontalParticipantsListView<Factory: ViewFactory>: View {
                     )
                     // Observe visibility changes.
                     .visibilityObservation(
-                        in: barFrame,
-                        hasVideo: participant.hasVideo
+                        in: barFrame
                     ) { isVisible in
                         Task {
                             await call?.changeTrackVisibility(

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/SpotlightSpeakerView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/SpotlightSpeakerView.swift
@@ -84,8 +84,7 @@ public struct SpotlightSpeakerView<Factory: ViewFactory>: View {
         )
         // Observes visibility changes of the dominant speaker's video track.
         .visibilityObservation(
-            in: availableFrame,
-            hasVideo: participant.hasVideo
+            in: availableFrame
         ) { isVisible in
             Task {
                 await call?.changeTrackVisibility(

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridView.swift
@@ -94,7 +94,7 @@ struct ParticipantsGridView<Factory: ViewFactory>: View {
                     showAllInfo: true
                 )
             )
-            .visibilityObservation(in: bounds, hasVideo: participant.hasVideo) {
+            .visibilityObservation(in: bounds) {
                 log.debug("Participant \(participant.name) is \($0 ? "visible" : "not visible.")")
                 participantVisibilityChanged(participant, $0)
             }

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -350,6 +350,7 @@ public struct VideoCallParticipantView: View {
             id: id,
             size: availableFrame.size,
             contentMode: contentMode,
+            showVideo: showVideo,
             handleRendering: { [weak call] view in
                 guard call != nil else { return }
                 view.handleViewRendering(for: participant) { size, participant in

--- a/Sources/StreamVideoSwiftUI/CallView/VisibilityThresholdModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VisibilityThresholdModifier.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// "on screen".
 ///
 /// When the visibility state of the view changes (i.e., it transitions between being "on screen" and "off screen"),
-/// a callback is triggered to notify the user of this change. This can be particularly useful in scenarios where 
+/// a callback is triggered to notify the user of this change. This can be particularly useful in scenarios where
 /// resource management is crucial, such as video playback or dynamic content loading, where actions might
 /// be triggered based on whether a view is currently visible to the user.
 ///
@@ -72,10 +72,10 @@ struct VisibilityThresholdModifier: ViewModifier {
 
         /// Check if the content view is vertically within the parent's bounds.
         let verticalVisible = (minY + requiredHeight <= bounds.maxY && minY >= bounds.minY) ||
-                              (maxY - requiredHeight >= bounds.minY && maxY <= bounds.maxY)
+        (maxY - requiredHeight >= bounds.minY && maxY <= bounds.maxY)
         /// Check if the content view is horizontally within the parent's bounds.
         let horizontalVisible = (minX + requiredWidth <= bounds.maxX && minX >= bounds.minX) ||
-                                (maxX - requiredWidth >= bounds.minX && maxX <= bounds.maxX)
+        (maxX - requiredWidth >= bounds.minX && maxX <= bounds.maxX)
 
         return (verticalVisible, horizontalVisible)
     }
@@ -85,31 +85,26 @@ extension View {
     /// Attaches a visibility observation modifier to the view.
     ///
     /// - Parameters:
-    ///   - bounds: The bounds of the parent view or viewport within which the visibility of the view will 
+    ///   - bounds: The bounds of the parent view or viewport within which the visibility of the view will
     ///   be tracked.
     ///   - threshold: A percentage value (defaulted to 0.3 or 30%) representing how much of the view
     ///   should be visible within the `bounds` before it's considered "on screen".
-    ///   - changeHandler: A closure that gets triggered with a Boolean value indicating the visibility 
+    ///   - changeHandler: A closure that gets triggered with a Boolean value indicating the visibility
     ///   state of the view whenever it changes.
     ///
     /// - Returns: A modified view that observes its visibility status within the specified bounds.
     @ViewBuilder
     func visibilityObservation(
         in bounds: CGRect,
-        hasVideo: Bool,
         threshold: CGFloat = 0.3,
         changeHandler: @escaping (Bool) -> Void
     ) -> some View {
-        if hasVideo {
-            modifier(
-                VisibilityThresholdModifier(
-                    in: bounds,
-                    threshold: threshold,
-                    changeHandler: changeHandler
-                )
+        modifier(
+            VisibilityThresholdModifier(
+                in: bounds,
+                threshold: threshold,
+                changeHandler: changeHandler
             )
-        } else {
-            self
-        }
+        )
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Ensure that video tracks are always visible.

### 📝 Summary

There are a two underline issues resulting in this bug:
- When a user stops publishing video (that is translated as track muted for BE) we remove the track from our array and then we stop receiving events about it whenever the user decides to re-enable their camera.
- The visibility observation was being added on the view ONLY when the participant had video. When the user reenables their video the view doesn't fire the geometry calculation causing the view to not trigger the track visibility change.
- For local track we rely on 2 input signals to disable the track a) we disable locally the track we have a reference to, b) we send a mute request to the SFU which replies with an event that updates the participant to `hasVideo:false`. Due to this we have multiple instances of VideoRendererView trying to use the cached VideoRenderer. 

### 🛠 Implementation

- We now remove the unpublished track only in the case where the reason is different that `muted`
- We apply the visibility modifier on all renderer views regardless of the user's publishing video.
- We now have an optimisation in the VideoRendererView, where if the participant doesn't need to `showVideo` we render a dummy VideoRenderer and not trying to use the cached value.

### 🧪 Manual Testing Notes

- Enter a call from web and iOS (with more than 6 participants).
- Try all layouts and verify they work.
- Start sharing from web and ensure that the local track is visible in all layouts.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)