### PR TITLE
Fixed call types tutorial links

### DIFF
--- a/docusaurus/docs/iOS/03-guides/05-call-types.mdx
+++ b/docusaurus/docs/iOS/03-guides/05-call-types.mdx
@@ -1,8 +1,20 @@
 ---
+id: configuring-call-types
 title: Call Types
-description: How Call Types control features and permissions
 ---
 
-import CallTypesPage from '../../../shared/video/_call-types.md';
+import CallTypesPage from '../../../shared/video/_call-types.mdx';
+import WithExternalLinks from '../../../shared/video/_withExternalLinks';
 
 <CallTypesPage />
+
+<WithExternalLinks
+  mapping={{
+    '/tutorials/video-calling/':
+      'https://getstream.io/video/sdk/ios/tutorial/video-calling/',
+    '/tutorials/audio-room/':
+      'https://getstream.io/video/sdk/ios/tutorial/audio-room/',
+    '/tutorials/livestream/':
+      'https://getstream.io/video/sdk/ios/tutorial/livestreaming/',
+  }}
+/>


### PR DESCRIPTION
### 🎯 Goal

Fix broken links in the call types shared page.

### 🧪 Manual Testing Notes

- Update docusaurus cli to latest `production`
- Run `npx stream-chat-docusaurus -i -s` 
- Open the three tutorial links

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
