### PR TITLE
Remove next assertion

### DIFF
--- a/StreamVideoTests/IntegrationTests/CallCRUDTests.swift
+++ b/StreamVideoTests/IntegrationTests/CallCRUDTests.swift
@@ -252,13 +252,12 @@ final class CallCRUDTest: IntegrationTest {
         let call = client.call(callType: defaultCallType, callId: randomCallId)
         try await call.create(memberIds: [user1])
         
-        let (calls, next) = try await client.queryCalls(
+        let (calls, _) = try await client.queryCalls(
             filters: [CallSortField.cid.rawValue: .string(call.cId)],
             watch: true
         )
         XCTAssertEqual(1, calls.count)
         XCTAssertEqual(call.cId, calls[0].cId)
-        XCTAssertEqual(nil, next)
         
         // changes to a watched call via query call should propagate as usual to the state
         let updateResponse = try await call.update(custom: [colorKey: blue])


### PR DESCRIPTION
## This test was failing
![image](https://github.com/GetStream/stream-video-swift/assets/20794991/013abc3f-a8f1-46b4-9e45-0cb5692a8019)

Following the cursor, we were also getting data that didn't make much sense, with the existing callId at the top:

```
25 elements
  - 0 : "A6F90889-653C-4B23-9438-96CC942FF141"
  - 1 : "C86AEEDB-9ADD-4108-B02D-6310C85696E4"
  - 2 : "2B3B4A9A-22AA-4D7F-A97A-29F056937F89"
  - 3 : "B2F70597-7A46-41E5-A225-E8C6CD775BD8"
  - 4 : "602a6dbf-689b-4b82-bc01-0afc1d6015ce"
  - 5 : "call73172a71-433e-42c9-a0bb-22360637ec21"
  - 6 : "call4a0d66af-7c7d-452b-81a5-c6ee74fb6335"
  - 7 : "a8c0f21f-fbd7-49ef-9efc-4597d31c0e6f"
  - 8 : "call41ef65cd-1cf4-4ec0-ae90-0853e8cae7f9"
  - 9 : "call89423f2b-3577-4203-a34c-9411ff33418d"
  - 10 : "e2e-test-a75a5ccaaae29"
  - 11 : "e2e-test-9f8b46fda5625"
  - 12 : "e2e-test-3b6e861506bb4"
  - 13 : "e2e-test-ddbc158b2f1f1"
  - 14 : "e2e-test-25595ef6f4d6d"
  - 15 : "e2e-test-5cabd18441ebd"
  - 16 : "2AD9FF28-6854-44E2-999C-21F360670666"
  - 17 : "1234asdf"
  - 18 : "58c5b6e5-1432-4d95-99aa-158ca3c2e166"
  - 19 : "call40293979-da7a-4742-bd1e-3ccb663cdff8"
  - 20 : "call50d752d7-81dd-4745-8406-f53b3ebf31b1"
  - 21 : "A5F5AA93-C925-48C7-86BE-18806984E75C"
  - 22 : "e2e-test-4155123393ee3"
  - 23 : "csb-3adaa168dd3d"
  - 24 : "361BEFE0-9E83-4908-8137-0D462EDDC70D"
```