### PR TITLE
Disable pause/unpause of track with app's lifecycle

### DIFF
--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -1197,18 +1197,28 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     }
     
     private func subscribeToAppLifecycleChanges() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(pauseTracks),
-            name: UIScene.didEnterBackgroundNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(unpauseTracks),
-            name: UIScene.willEnterForegroundNotification,
-            object: nil
-        )
+        let isiOSAppOnIpad = {
+            if #available(iOS 14.0, *) {
+                return ProcessInfo.processInfo.isiOSAppOnMac
+            } else {
+                return false
+            }
+        }()
+
+        if !isiOSAppOnIpad {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(pauseTracks),
+                name: UIScene.didEnterBackgroundNotification,
+                object: nil
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(unpauseTracks),
+                name: UIScene.willEnterForegroundNotification,
+                object: nil
+            )
+        }
     }
     
     private func subscribeToInternetConnectionUpdates() {


### PR DESCRIPTION
### 🎯 Goal

Disable track pause/unpause when the the macOS window loses focus, but can still be visible.

### 🧪 Manual Testing Notes

Run the macOS app, get on a call with others and open another window's app. The video tracks in the app should remain active.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)