### PR TITLE
[Fix]Ensuring background task expiration

### DIFF
--- a/Sources/StreamVideo/WebSockets/Client/BackgroundTaskScheduler.swift
+++ b/Sources/StreamVideo/WebSockets/Client/BackgroundTaskScheduler.swift
@@ -67,6 +67,7 @@ class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
             self?.backgroundTaskExpirationCancellable = nil
         }
 
+        // Cancel any existing task before starting a new one.
         backgroundTaskExpirationCancellable?.cancel()
 
         activeBackgroundTask = app?.beginBackgroundTask(
@@ -77,8 +78,11 @@ class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
             return false
         }
 
+        // Set a timer for 30 seconds(which is the max the OS will give us anyway)
+        // to stop our task if we end up not getting the call from OS. In that
+        // way we avoid getting killed by the OS.
         backgroundTaskExpirationCancellable = Foundation.Timer
-            .publish(every: 25, on: .main, in: .default)
+            .publish(every: 30, on: .main, in: .default)
             .autoconnect()
             .sink { _ in expirationHandler() }
 


### PR DESCRIPTION
### 📝 Summary

It seems that even though we provide an expiration handler, the system still warns us that we have have long running tasks and we may get killed. This PR adds a time control to stop any background task just before the OS's timeout.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)