### PR TITLE
Fix memory leaks on Utils and UserState

### DIFF
--- a/DemoApp/Sources/Components/Router.swift
+++ b/DemoApp/Sources/Components/Router.swift
@@ -196,7 +196,8 @@ final class Router: ObservableObject {
         appState.userState = .loggedIn
 
         appState.streamVideo = streamVideo
-        let utils = Utils(userListProvider: appState)
+        var utils = UtilsKey.currentValue
+        utils.userListProvider = appState
         streamVideoUI = StreamVideoUI(streamVideo: streamVideo, utils: utils)
 
         appState.connectUser()

--- a/DemoApp/Sources/DemoApp.swift
+++ b/DemoApp/Sources/DemoApp.swift
@@ -15,14 +15,13 @@ struct DemoApp: App {
 
     // MARK: - State properties
 
-    @StateObject var appState: AppState
+    @State private var userState: UserState = .notLoggedIn
     private let router: Router
 
     // MARK: - Lifecycle
 
     init() {
         let router = Router.shared
-        self._appState = .init(wrappedValue: router.appState)
         self.router = router
 
         LogConfig.level = .debug
@@ -32,9 +31,9 @@ struct DemoApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                if appState.userState == .loggedIn {
+                if userState == .loggedIn {
                     NavigationView {
-                        DemoCallContainerView(callId: appState.deeplinkInfo.callId)
+                        DemoCallContainerView(callId: router.appState.deeplinkInfo.callId)
                             .navigationBarHidden(true)
                     }
                     .navigationViewStyle(.stack)
@@ -53,6 +52,7 @@ struct DemoApp: App {
                     }
                 }
             }
+            .onReceive(router.appState.$userState) { self.userState = $0 }
             .preferredColorScheme(.dark)
             .onOpenURL { router.handle(url: $0) }
             .onContinueUserActivity(

--- a/Sources/StreamVideoSwiftUI/StreamVideoUI.swift
+++ b/Sources/StreamVideoSwiftUI/StreamVideoUI.swift
@@ -26,7 +26,7 @@ public class StreamVideoUI {
         videoConfig: VideoConfig = VideoConfig(),
         tokenProvider: @escaping UserTokenProvider,
         appearance: Appearance = Appearance(),
-        utils: Utils = Utils()
+        utils: Utils = UtilsKey.currentValue
     ) {
         let streamVideo = StreamVideo(
             apiKey: apiKey,
@@ -51,7 +51,7 @@ public class StreamVideoUI {
     public init(
         streamVideo: StreamVideo,
         appearance: Appearance = Appearance(),
-        utils: Utils = Utils()
+        utils: Utils = UtilsKey.currentValue
     ) {
         self.streamVideo = streamVideo
         self.appearance = appearance

--- a/Sources/StreamVideoSwiftUI/Utils.swift
+++ b/Sources/StreamVideoSwiftUI/Utils.swift
@@ -23,7 +23,7 @@ public extension Utils {
 
 /// Provides the default value of the `Utils` class.
 public struct UtilsKey: InjectionKey {
-    public static var currentValue: Utils = Utils()
+    public static var currentValue: Utils = .default
 }
 
 extension InjectedValues {


### PR DESCRIPTION
### 📝 Summary

- UserState: By having the AppState as a StateObject on the DemoApp we were causing rerenders on the View everytime the AppState was changing, causing cases where we had more than one CallViewModel instances available.

- Utils: The way we were instatiating and injecting the values was resulting in more than one instances to be available during runtime. That's causing issues like the missing tracks as there are different videoRendererFactories that being involved during the call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)