### PR TITLE
[Fix]Only reuse VideoRenderers when they are actually presented

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -327,6 +327,8 @@ public struct VideoCallParticipantView: View {
     var customData: [String: RawJSON]
     var call: Call?
     
+    @State private var isVisible = false
+
     public init(
         participant: CallParticipant,
         id: String? = nil,
@@ -350,7 +352,7 @@ public struct VideoCallParticipantView: View {
             id: id,
             size: availableFrame.size,
             contentMode: contentMode,
-            showVideo: showVideo,
+            showVideo: showVideo && isVisible,
             handleRendering: { [weak call] view in
                 guard call != nil else { return }
                 view.handleViewRendering(for: participant) { size, participant in
@@ -360,6 +362,8 @@ public struct VideoCallParticipantView: View {
                 }
             }
         )
+        .onAppear { isVisible = true }
+        .onDisappear { isVisible = false }
         .opacity(showVideo ? 1 : 0)
         .edgesIgnoringSafeArea(edgesIgnoringSafeArea)
         .accessibility(identifier: "callParticipantView")


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)