### PR TITLE
[Fix]When Nuke fails render failback

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
@@ -37,7 +37,12 @@ struct CallParticipantImage: View {
     var body: some View {
         ZStack {
             if #available(iOS 14.0, *), let imageURL = imageURL {
-                UserAvatar(imageURL: imageURL, size: size)
+                UserAvatar(imageURL: imageURL, size: size) {
+                    CircledTitleView(
+                        title: name.isEmpty ? id : String(name.uppercased().first!),
+                        size: size
+                    )
+                }
             } else {
                 CircledTitleView(
                     title: name.isEmpty ? id : String(name.uppercased().first!),

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
@@ -51,10 +51,12 @@ struct CallParticipantBackground<Background: View>: View {
     var body: some View {
         ZStack {
             if #available(iOS 14.0, *), let imageURL = imageURL {
-                StreamLazyImage(imageURL: imageURL)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .blur(radius: 8)
-                    .clipped()
+                StreamLazyImage(imageURL: imageURL) {
+                    fallbackBackground()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .blur(radius: 8)
+                .clipped()
             } else {
                 fallbackBackground()
             }

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -314,7 +314,12 @@ struct ParticipantsInCallView: View {
                 ForEach(participantsInCall) { participant in
                     VStack {
                         if let imageURL = participant.user.imageURL {
-                            UserAvatar(imageURL: imageURL, size: 40)
+                            UserAvatar(imageURL: imageURL, size: 40) {
+                                CircledTitleView(
+                                    title: participant.user.name.isEmpty ? participant.user.id : String(participant.user.name.uppercased().first!),
+                                    size: 40
+                                )
+                            }
                         } else {
                             CircledTitleView(
                                 title: participant.user.name.isEmpty ? participant.user.id : String(participant.user.name.uppercased().first!),

--- a/Sources/StreamVideoSwiftUI/Utils/UserAvatar.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/UserAvatar.swift
@@ -5,19 +5,31 @@
 import SwiftUI
 
 @available(iOS 14.0, *)
-public struct UserAvatar: View {
-    
+public struct UserAvatar<Failback: View>: View {
+
+    public typealias FailbackProvider = () -> Failback
+
     public var imageURL: URL?
     public var size: CGFloat
-    
-    public init(imageURL: URL?, size: CGFloat) {
+    public var failbackProvider: FailbackProvider?
+
+    public init(imageURL: URL?, size: CGFloat, failbackProvider: FailbackProvider?) {
         self.imageURL = imageURL
         self.size = size
+        self.failbackProvider = failbackProvider
     }
     
     public var body: some View {
-        StreamLazyImage(imageURL: imageURL)
+        StreamLazyImage(imageURL: imageURL, failback: failbackProvider)
             .frame(width: size, height: size)
             .clipShape(Circle())
+    }
+}
+
+@available(iOS 14.0, *)
+extension UserAvatar where Failback == EmptyView {
+
+    public init(imageURL: URL?, size: CGFloat) {
+        self.init(imageURL: imageURL, size: size, failbackProvider: nil)
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Provide a failback View to render when Nuke fails to fetch or decode the image.

### 📝 Summary

Due to a recent change on BE now all users contain default imageURL. Unfortunately this URL points to an SVG image which Nuke fails to render. This PR adds a way to provide a failback View to render whenever Nuke fails.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)