### PR TITLE
Testable documentation

### DIFF
--- a/DemoApp/Sources/Components/Services/VoIPPushService.swift
+++ b/DemoApp/Sources/Components/Services/VoIPPushService.swift
@@ -6,7 +6,7 @@ import Foundation
 import PushKit
 import StreamVideo
 
-public typealias VoIPPushHandler = ((PKPushPayload, PKPushType, () -> Void)) -> ()
+typealias VoIPPushHandler = ((PKPushPayload, PKPushType, () -> Void)) -> ()
 
 final class VoIPPushService: NSObject, PKPushRegistryDelegate {
 

--- a/DemoApp/Sources/Components/Services/VoIPPushService.swift
+++ b/DemoApp/Sources/Components/Services/VoIPPushService.swift
@@ -6,7 +6,7 @@ import Foundation
 import PushKit
 import StreamVideo
 
-typealias VoIPPushHandler = ((PKPushPayload, PKPushType, () -> Void)) -> ()
+public typealias VoIPPushHandler = ((PKPushPayload, PKPushType, () -> Void)) -> ()
 
 final class VoIPPushService: NSObject, PKPushRegistryDelegate {
 

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		400D91B62B63D88100EBA47D /* DocumentationTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 400D91B52B63D88100EBA47D /* DocumentationTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		400D91C32B63D95200EBA47D /* StreamVideo in Frameworks */ = {isa = PBXBuildFile; productRef = 400D91C22B63D95200EBA47D /* StreamVideo */; };
-		400D91C52B63D95200EBA47D /* StreamVideoSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 400D91C42B63D95200EBA47D /* StreamVideoSwiftUI */; };
 		400D91C72B63D96800EBA47D /* 03-quickstart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91C62B63D96800EBA47D /* 03-quickstart.swift */; };
 		400D91C92B63DB3700EBA47D /* 01-client-auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91C82B63DB3700EBA47D /* 01-client-auth.swift */; };
 		400D91CB2B63DB5F00EBA47D /* GloballyUsedVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91CA2B63DB5F00EBA47D /* GloballyUsedVariables.swift */; };
@@ -18,6 +16,57 @@
 		400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */; };
 		400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */; };
 		400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */; };
+		40FFDC372B63E400004DA7A2 /* 08-permissions-and-moderation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */; };
+		40FFDC392B63E459004DA7A2 /* 09-reactions-and-custom-events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC382B63E459004DA7A2 /* 09-reactions-and-custom-events.swift */; };
+		40FFDC3B2B63E493004DA7A2 /* 10-view-slots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC3A2B63E493004DA7A2 /* 10-view-slots.swift */; };
+		40FFDC3D2B63E6EC004DA7A2 /* 11-call-lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC3C2B63E6EC004DA7A2 /* 11-call-lifecycle.swift */; };
+		40FFDC3F2B63E734004DA7A2 /* 12-call-state.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC3E2B63E734004DA7A2 /* 12-call-state.swift */; };
+		40FFDC442B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC432B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift */; };
+		40FFDC462B63EA54004DA7A2 /* 15-migration-from-dolby.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC452B63EA54004DA7A2 /* 15-migration-from-dolby.swift */; };
+		40FFDC492B63EB92004DA7A2 /* 01-call-container.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC482B63EB92004DA7A2 /* 01-call-container.swift */; };
+		40FFDC4B2B63EC3D004DA7A2 /* 02-outgoing-call.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC4A2B63EC3D004DA7A2 /* 02-outgoing-call.swift */; };
+		40FFDC4D2B63ED16004DA7A2 /* 03-incoming-call.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC4C2B63ED16004DA7A2 /* 03-incoming-call.swift */; };
+		40FFDC4F2B63EE50004DA7A2 /* 04-active-call.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC4E2B63EE50004DA7A2 /* 04-active-call.swift */; };
+		40FFDC512B63EF58004DA7A2 /* 05-call-controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC502B63EF58004DA7A2 /* 05-call-controls.swift */; };
+		40FFDC532B63EFA2004DA7A2 /* 06-call-app-bar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC522B63EFA2004DA7A2 /* 06-call-app-bar.swift */; };
+		40FFDC552B63EFD3004DA7A2 /* 07-screen-share-content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC542B63EFD3004DA7A2 /* 07-screen-share-content.swift */; };
+		40FFDC5A2B63F08D004DA7A2 /* 01-call-participant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC592B63F08D004DA7A2 /* 01-call-participant.swift */; };
+		40FFDC5C2B63F137004DA7A2 /* 02-call-participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC5B2B63F137004DA7A2 /* 02-call-participants.swift */; };
+		40FFDC5E2B63F236004DA7A2 /* 03-call-participants-info-menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC5D2B63F236004DA7A2 /* 03-call-participants-info-menu.swift */; };
+		40FFDC602B63F2EC004DA7A2 /* 04-local-video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC5F2B63F2EC004DA7A2 /* 04-local-video.swift */; };
+		40FFDC632B63F370004DA7A2 /* 02-sound-indicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC622B63F370004DA7A2 /* 02-sound-indicator.swift */; };
+		40FFDC652B63F395004DA7A2 /* 03-avatars.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC642B63F395004DA7A2 /* 03-avatars.swift */; };
+		40FFDC672B63F430004DA7A2 /* 04-connection-quality-indicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC662B63F430004DA7A2 /* 04-connection-quality-indicator.swift */; };
+		40FFDC692B63F474004DA7A2 /* 05-call-background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC682B63F474004DA7A2 /* 05-call-background.swift */; };
+		40FFDC6B2B63F4AB004DA7A2 /* 02-video-renderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC6A2B63F4AB004DA7A2 /* 02-video-renderer.swift */; };
+		40FFDC6D2B63F556004DA7A2 /* 03-video-theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC6C2B63F556004DA7A2 /* 03-video-theme.swift */; };
+		40FFDC6F2B63F58B004DA7A2 /* 04-customizing-views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC6E2B63F58B004DA7A2 /* 04-customizing-views.swift */; };
+		40FFDC712B63F5C1004DA7A2 /* 05-uikit-customizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC702B63F5C1004DA7A2 /* 05-uikit-customizations.swift */; };
+		40FFDC742B63F767004DA7A2 /* StreamChatSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC732B63F767004DA7A2 /* StreamChatSwiftUI */; };
+		40FFDC762B63F7D6004DA7A2 /* ChatGloballyUsedVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC752B63F7D6004DA7A2 /* ChatGloballyUsedVariables.swift */; };
+		40FFDC782B63FA2E004DA7A2 /* 06-view-model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC772B63FA2E004DA7A2 /* 06-view-model.swift */; };
+		40FFDC7A2B63FA96004DA7A2 /* 02-replacing-call-controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC792B63FA96004DA7A2 /* 02-replacing-call-controls.swift */; };
+		40FFDC7C2B63FB76004DA7A2 /* 03-custom-label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC7B2B63FB76004DA7A2 /* 03-custom-label.swift */; };
+		40FFDC7E2B63FC10004DA7A2 /* 04-video-layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC7D2B63FC10004DA7A2 /* 04-video-layout.swift */; };
+		40FFDC812B63FD92004DA7A2 /* StreamVideo in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC802B63FD92004DA7A2 /* StreamVideo */; };
+		40FFDC832B63FD92004DA7A2 /* StreamVideoSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC822B63FD92004DA7A2 /* StreamVideoSwiftUI */; };
+		40FFDC852B63FD92004DA7A2 /* StreamVideoUIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC842B63FD92004DA7A2 /* StreamVideoUIKit */; };
+		40FFDC872B63FEAE004DA7A2 /* 05-incoming-call.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC862B63FEAE004DA7A2 /* 05-incoming-call.swift */; };
+		40FFDC8A2B63FEFD004DA7A2 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC892B63FEFD004DA7A2 /* Nuke */; };
+		40FFDC8C2B63FEFD004DA7A2 /* NukeExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC8B2B63FEFD004DA7A2 /* NukeExtensions */; };
+		40FFDC8E2B63FEFD004DA7A2 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC8D2B63FEFD004DA7A2 /* NukeUI */; };
+		40FFDC902B63FEFD004DA7A2 /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = 40FFDC8F2B63FEFD004DA7A2 /* NukeVideo */; };
+		40FFDC922B63FF70004DA7A2 /* 06-lobby-preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC912B63FF70004DA7A2 /* 06-lobby-preview.swift */; };
+		40FFDC942B6401CC004DA7A2 /* 07-video-fallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC932B6401CC004DA7A2 /* 07-video-fallback.swift */; };
+		40FFDC962B64023A004DA7A2 /* 08-permission-requests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC952B64023A004DA7A2 /* 08-permission-requests.swift */; };
+		40FFDC982B640566004DA7A2 /* 09-audio-volume-indicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC972B640566004DA7A2 /* 09-audio-volume-indicator.swift */; };
+		40FFDC9A2B6405C7004DA7A2 /* 10-network-quality-indicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC992B6405C7004DA7A2 /* 10-network-quality-indicator.swift */; };
+		40FFDC9C2B6405EA004DA7A2 /* 11-speaking-while-muted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC9B2B6405EA004DA7A2 /* 11-speaking-while-muted.swift */; };
+		40FFDC9E2B64063D004DA7A2 /* 12-connection-unstable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC9D2B64063D004DA7A2 /* 12-connection-unstable.swift */; };
+		40FFDCA02B640676004DA7A2 /* 13-pinning-users.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC9F2B640676004DA7A2 /* 13-pinning-users.swift */; };
+		40FFDCA22B640741004DA7A2 /* 14-livestream-player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDCA12B640741004DA7A2 /* 14-livestream-player.swift */; };
+		40FFDCA42B640772004DA7A2 /* 15-long-press-to-focus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDCA32B640772004DA7A2 /* 15-long-press-to-focus.swift */; };
+		40FFDCA62B6408DE004DA7A2 /* 00-ringing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDCA52B6408DE004DA7A2 /* 00-ringing.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +80,50 @@
 		400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-camera-and-microphone.swift"; sourceTree = "<group>"; };
 		400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-querying-calls.swift"; sourceTree = "<group>"; };
 		400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "07-dependency-injection.swift"; sourceTree = "<group>"; };
+		40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "08-permissions-and-moderation.swift"; sourceTree = "<group>"; };
+		40FFDC382B63E459004DA7A2 /* 09-reactions-and-custom-events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "09-reactions-and-custom-events.swift"; sourceTree = "<group>"; };
+		40FFDC3A2B63E493004DA7A2 /* 10-view-slots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "10-view-slots.swift"; sourceTree = "<group>"; };
+		40FFDC3C2B63E6EC004DA7A2 /* 11-call-lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "11-call-lifecycle.swift"; sourceTree = "<group>"; };
+		40FFDC3E2B63E734004DA7A2 /* 12-call-state.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "12-call-state.swift"; sourceTree = "<group>"; };
+		40FFDC432B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "14-swiftui-vs-uikit.swift"; sourceTree = "<group>"; };
+		40FFDC452B63EA54004DA7A2 /* 15-migration-from-dolby.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "15-migration-from-dolby.swift"; sourceTree = "<group>"; };
+		40FFDC482B63EB92004DA7A2 /* 01-call-container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-call-container.swift"; sourceTree = "<group>"; };
+		40FFDC4A2B63EC3D004DA7A2 /* 02-outgoing-call.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-outgoing-call.swift"; sourceTree = "<group>"; };
+		40FFDC4C2B63ED16004DA7A2 /* 03-incoming-call.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-incoming-call.swift"; sourceTree = "<group>"; };
+		40FFDC4E2B63EE50004DA7A2 /* 04-active-call.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-active-call.swift"; sourceTree = "<group>"; };
+		40FFDC502B63EF58004DA7A2 /* 05-call-controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "05-call-controls.swift"; sourceTree = "<group>"; };
+		40FFDC522B63EFA2004DA7A2 /* 06-call-app-bar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-call-app-bar.swift"; sourceTree = "<group>"; };
+		40FFDC542B63EFD3004DA7A2 /* 07-screen-share-content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "07-screen-share-content.swift"; sourceTree = "<group>"; };
+		40FFDC592B63F08D004DA7A2 /* 01-call-participant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-call-participant.swift"; sourceTree = "<group>"; };
+		40FFDC5B2B63F137004DA7A2 /* 02-call-participants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-call-participants.swift"; sourceTree = "<group>"; };
+		40FFDC5D2B63F236004DA7A2 /* 03-call-participants-info-menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-call-participants-info-menu.swift"; sourceTree = "<group>"; };
+		40FFDC5F2B63F2EC004DA7A2 /* 04-local-video.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-local-video.swift"; sourceTree = "<group>"; };
+		40FFDC622B63F370004DA7A2 /* 02-sound-indicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-sound-indicator.swift"; sourceTree = "<group>"; };
+		40FFDC642B63F395004DA7A2 /* 03-avatars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-avatars.swift"; sourceTree = "<group>"; };
+		40FFDC662B63F430004DA7A2 /* 04-connection-quality-indicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-connection-quality-indicator.swift"; sourceTree = "<group>"; };
+		40FFDC682B63F474004DA7A2 /* 05-call-background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "05-call-background.swift"; sourceTree = "<group>"; };
+		40FFDC6A2B63F4AB004DA7A2 /* 02-video-renderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-video-renderer.swift"; sourceTree = "<group>"; };
+		40FFDC6C2B63F556004DA7A2 /* 03-video-theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-video-theme.swift"; sourceTree = "<group>"; };
+		40FFDC6E2B63F58B004DA7A2 /* 04-customizing-views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-customizing-views.swift"; sourceTree = "<group>"; };
+		40FFDC702B63F5C1004DA7A2 /* 05-uikit-customizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "05-uikit-customizations.swift"; sourceTree = "<group>"; };
+		40FFDC752B63F7D6004DA7A2 /* ChatGloballyUsedVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGloballyUsedVariables.swift; sourceTree = "<group>"; };
+		40FFDC772B63FA2E004DA7A2 /* 06-view-model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-view-model.swift"; sourceTree = "<group>"; };
+		40FFDC792B63FA96004DA7A2 /* 02-replacing-call-controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-replacing-call-controls.swift"; sourceTree = "<group>"; };
+		40FFDC7B2B63FB76004DA7A2 /* 03-custom-label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-custom-label.swift"; sourceTree = "<group>"; };
+		40FFDC7D2B63FC10004DA7A2 /* 04-video-layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-video-layout.swift"; sourceTree = "<group>"; };
+		40FFDC7F2B63FD7A004DA7A2 /* stream-video-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "stream-video-swift"; path = ../..; sourceTree = "<group>"; };
+		40FFDC862B63FEAE004DA7A2 /* 05-incoming-call.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "05-incoming-call.swift"; sourceTree = "<group>"; };
+		40FFDC912B63FF70004DA7A2 /* 06-lobby-preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-lobby-preview.swift"; sourceTree = "<group>"; };
+		40FFDC932B6401CC004DA7A2 /* 07-video-fallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "07-video-fallback.swift"; sourceTree = "<group>"; };
+		40FFDC952B64023A004DA7A2 /* 08-permission-requests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "08-permission-requests.swift"; sourceTree = "<group>"; };
+		40FFDC972B640566004DA7A2 /* 09-audio-volume-indicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "09-audio-volume-indicator.swift"; sourceTree = "<group>"; };
+		40FFDC992B6405C7004DA7A2 /* 10-network-quality-indicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "10-network-quality-indicator.swift"; sourceTree = "<group>"; };
+		40FFDC9B2B6405EA004DA7A2 /* 11-speaking-while-muted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "11-speaking-while-muted.swift"; sourceTree = "<group>"; };
+		40FFDC9D2B64063D004DA7A2 /* 12-connection-unstable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "12-connection-unstable.swift"; sourceTree = "<group>"; };
+		40FFDC9F2B640676004DA7A2 /* 13-pinning-users.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "13-pinning-users.swift"; sourceTree = "<group>"; };
+		40FFDCA12B640741004DA7A2 /* 14-livestream-player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "14-livestream-player.swift"; sourceTree = "<group>"; };
+		40FFDCA32B640772004DA7A2 /* 15-long-press-to-focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "15-long-press-to-focus.swift"; sourceTree = "<group>"; };
+		40FFDCA52B6408DE004DA7A2 /* 00-ringing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "00-ringing.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -38,8 +131,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				400D91C52B63D95200EBA47D /* StreamVideoSwiftUI in Frameworks */,
-				400D91C32B63D95200EBA47D /* StreamVideo in Frameworks */,
+				40FFDC832B63FD92004DA7A2 /* StreamVideoSwiftUI in Frameworks */,
+				40FFDC8E2B63FEFD004DA7A2 /* NukeUI in Frameworks */,
+				40FFDC852B63FD92004DA7A2 /* StreamVideoUIKit in Frameworks */,
+				40FFDC902B63FEFD004DA7A2 /* NukeVideo in Frameworks */,
+				40FFDC812B63FD92004DA7A2 /* StreamVideo in Frameworks */,
+				40FFDC742B63F767004DA7A2 /* StreamChatSwiftUI in Frameworks */,
+				40FFDC8A2B63FEFD004DA7A2 /* Nuke in Frameworks */,
+				40FFDC8C2B63FEFD004DA7A2 /* NukeExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -49,8 +148,10 @@
 		400D91A82B63D88100EBA47D = {
 			isa = PBXGroup;
 			children = (
+				40FFDC7F2B63FD7A004DA7A2 /* stream-video-swift */,
 				400D91B42B63D88100EBA47D /* DocumentationTests */,
 				400D91B32B63D88100EBA47D /* Products */,
+				40FFDC402B63E8A9004DA7A2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -72,6 +173,7 @@
 				400D91C02B63D8FB00EBA47D /* 06-advanced */,
 				400D91B52B63D88100EBA47D /* DocumentationTests.h */,
 				400D91CA2B63DB5F00EBA47D /* GloballyUsedVariables.swift */,
+				40FFDC752B63F7D6004DA7A2 /* ChatGloballyUsedVariables.swift */,
 			);
 			path = DocumentationTests;
 			sourceTree = "<group>";
@@ -93,6 +195,13 @@
 				400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */,
 				400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */,
 				400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */,
+				40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */,
+				40FFDC382B63E459004DA7A2 /* 09-reactions-and-custom-events.swift */,
+				40FFDC3A2B63E493004DA7A2 /* 10-view-slots.swift */,
+				40FFDC3C2B63E6EC004DA7A2 /* 11-call-lifecycle.swift */,
+				40FFDC3E2B63E734004DA7A2 /* 12-call-state.swift */,
+				40FFDC432B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift */,
+				40FFDC452B63EA54004DA7A2 /* 15-migration-from-dolby.swift */,
 			);
 			path = "03-guides";
 			sourceTree = "<group>";
@@ -100,6 +209,14 @@
 		400D91BE2B63D8EB00EBA47D /* 04-ui-components */ = {
 			isa = PBXGroup;
 			children = (
+				40FFDC612B63F363004DA7A2 /* 09-utility */,
+				40FFDC582B63F085004DA7A2 /* 08-participants */,
+				40FFDC472B63EB89004DA7A2 /* 07-call */,
+				40FFDC6A2B63F4AB004DA7A2 /* 02-video-renderer.swift */,
+				40FFDC6C2B63F556004DA7A2 /* 03-video-theme.swift */,
+				40FFDC6E2B63F58B004DA7A2 /* 04-customizing-views.swift */,
+				40FFDC702B63F5C1004DA7A2 /* 05-uikit-customizations.swift */,
+				40FFDC772B63FA2E004DA7A2 /* 06-view-model.swift */,
 			);
 			path = "04-ui-components";
 			sourceTree = "<group>";
@@ -107,6 +224,20 @@
 		400D91BF2B63D8F200EBA47D /* 05-ui-cookbook */ = {
 			isa = PBXGroup;
 			children = (
+				40FFDC792B63FA96004DA7A2 /* 02-replacing-call-controls.swift */,
+				40FFDC7B2B63FB76004DA7A2 /* 03-custom-label.swift */,
+				40FFDC7D2B63FC10004DA7A2 /* 04-video-layout.swift */,
+				40FFDC862B63FEAE004DA7A2 /* 05-incoming-call.swift */,
+				40FFDC912B63FF70004DA7A2 /* 06-lobby-preview.swift */,
+				40FFDC932B6401CC004DA7A2 /* 07-video-fallback.swift */,
+				40FFDC952B64023A004DA7A2 /* 08-permission-requests.swift */,
+				40FFDC972B640566004DA7A2 /* 09-audio-volume-indicator.swift */,
+				40FFDC992B6405C7004DA7A2 /* 10-network-quality-indicator.swift */,
+				40FFDC9B2B6405EA004DA7A2 /* 11-speaking-while-muted.swift */,
+				40FFDC9D2B64063D004DA7A2 /* 12-connection-unstable.swift */,
+				40FFDC9F2B640676004DA7A2 /* 13-pinning-users.swift */,
+				40FFDCA12B640741004DA7A2 /* 14-livestream-player.swift */,
+				40FFDCA32B640772004DA7A2 /* 15-long-press-to-focus.swift */,
 			);
 			path = "05-ui-cookbook";
 			sourceTree = "<group>";
@@ -114,8 +245,52 @@
 		400D91C02B63D8FB00EBA47D /* 06-advanced */ = {
 			isa = PBXGroup;
 			children = (
+				40FFDCA52B6408DE004DA7A2 /* 00-ringing.swift */,
 			);
 			path = "06-advanced";
+			sourceTree = "<group>";
+		};
+		40FFDC402B63E8A9004DA7A2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		40FFDC472B63EB89004DA7A2 /* 07-call */ = {
+			isa = PBXGroup;
+			children = (
+				40FFDC482B63EB92004DA7A2 /* 01-call-container.swift */,
+				40FFDC4A2B63EC3D004DA7A2 /* 02-outgoing-call.swift */,
+				40FFDC4C2B63ED16004DA7A2 /* 03-incoming-call.swift */,
+				40FFDC4E2B63EE50004DA7A2 /* 04-active-call.swift */,
+				40FFDC502B63EF58004DA7A2 /* 05-call-controls.swift */,
+				40FFDC522B63EFA2004DA7A2 /* 06-call-app-bar.swift */,
+				40FFDC542B63EFD3004DA7A2 /* 07-screen-share-content.swift */,
+			);
+			path = "07-call";
+			sourceTree = "<group>";
+		};
+		40FFDC582B63F085004DA7A2 /* 08-participants */ = {
+			isa = PBXGroup;
+			children = (
+				40FFDC592B63F08D004DA7A2 /* 01-call-participant.swift */,
+				40FFDC5B2B63F137004DA7A2 /* 02-call-participants.swift */,
+				40FFDC5D2B63F236004DA7A2 /* 03-call-participants-info-menu.swift */,
+				40FFDC5F2B63F2EC004DA7A2 /* 04-local-video.swift */,
+			);
+			path = "08-participants";
+			sourceTree = "<group>";
+		};
+		40FFDC612B63F363004DA7A2 /* 09-utility */ = {
+			isa = PBXGroup;
+			children = (
+				40FFDC622B63F370004DA7A2 /* 02-sound-indicator.swift */,
+				40FFDC642B63F395004DA7A2 /* 03-avatars.swift */,
+				40FFDC662B63F430004DA7A2 /* 04-connection-quality-indicator.swift */,
+				40FFDC682B63F474004DA7A2 /* 05-call-background.swift */,
+			);
+			path = "09-utility";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -147,8 +322,14 @@
 			);
 			name = DocumentationTests;
 			packageProductDependencies = (
-				400D91C22B63D95200EBA47D /* StreamVideo */,
-				400D91C42B63D95200EBA47D /* StreamVideoSwiftUI */,
+				40FFDC732B63F767004DA7A2 /* StreamChatSwiftUI */,
+				40FFDC802B63FD92004DA7A2 /* StreamVideo */,
+				40FFDC822B63FD92004DA7A2 /* StreamVideoSwiftUI */,
+				40FFDC842B63FD92004DA7A2 /* StreamVideoUIKit */,
+				40FFDC892B63FEFD004DA7A2 /* Nuke */,
+				40FFDC8B2B63FEFD004DA7A2 /* NukeExtensions */,
+				40FFDC8D2B63FEFD004DA7A2 /* NukeUI */,
+				40FFDC8F2B63FEFD004DA7A2 /* NukeVideo */,
 			);
 			productName = DocumentationTests;
 			productReference = 400D91B22B63D88100EBA47D /* DocumentationTests.framework */;
@@ -179,7 +360,8 @@
 			);
 			mainGroup = 400D91A82B63D88100EBA47D;
 			packageReferences = (
-				400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */,
+				40FFDC722B63F767004DA7A2 /* XCRemoteSwiftPackageReference "stream-chat-swiftui" */,
+				40FFDC882B63FEFD004DA7A2 /* XCRemoteSwiftPackageReference "Nuke" */,
 			);
 			productRefGroup = 400D91B32B63D88100EBA47D /* Products */;
 			projectDirPath = "";
@@ -205,14 +387,57 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				40FFDC5A2B63F08D004DA7A2 /* 01-call-participant.swift in Sources */,
+				40FFDC9A2B6405C7004DA7A2 /* 10-network-quality-indicator.swift in Sources */,
 				400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */,
+				40FFDC4F2B63EE50004DA7A2 /* 04-active-call.swift in Sources */,
+				40FFDCA02B640676004DA7A2 /* 13-pinning-users.swift in Sources */,
+				40FFDC602B63F2EC004DA7A2 /* 04-local-video.swift in Sources */,
+				40FFDC632B63F370004DA7A2 /* 02-sound-indicator.swift in Sources */,
+				40FFDC5E2B63F236004DA7A2 /* 03-call-participants-info-menu.swift in Sources */,
+				40FFDC3F2B63E734004DA7A2 /* 12-call-state.swift in Sources */,
+				40FFDC712B63F5C1004DA7A2 /* 05-uikit-customizations.swift in Sources */,
+				40FFDC462B63EA54004DA7A2 /* 15-migration-from-dolby.swift in Sources */,
+				40FFDC532B63EFA2004DA7A2 /* 06-call-app-bar.swift in Sources */,
+				40FFDC782B63FA2E004DA7A2 /* 06-view-model.swift in Sources */,
+				40FFDC6F2B63F58B004DA7A2 /* 04-customizing-views.swift in Sources */,
 				400D91CB2B63DB5F00EBA47D /* GloballyUsedVariables.swift in Sources */,
+				40FFDC982B640566004DA7A2 /* 09-audio-volume-indicator.swift in Sources */,
+				40FFDC7E2B63FC10004DA7A2 /* 04-video-layout.swift in Sources */,
+				40FFDC552B63EFD3004DA7A2 /* 07-screen-share-content.swift in Sources */,
+				40FFDC9C2B6405EA004DA7A2 /* 11-speaking-while-muted.swift in Sources */,
+				40FFDC3D2B63E6EC004DA7A2 /* 11-call-lifecycle.swift in Sources */,
 				400D91CD2B63DC2600EBA47D /* 02-joining-creating-calls.swift in Sources */,
 				400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */,
+				40FFDC512B63EF58004DA7A2 /* 05-call-controls.swift in Sources */,
 				400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */,
+				40FFDC922B63FF70004DA7A2 /* 06-lobby-preview.swift in Sources */,
+				40FFDC762B63F7D6004DA7A2 /* ChatGloballyUsedVariables.swift in Sources */,
+				40FFDC672B63F430004DA7A2 /* 04-connection-quality-indicator.swift in Sources */,
+				40FFDC3B2B63E493004DA7A2 /* 10-view-slots.swift in Sources */,
+				40FFDC442B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift in Sources */,
+				40FFDC872B63FEAE004DA7A2 /* 05-incoming-call.swift in Sources */,
+				40FFDC942B6401CC004DA7A2 /* 07-video-fallback.swift in Sources */,
 				400D91C72B63D96800EBA47D /* 03-quickstart.swift in Sources */,
+				40FFDC9E2B64063D004DA7A2 /* 12-connection-unstable.swift in Sources */,
+				40FFDC372B63E400004DA7A2 /* 08-permissions-and-moderation.swift in Sources */,
+				40FFDC4B2B63EC3D004DA7A2 /* 02-outgoing-call.swift in Sources */,
+				40FFDC6D2B63F556004DA7A2 /* 03-video-theme.swift in Sources */,
+				40FFDC492B63EB92004DA7A2 /* 01-call-container.swift in Sources */,
+				40FFDC4D2B63ED16004DA7A2 /* 03-incoming-call.swift in Sources */,
+				40FFDC692B63F474004DA7A2 /* 05-call-background.swift in Sources */,
+				40FFDCA62B6408DE004DA7A2 /* 00-ringing.swift in Sources */,
 				400D91C92B63DB3700EBA47D /* 01-client-auth.swift in Sources */,
+				40FFDC962B64023A004DA7A2 /* 08-permission-requests.swift in Sources */,
 				400D91CF2B63DE0100EBA47D /* 03-call-and-participant-state.swift in Sources */,
+				40FFDC652B63F395004DA7A2 /* 03-avatars.swift in Sources */,
+				40FFDC392B63E459004DA7A2 /* 09-reactions-and-custom-events.swift in Sources */,
+				40FFDC7C2B63FB76004DA7A2 /* 03-custom-label.swift in Sources */,
+				40FFDC5C2B63F137004DA7A2 /* 02-call-participants.swift in Sources */,
+				40FFDC7A2B63FA96004DA7A2 /* 02-replacing-call-controls.swift in Sources */,
+				40FFDC6B2B63F4AB004DA7A2 /* 02-video-renderer.swift in Sources */,
+				40FFDCA22B640741004DA7A2 /* 14-livestream-player.swift in Sources */,
+				40FFDCA42B640772004DA7A2 /* 15-long-press-to-focus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,26 +672,61 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */ = {
+		40FFDC722B63F767004DA7A2 /* XCRemoteSwiftPackageReference "stream-chat-swiftui" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/GetStream/stream-video-swift";
+			repositoryURL = "https://github.com/GetStream/stream-chat-swiftui";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.47.0;
+			};
+		};
+		40FFDC882B63FEFD004DA7A2 /* XCRemoteSwiftPackageReference "Nuke" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Nuke";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		400D91C22B63D95200EBA47D /* StreamVideo */ = {
+		40FFDC732B63F767004DA7A2 /* StreamChatSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */;
+			package = 40FFDC722B63F767004DA7A2 /* XCRemoteSwiftPackageReference "stream-chat-swiftui" */;
+			productName = StreamChatSwiftUI;
+		};
+		40FFDC802B63FD92004DA7A2 /* StreamVideo */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = StreamVideo;
 		};
-		400D91C42B63D95200EBA47D /* StreamVideoSwiftUI */ = {
+		40FFDC822B63FD92004DA7A2 /* StreamVideoSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */;
 			productName = StreamVideoSwiftUI;
+		};
+		40FFDC842B63FD92004DA7A2 /* StreamVideoUIKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = StreamVideoUIKit;
+		};
+		40FFDC892B63FEFD004DA7A2 /* Nuke */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40FFDC882B63FEFD004DA7A2 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = Nuke;
+		};
+		40FFDC8B2B63FEFD004DA7A2 /* NukeExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40FFDC882B63FEFD004DA7A2 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeExtensions;
+		};
+		40FFDC8D2B63FEFD004DA7A2 /* NukeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40FFDC882B63FEFD004DA7A2 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeUI;
+		};
+		40FFDC8F2B63FEFD004DA7A2 /* NukeVideo */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40FFDC882B63FEFD004DA7A2 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeVideo;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */; };
 		400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */; };
 		4068C1252B67C056006B0BEE /* 03-callkit-integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */; };
+		409C39692B67CC5C0090044C /* 04-screensharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C39682B67CC5C0090044C /* 04-screensharing.swift */; };
+		409C396B2B67CD0B0090044C /* 05-picture-in-picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C396A2B67CD0B0090044C /* 05-picture-in-picture.swift */; };
+		409C396D2B67CD780090044C /* 08-recording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C396C2B67CD780090044C /* 08-recording.swift */; };
+		409C396F2B67CDF30090044C /* 09-broadcasting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C396E2B67CDF30090044C /* 09-broadcasting.swift */; };
 		40B468982B67B6DF009B5B3E /* 01-deeplinking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */; };
 		40E23B9B2B67BA4100D11FC1 /* 02-push-notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */; };
 		40FFDC372B63E400004DA7A2 /* 08-permissions-and-moderation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */; };
@@ -84,6 +88,10 @@
 		400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-querying-calls.swift"; sourceTree = "<group>"; };
 		400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "07-dependency-injection.swift"; sourceTree = "<group>"; };
 		4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-callkit-integration.swift"; sourceTree = "<group>"; };
+		409C39682B67CC5C0090044C /* 04-screensharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-screensharing.swift"; sourceTree = "<group>"; };
+		409C396A2B67CD0B0090044C /* 05-picture-in-picture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "05-picture-in-picture.swift"; sourceTree = "<group>"; };
+		409C396C2B67CD780090044C /* 08-recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "08-recording.swift"; sourceTree = "<group>"; };
+		409C396E2B67CDF30090044C /* 09-broadcasting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "09-broadcasting.swift"; sourceTree = "<group>"; };
 		40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-deeplinking.swift"; sourceTree = "<group>"; };
 		40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-push-notifications.swift"; sourceTree = "<group>"; };
 		40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "08-permissions-and-moderation.swift"; sourceTree = "<group>"; };
@@ -255,6 +263,10 @@
 				40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */,
 				40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */,
 				4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */,
+				409C39682B67CC5C0090044C /* 04-screensharing.swift */,
+				409C396A2B67CD0B0090044C /* 05-picture-in-picture.swift */,
+				409C396C2B67CD780090044C /* 08-recording.swift */,
+				409C396E2B67CDF30090044C /* 09-broadcasting.swift */,
 			);
 			path = "06-advanced";
 			sourceTree = "<group>";
@@ -401,6 +413,7 @@
 				400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */,
 				40FFDC4F2B63EE50004DA7A2 /* 04-active-call.swift in Sources */,
 				40FFDCA02B640676004DA7A2 /* 13-pinning-users.swift in Sources */,
+				409C396D2B67CD780090044C /* 08-recording.swift in Sources */,
 				40FFDC602B63F2EC004DA7A2 /* 04-local-video.swift in Sources */,
 				40FFDC632B63F370004DA7A2 /* 02-sound-indicator.swift in Sources */,
 				40FFDC5E2B63F236004DA7A2 /* 03-call-participants-info-menu.swift in Sources */,
@@ -413,6 +426,7 @@
 				400D91CB2B63DB5F00EBA47D /* GloballyUsedVariables.swift in Sources */,
 				40FFDC982B640566004DA7A2 /* 09-audio-volume-indicator.swift in Sources */,
 				40FFDC7E2B63FC10004DA7A2 /* 04-video-layout.swift in Sources */,
+				409C396B2B67CD0B0090044C /* 05-picture-in-picture.swift in Sources */,
 				40FFDC552B63EFD3004DA7A2 /* 07-screen-share-content.swift in Sources */,
 				40FFDC9C2B6405EA004DA7A2 /* 11-speaking-while-muted.swift in Sources */,
 				40FFDC3D2B63E6EC004DA7A2 /* 11-call-lifecycle.swift in Sources */,
@@ -437,6 +451,7 @@
 				40FFDC6D2B63F556004DA7A2 /* 03-video-theme.swift in Sources */,
 				40FFDC492B63EB92004DA7A2 /* 01-call-container.swift in Sources */,
 				40FFDC4D2B63ED16004DA7A2 /* 03-incoming-call.swift in Sources */,
+				409C396F2B67CDF30090044C /* 09-broadcasting.swift in Sources */,
 				40FFDC692B63F474004DA7A2 /* 05-call-background.swift in Sources */,
 				40FFDCA62B6408DE004DA7A2 /* 00-ringing.swift in Sources */,
 				400D91C92B63DB3700EBA47D /* 01-client-auth.swift in Sources */,
@@ -448,6 +463,7 @@
 				40FFDC5C2B63F137004DA7A2 /* 02-call-participants.swift in Sources */,
 				40FFDC7A2B63FA96004DA7A2 /* 02-replacing-call-controls.swift in Sources */,
 				40FFDC6B2B63F4AB004DA7A2 /* 02-video-renderer.swift in Sources */,
+				409C39692B67CC5C0090044C /* 04-screensharing.swift in Sources */,
 				40FFDCA22B640741004DA7A2 /* 14-livestream-player.swift in Sources */,
 				40FFDCA42B640772004DA7A2 /* 15-long-press-to-focus.swift in Sources */,
 			);

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */; };
 		400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */; };
 		400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */; };
+		4068C1252B67C056006B0BEE /* 03-callkit-integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */; };
+		40B468982B67B6DF009B5B3E /* 01-deeplinking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */; };
+		40E23B9B2B67BA4100D11FC1 /* 02-push-notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */; };
 		40FFDC372B63E400004DA7A2 /* 08-permissions-and-moderation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */; };
 		40FFDC392B63E459004DA7A2 /* 09-reactions-and-custom-events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC382B63E459004DA7A2 /* 09-reactions-and-custom-events.swift */; };
 		40FFDC3B2B63E493004DA7A2 /* 10-view-slots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FFDC3A2B63E493004DA7A2 /* 10-view-slots.swift */; };
@@ -80,6 +83,9 @@
 		400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-camera-and-microphone.swift"; sourceTree = "<group>"; };
 		400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-querying-calls.swift"; sourceTree = "<group>"; };
 		400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "07-dependency-injection.swift"; sourceTree = "<group>"; };
+		4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-callkit-integration.swift"; sourceTree = "<group>"; };
+		40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-deeplinking.swift"; sourceTree = "<group>"; };
+		40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-push-notifications.swift"; sourceTree = "<group>"; };
 		40FFDC362B63E400004DA7A2 /* 08-permissions-and-moderation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "08-permissions-and-moderation.swift"; sourceTree = "<group>"; };
 		40FFDC382B63E459004DA7A2 /* 09-reactions-and-custom-events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "09-reactions-and-custom-events.swift"; sourceTree = "<group>"; };
 		40FFDC3A2B63E493004DA7A2 /* 10-view-slots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "10-view-slots.swift"; sourceTree = "<group>"; };
@@ -246,6 +252,9 @@
 			isa = PBXGroup;
 			children = (
 				40FFDCA52B6408DE004DA7A2 /* 00-ringing.swift */,
+				40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */,
+				40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */,
+				4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */,
 			);
 			path = "06-advanced";
 			sourceTree = "<group>";
@@ -408,12 +417,15 @@
 				40FFDC9C2B6405EA004DA7A2 /* 11-speaking-while-muted.swift in Sources */,
 				40FFDC3D2B63E6EC004DA7A2 /* 11-call-lifecycle.swift in Sources */,
 				400D91CD2B63DC2600EBA47D /* 02-joining-creating-calls.swift in Sources */,
+				40E23B9B2B67BA4100D11FC1 /* 02-push-notifications.swift in Sources */,
 				400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */,
 				40FFDC512B63EF58004DA7A2 /* 05-call-controls.swift in Sources */,
 				400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */,
 				40FFDC922B63FF70004DA7A2 /* 06-lobby-preview.swift in Sources */,
+				4068C1252B67C056006B0BEE /* 03-callkit-integration.swift in Sources */,
 				40FFDC762B63F7D6004DA7A2 /* ChatGloballyUsedVariables.swift in Sources */,
 				40FFDC672B63F430004DA7A2 /* 04-connection-quality-indicator.swift in Sources */,
+				40B468982B67B6DF009B5B3E /* 01-deeplinking.swift in Sources */,
 				40FFDC3B2B63E493004DA7A2 /* 10-view-slots.swift in Sources */,
 				40FFDC442B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift in Sources */,
 				40FFDC872B63FEAE004DA7A2 /* 05-incoming-call.swift in Sources */,

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
@@ -1,0 +1,474 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		400D91B62B63D88100EBA47D /* DocumentationTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 400D91B52B63D88100EBA47D /* DocumentationTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		400D91C32B63D95200EBA47D /* StreamVideo in Frameworks */ = {isa = PBXBuildFile; productRef = 400D91C22B63D95200EBA47D /* StreamVideo */; };
+		400D91C52B63D95200EBA47D /* StreamVideoSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 400D91C42B63D95200EBA47D /* StreamVideoSwiftUI */; };
+		400D91C72B63D96800EBA47D /* 03-quickstart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91C62B63D96800EBA47D /* 03-quickstart.swift */; };
+		400D91C92B63DB3700EBA47D /* 01-client-auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91C82B63DB3700EBA47D /* 01-client-auth.swift */; };
+		400D91CB2B63DB5F00EBA47D /* GloballyUsedVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91CA2B63DB5F00EBA47D /* GloballyUsedVariables.swift */; };
+		400D91CD2B63DC2600EBA47D /* 02-joining-creating-calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91CC2B63DC2600EBA47D /* 02-joining-creating-calls.swift */; };
+		400D91CF2B63DE0100EBA47D /* 03-call-and-participant-state.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91CE2B63DE0100EBA47D /* 03-call-and-participant-state.swift */; };
+		400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */; };
+		400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */; };
+		400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		400D91B22B63D88100EBA47D /* DocumentationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DocumentationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		400D91B52B63D88100EBA47D /* DocumentationTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DocumentationTests.h; sourceTree = "<group>"; };
+		400D91C62B63D96800EBA47D /* 03-quickstart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-quickstart.swift"; sourceTree = "<group>"; };
+		400D91C82B63DB3700EBA47D /* 01-client-auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-client-auth.swift"; sourceTree = "<group>"; };
+		400D91CA2B63DB5F00EBA47D /* GloballyUsedVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GloballyUsedVariables.swift; sourceTree = "<group>"; };
+		400D91CC2B63DC2600EBA47D /* 02-joining-creating-calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-joining-creating-calls.swift"; sourceTree = "<group>"; };
+		400D91CE2B63DE0100EBA47D /* 03-call-and-participant-state.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-call-and-participant-state.swift"; sourceTree = "<group>"; };
+		400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-camera-and-microphone.swift"; sourceTree = "<group>"; };
+		400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-querying-calls.swift"; sourceTree = "<group>"; };
+		400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "07-dependency-injection.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		400D91AF2B63D88100EBA47D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				400D91C52B63D95200EBA47D /* StreamVideoSwiftUI in Frameworks */,
+				400D91C32B63D95200EBA47D /* StreamVideo in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		400D91A82B63D88100EBA47D = {
+			isa = PBXGroup;
+			children = (
+				400D91B42B63D88100EBA47D /* DocumentationTests */,
+				400D91B32B63D88100EBA47D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		400D91B32B63D88100EBA47D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				400D91B22B63D88100EBA47D /* DocumentationTests.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		400D91B42B63D88100EBA47D /* DocumentationTests */ = {
+			isa = PBXGroup;
+			children = (
+				400D91BC2B63D8D000EBA47D /* 01-basics */,
+				400D91BD2B63D8DF00EBA47D /* 03-guides */,
+				400D91BE2B63D8EB00EBA47D /* 04-ui-components */,
+				400D91BF2B63D8F200EBA47D /* 05-ui-cookbook */,
+				400D91C02B63D8FB00EBA47D /* 06-advanced */,
+				400D91B52B63D88100EBA47D /* DocumentationTests.h */,
+				400D91CA2B63DB5F00EBA47D /* GloballyUsedVariables.swift */,
+			);
+			path = DocumentationTests;
+			sourceTree = "<group>";
+		};
+		400D91BC2B63D8D000EBA47D /* 01-basics */ = {
+			isa = PBXGroup;
+			children = (
+				400D91C62B63D96800EBA47D /* 03-quickstart.swift */,
+			);
+			path = "01-basics";
+			sourceTree = "<group>";
+		};
+		400D91BD2B63D8DF00EBA47D /* 03-guides */ = {
+			isa = PBXGroup;
+			children = (
+				400D91C82B63DB3700EBA47D /* 01-client-auth.swift */,
+				400D91CC2B63DC2600EBA47D /* 02-joining-creating-calls.swift */,
+				400D91CE2B63DE0100EBA47D /* 03-call-and-participant-state.swift */,
+				400D91D02B63DEA200EBA47D /* 04-camera-and-microphone.swift */,
+				400D91D22B63DFA500EBA47D /* 06-querying-calls.swift */,
+				400D91D42B63E27300EBA47D /* 07-dependency-injection.swift */,
+			);
+			path = "03-guides";
+			sourceTree = "<group>";
+		};
+		400D91BE2B63D8EB00EBA47D /* 04-ui-components */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "04-ui-components";
+			sourceTree = "<group>";
+		};
+		400D91BF2B63D8F200EBA47D /* 05-ui-cookbook */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "05-ui-cookbook";
+			sourceTree = "<group>";
+		};
+		400D91C02B63D8FB00EBA47D /* 06-advanced */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "06-advanced";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		400D91AD2B63D88100EBA47D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				400D91B62B63D88100EBA47D /* DocumentationTests.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		400D91B12B63D88100EBA47D /* DocumentationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 400D91B92B63D88100EBA47D /* Build configuration list for PBXNativeTarget "DocumentationTests" */;
+			buildPhases = (
+				400D91AD2B63D88100EBA47D /* Headers */,
+				400D91AE2B63D88100EBA47D /* Sources */,
+				400D91AF2B63D88100EBA47D /* Frameworks */,
+				400D91B02B63D88100EBA47D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DocumentationTests;
+			packageProductDependencies = (
+				400D91C22B63D95200EBA47D /* StreamVideo */,
+				400D91C42B63D95200EBA47D /* StreamVideoSwiftUI */,
+			);
+			productName = DocumentationTests;
+			productReference = 400D91B22B63D88100EBA47D /* DocumentationTests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		400D91A92B63D88100EBA47D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1520;
+				TargetAttributes = {
+					400D91B12B63D88100EBA47D = {
+						CreatedOnToolsVersion = 15.2;
+						LastSwiftMigration = 1520;
+					};
+				};
+			};
+			buildConfigurationList = 400D91AC2B63D88100EBA47D /* Build configuration list for PBXProject "DocumentationTests" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 400D91A82B63D88100EBA47D;
+			packageReferences = (
+				400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */,
+			);
+			productRefGroup = 400D91B32B63D88100EBA47D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				400D91B12B63D88100EBA47D /* DocumentationTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		400D91B02B63D88100EBA47D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		400D91AE2B63D88100EBA47D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */,
+				400D91CB2B63DB5F00EBA47D /* GloballyUsedVariables.swift in Sources */,
+				400D91CD2B63DC2600EBA47D /* 02-joining-creating-calls.swift in Sources */,
+				400D91D52B63E27300EBA47D /* 07-dependency-injection.swift in Sources */,
+				400D91D32B63DFA500EBA47D /* 06-querying-calls.swift in Sources */,
+				400D91C72B63D96800EBA47D /* 03-quickstart.swift in Sources */,
+				400D91C92B63DB3700EBA47D /* 01-client-auth.swift in Sources */,
+				400D91CF2B63DE0100EBA47D /* 03-call-and-participant-state.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		400D91B72B63D88100EBA47D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		400D91B82B63D88100EBA47D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		400D91BA2B63D88100EBA47D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GCC_WARN_MISSING_PARENTHESES = YES;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNINITIALIZED_AUTOS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.tests.documentation.DocumentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		400D91BB2B63D88100EBA47D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GCC_WARN_MISSING_PARENTHESES = YES;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNINITIALIZED_AUTOS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.tests.documentation.DocumentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		400D91AC2B63D88100EBA47D /* Build configuration list for PBXProject "DocumentationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				400D91B72B63D88100EBA47D /* Debug */,
+				400D91B82B63D88100EBA47D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		400D91B92B63D88100EBA47D /* Build configuration list for PBXNativeTarget "DocumentationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				400D91BA2B63D88100EBA47D /* Debug */,
+				400D91BB2B63D88100EBA47D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/GetStream/stream-video-swift";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		400D91C22B63D95200EBA47D /* StreamVideo */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */;
+			productName = StreamVideo;
+		};
+		400D91C42B63D95200EBA47D /* StreamVideoSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 400D91C12B63D95200EBA47D /* XCRemoteSwiftPackageReference "stream-video-swift" */;
+			productName = StreamVideoSwiftUI;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 400D91A92B63D88100EBA47D /* Project object */;
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/DocumentationTests/DocumentationTests/DocumentationTests/01-basics/03-quickstart.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/01-basics/03-quickstart.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import StreamVideo
+import StreamVideoSwiftUI
+
+fileprivate func content() {
+    container {
+        struct VideoDemoSwiftUIApp: View {
+
+            @State var streamVideo: StreamVideoUI?
+
+            init() {
+                setupStreamVideo(with: "key1", userCredentials: .demoUser)
+            }
+
+            private func setupStreamVideo(
+                with apiKey: String,
+                userCredentials: UserCredentials
+            ) {
+                streamVideo = StreamVideoUI(
+                    apiKey: apiKey,
+                    user: userCredentials.user,
+                    token: userCredentials.token,
+                    tokenProvider: { result in
+                        // Call your networking service to generate a new token here.
+                        // When finished, call the result handler with either .success or .failure.
+                        result(.success(userCredentials.token))
+                    }
+                )
+            }
+
+            var body: some View {
+                NavigationView {
+                    ContentView()
+                }
+            }
+        }
+
+        struct ContentView: View {
+
+            @Injected(\.streamVideo) var streamVideo
+
+            @StateObject var callViewModel = CallViewModel()
+            @State var callId = ""
+
+            var body: some View {
+                VStack {
+                    TextField("Insert a call id", text: $callId)
+                        .textFieldStyle(.roundedBorder)
+                        .padding()
+
+                    Button {
+                        resignFirstResponder()
+                        callViewModel.startCall(
+                            callType: "default",
+                            callId: callId,
+                            members: [/* Your list of participants goes here. */]
+                        )
+                    } label: {
+                        Text("Start a call")
+                    }
+                }
+                .padding()
+                .modifier(CallModifier(viewModel: callViewModel))
+            }
+        }
+
+        struct VideoDemoSwiftUIApp2: View {
+
+            @State var streamVideo: StreamVideoUI?
+
+            init() {
+                setupStreamVideo(with: "key1", userCredentials: .demoUser)
+            }
+
+            private func setupStreamVideo(
+                with apiKey: String,
+                userCredentials: UserCredentials
+            ) {
+                let images = Images()
+                images.hangup = Image(systemName: "phone.down")
+                let appearance = Appearance(images: images)
+                streamVideo = StreamVideoUI(
+                    apiKey: apiKey,
+                    user: userCredentials.user,
+                    token: userCredentials.token,
+                    tokenProvider: { result in
+                        // Call your networking service to generate a new token here.
+                        // When finished, call the result handler with either .success or .failure.
+                        result(.success(userCredentials.token))
+                    },
+                    appearance: appearance
+                )
+            }
+
+            var body: some View {
+                NavigationView {
+                    ContentView()
+                }
+            }
+        }
+
+        class CustomViewFactory: ViewFactory {
+
+            func makeOutgoingCallView(viewModel: CallViewModel) -> some View {
+                // Here you can also provide your own custom view.
+                // In this example, we are re-using the standard one, while also adding an overlay.
+                let view = DefaultViewFactory.shared.makeOutgoingCallView(viewModel: viewModel)
+                return view.overlay(
+                    Text("Custom text overlay")
+                )
+            }
+        }
+
+        struct ContentViewWithCustomViewFactory: View {
+
+            @StateObject var callViewModel = CallViewModel()
+            @State var callId = ""
+
+            var body: some View {
+                VStack {
+                    TextField("Insert a call id", text: $callId)
+                        .textFieldStyle(.roundedBorder)
+                        .padding()
+
+                    Button {
+                        resignFirstResponder()
+                        callViewModel.startCall(
+                            callType: "default",
+                            callId: callId,
+                            members: [/* Your list of participants goes here. */]
+                        )
+                    } label: {
+                        Text("Start a call")
+                    }
+                }
+                .padding()
+                .modifier(CallModifier(viewFactory: CustomViewFactory(), viewModel: callViewModel))
+            }
+        }
+
+    }
+
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/01-client-auth.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/01-client-auth.swift
@@ -1,0 +1,39 @@
+import StreamVideo
+
+fileprivate enum First {
+    static let streamVideo = StreamVideo(
+        apiKey: apiKey,
+        user: user,
+        token: token,
+        tokenProvider: { _ in }
+    )
+}
+
+fileprivate enum Second {
+    static let streamVideo = StreamVideo(
+        apiKey: apiKey,
+        user: .guest("guest"),
+        token: token,
+        tokenProvider: { _ in }
+    )
+}
+
+fileprivate enum Third {
+    static let streamVideo = StreamVideo(
+        apiKey: apiKey,
+        user: .anonymous,
+        token: token,
+        tokenProvider: { _ in }
+    )
+}
+
+fileprivate enum Fourth {
+    static let streamVideo = StreamVideo(
+        apiKey: apiKey,
+        user: user,
+        token: token,
+        videoConfig: VideoConfig(),
+        pushNotificationsConfig: .default,
+        tokenProvider: { _ in }
+    )
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/02-joining-creating-calls.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/02-joining-creating-calls.swift
@@ -1,0 +1,49 @@
+import StreamVideo
+
+fileprivate func content() {
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: "123")
+        let result = try await call.create()
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: "123")
+        let result = try await call.join()
+    }
+
+    asyncContainer {
+        // create
+        let call = streamVideo.call(callType: "default", callId: "123")
+        let result = try await call.create()
+
+        // update
+        let custom: [String: RawJSON] = ["secret": .string("secret")]
+        let updateResult = try await call.update(custom: custom)
+
+        // get
+        let getResult = try await call.get()
+    }
+
+    asyncContainer {
+        let members = ["thierry", "tommaso"]
+        let call = streamVideo.call(callType: "default", callId: UUID().uuidString)
+
+        let result = try await call.create(
+            memberIds: members,
+            custom: ["color": .string("red")],
+            startsAt: Calendar.current.date(byAdding: .day, value: 1, to: Date()),
+            team: "stream",
+            ring: true,
+            notify: false
+        )
+    }
+
+    asyncContainer {
+        let filters: [String: RawJSON] = ["user_id": .string("jaewoong")]
+        let response = try await call.queryMembers(
+            filters: filters,
+            sort: [SortParamRequest.descending("created_at")],
+            limit: 5
+        )
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/03-call-and-participant-state.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/03-call-and-participant-state.swift
@@ -1,0 +1,31 @@
+import StreamVideo
+import StreamVideoSwiftUI
+
+@MainActor
+fileprivate func content() {
+    container {
+        let clientState = streamVideo.state
+        let callState = call.state
+        let participants = call.state.participants
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: "mycall")
+        let joinResult = try await call.join(create: true)
+        // state is now available at
+        let state = call.state
+    }
+
+    container {
+        let cancellable = call.state.$participants.sink { participants in
+            // ..
+        }
+
+        // you
+        let localParticipant: CallParticipant? = call.state.localParticipant
+    }
+
+    container {
+        let state = streamVideo.state
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/04-camera-and-microphone.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/04-camera-and-microphone.swift
@@ -1,0 +1,28 @@
+import StreamVideo
+import StreamVideoSwiftUI
+
+@MainActor
+fileprivate func content() {
+    container {
+        let call = streamVideo.call(callType: "default", callId: "123")
+        let camera = call.camera
+        let microphone = call.microphone
+        let speaker = call.speaker
+    }
+
+    asyncContainer {
+        try await call.camera.enable() // enable the camera
+        try await call.camera.disable() // disable the camera
+        try await call.camera.flip() // switch between front and back camera
+    }
+
+    container {
+        call.camera.direction // front/back
+        call.camera.status // enabled/ disabled.
+    }
+
+    asyncContainer {
+        try await call.microphone.enable() // enable the microphone
+        try await call.microphone.disable() // disable the microphone
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/06-querying-calls.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/06-querying-calls.swift
@@ -1,0 +1,101 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        let filters: [String: RawJSON] = ["ended_at": .nil]
+        let sort = [SortParamRequest.descending("created_at")]
+        let limit = 10
+
+        // Fetch the first page of calls
+        let (firstPageCalls, secondPageCursor) = try await streamVideo.queryCalls(
+            filters: filters,
+            sort: sort,
+            limit: limit
+        )
+
+        // Use the cursor we received from the previous call to fetch the second page
+        let (secondPageCalls, _) = try await streamVideo.queryCalls(next: secondPageCursor)
+    }
+
+    container {
+        var callsController: CallsController = {
+            let sortParam = CallSortParam(direction: .descending, field: .createdAt)
+            let filters: [String: RawJSON] = ["type": .dictionary(["$eq": .string("audio_room")])]
+            let callsQuery = CallsQuery(sortParams: [sortParam], filters: filters, watch: true)
+            return streamVideo.makeCallsController(callsQuery: callsQuery)
+        }()
+    }
+
+    container {
+        let filters: [String: RawJSON] = ["type": .dictionary(["$eq": .string("audio_room")])]
+    }
+
+    container {
+        @MainActor
+        final class CallsViewModel: ObservableObject {
+
+            @Injected(\.streamVideo) internal var streamVideo
+
+            @Published internal var calls = [Call]()
+
+            private var cancellables = Set<AnyCancellable>()
+
+            private lazy var callsController: CallsController = {
+                let sortParam = CallSortParam(direction: .descending, field: .createdAt)
+                let filters: [String: RawJSON] = ["type": .dictionary(["$eq": .string("audio_room")])]
+                let callsQuery = CallsQuery(sortParams: [sortParam], filters: filters, watch: true)
+                return streamVideo.makeCallsController(callsQuery: callsQuery)
+            }()
+
+            init() {
+                subscribeToCallsUpdates()
+                loadCalls()
+            }
+
+            func onCallAppear(_ call: Call) {
+                let index = calls.firstIndex { callData in
+                    callData.cId == call.cId
+                }
+                guard let index else { return }
+
+                if index < calls.count - 10 {
+                    return
+                }
+
+                loadCalls()
+            }
+
+            func loadCalls() {
+                Task {
+                    try await callsController.loadNextCalls()
+                }
+            }
+
+            func subscribeToCallsUpdates() {
+                callsController.$calls.sink { calls in
+                    DispatchQueue.main.async {
+                        self.calls = calls
+                    }
+                }
+                .store(in: &cancellables)
+            }
+        }
+
+        viewContainer {
+            let callsViewModel = CallsViewModel()
+
+            ScrollView {
+                LazyVStack {
+                    ForEach(callsViewModel.calls, id: \.callId) { call in
+                        CallView(viewFactory: viewFactory, viewModel: viewModel)
+                            .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/07-dependency-injection.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/07-dependency-injection.swift
@@ -1,8 +1,20 @@
-//
-//  07-dependency-injection.swift
-//  DocumentationTests
-//
-//  Created by Ilias Pavlidakis on 26/1/24.
-//
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
 
-import Foundation
+@MainActor
+fileprivate func content() {
+    container {
+        @Injected(\.streamVideo) var streamVideo
+        @Injected(\.fonts) var fonts
+        @Injected(\.colors) var colors
+        @Injected(\.images) var images
+        @Injected(\.sounds) var sounds
+        @Injected(\.utils) var utils
+    }
+
+    container {
+        @Injected(\.customType) var customType
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/07-dependency-injection.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/07-dependency-injection.swift
@@ -1,0 +1,8 @@
+//
+//  07-dependency-injection.swift
+//  DocumentationTests
+//
+//  Created by Ilias Pavlidakis on 26/1/24.
+//
+
+import Foundation

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/08-permissions-and-moderation.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/08-permissions-and-moderation.swift
@@ -1,0 +1,52 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        // see if you currently have this permission.
+        let hasPermission = call.currentUserHasCapability(.sendAudio)
+
+        // request the host to grant you this permission.
+        let response = try await call.request(permissions: [.sendAudio])
+    }
+
+    asyncContainer {
+        if let request = call.state.permissionRequests.first {
+            // reject it
+            request.reject()
+
+            // grant it
+            try await call.grant(request: request)
+        }
+    }
+
+    asyncContainer {
+        try await call.grant(permissions: [.sendAudio], for: "thrierry")
+    }
+
+    asyncContainer {
+        let response = try await call.revoke(permissions: [.sendAudio], for: "tommaso")
+    }
+
+    asyncContainer {
+        // block a user
+        try await call.blockUser(with: "tommaso")
+
+        // unblock a user
+        try await call.unblockUser(with: "tommaso")
+
+        // remove a member from a call
+        try await call.removeMembers(ids: ["tommaso"])
+    }
+
+    asyncContainer {
+        // mutes all users (audio and video are true by default) other than yourself
+        try await call.muteAllUsers()
+
+        // mute user with id "tommaso" specifically
+        try await call.mute(userId: "tommaso")
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/09-reactions-and-custom-events.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/09-reactions-and-custom-events.swift
@@ -1,0 +1,23 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        let response = try await call.sendReaction(type: "fireworks")
+    }
+
+    asyncContainer {
+        let response = try await call.sendReaction(
+            type: "raise-hand",
+            custom: ["mycustomfield": "hello"],
+            emojiCode: ":smile:"
+        )
+    }
+
+    asyncContainer {
+        let response = try await call.sendCustomEvent(["type": .string("draw"), "x": .number(10), "y": .number(20)])
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/10-view-slots.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/10-view-slots.swift
@@ -1,0 +1,168 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            struct CustomOutgoingCallView: View {
+                var viewModel: CallViewModel
+                
+                @ViewBuilder
+                var body: some View {
+                    EmptyView()
+                }
+            }
+
+            func makeOutgoingCallView(viewModel: CallViewModel) -> some View {
+                CustomOutgoingCallView(viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            struct CustomIncomingCallView: View {
+                var callInfo: IncomingCall
+                var viewModel: CallViewModel
+
+                @ViewBuilder
+                var body: some View {
+                    EmptyView()
+                }
+            }
+
+            public func makeIncomingCallView(viewModel: CallViewModel, callInfo: IncomingCall) -> some View {
+                CustomIncomingCallView(callInfo: callInfo, viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            struct CustomCallView: View {
+                var viewModel: CallViewModel
+
+                @ViewBuilder
+                var body: some View {
+                    EmptyView()
+                }
+            }
+
+            public func makeCallView(viewModel: CallViewModel) -> some View {
+                CustomCallView(viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            struct CustomCallControlsView: View {
+                var viewModel: CallViewModel
+
+                @ViewBuilder
+                var body: some View {
+                    EmptyView()
+                }
+            }
+
+            func makeCallControlsView(viewModel: CallViewModel) -> some View {
+                CustomCallControlsView(viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoParticipantsView(
+                viewModel: CallViewModel,
+                availableFrame: CGRect,
+                onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
+            ) -> some View {
+                VideoParticipantsView(
+                    viewFactory: self,
+                    viewModel: viewModel,
+                    availableFrame: availableFrame,
+                    onChangeTrackVisibility: onChangeTrackVisibility
+                )
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeVideoParticipantView(
+                participant: CallParticipant,
+                id: String,
+                availableFrame: CGRect,
+                contentMode: UIView.ContentMode,
+                customData: [String: RawJSON],
+                call: Call?
+            ) -> some View {
+                VideoCallParticipantView(
+                    participant: participant,
+                    id: id,
+                    availableFrame: availableFrame,
+                    contentMode: contentMode,
+                    customData: customData, 
+                    call: call
+                )
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoCallParticipantModifier(
+                    participant: CallParticipant,
+                    call: Call?,
+                    availableFrame: CGRect,
+                    ratio: CGFloat,
+                    showAllInfo: Bool
+            ) -> some ViewModifier {
+                VideoCallParticipantModifier(
+                    participant: participant,
+                    call: call,
+                    availableFrame: availableFrame,
+                    ratio: ratio,
+                    showAllInfo: showAllInfo
+                )
+            }
+
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            struct CallTopView: View {
+                var viewModel: CallViewModel
+
+                @ViewBuilder
+                var body: some View {
+                    EmptyView()
+                }
+            }
+
+            public func makeCallTopView(viewModel: CallViewModel) -> some View {
+                CallTopView(viewModel: viewModel)
+            }
+
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/11-call-lifecycle.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/11-call-lifecycle.swift
@@ -1,0 +1,11 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        streamVideo.call(callType: "", callId: "")
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/12-call-state.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/12-call-state.swift
@@ -1,0 +1,81 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import StreamVideoUIKit
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        ZStack {
+                if viewModel.callingState == .outgoing {
+                    viewFactory.makeOutgoingCallView(viewModel: viewModel)
+                } else if viewModel.callingState == .inCall {
+                    if !viewModel.participants.isEmpty {
+                        if viewModel.isMinimized {
+                            MinimizedCallView(viewModel: viewModel)
+                        } else {
+                            viewFactory.makeCallView(viewModel: viewModel)
+                        }
+                    } else {
+                        WaitingLocalUserView(viewModel: viewModel, viewFactory: viewFactory)
+                    }
+                } else if case let .incoming(callInfo) = viewModel.callingState {
+                    viewFactory.makeIncomingCallView(viewModel: viewModel, callInfo: callInfo)
+                }
+            }
+            .onReceive(viewModel.$callingState) { _ in
+                if viewModel.callingState == .idle || viewModel.callingState == .inCall {
+                    utils.callSoundsPlayer.stopOngoingSound()
+                }
+            }
+    }
+
+    container {
+        @MainActor
+        class CallViewHelper {
+
+            static let shared = CallViewHelper()
+
+            private var callView: UIView?
+
+            private init() {}
+
+            func add(callView: UIView) {
+                guard self.callView == nil else { return }
+                guard let window = UIApplication.shared.windows.first else {
+                    return
+                }
+                callView.isOpaque = false
+                callView.backgroundColor = UIColor.clear
+                self.callView = callView
+                window.addSubview(callView)
+            }
+
+            func removeCallView() {
+                callView?.removeFromSuperview()
+                callView = nil
+            }
+        }
+
+        final class CustomObject: UIViewController {
+
+            var callViewModel: CallViewModel { viewModel }
+            var cancellables: Set<AnyCancellable> = []
+
+            @MainActor
+            private func listenToIncomingCalls() {
+                callViewModel.$callingState.sink { [weak self] newState in
+                    guard let self = self else { return }
+                    if case .incoming(_) = newState, self == self.navigationController?.topViewController {
+                        let next = CallViewController.make(with: self.callViewModel)
+                        CallViewHelper.shared.add(callView: next.view)
+                    } else if newState == .idle {
+                        CallViewHelper.shared.removeCallView()
+                    }
+                }
+                .store(in: &cancellables)
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/14-swiftui-vs-uikit.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/14-swiftui-vs-uikit.swift
@@ -17,7 +17,7 @@ fileprivate func content() {
             }
 
             var body: some View {
-                Color.clear // You can use any of your views.
+                HomeView(viewModel: viewModel)
                     .modifier(CallModifier(viewModel: viewModel))
             }
         }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/14-swiftui-vs-uikit.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/14-swiftui-vs-uikit.swift
@@ -1,0 +1,41 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import StreamVideoUIKit
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+
+    container {
+        struct CallView: View {
+
+            @StateObject var viewModel: CallViewModel
+
+            init() {
+                _viewModel = StateObject(wrappedValue: CallViewModel())
+            }
+
+            var body: some View {
+                Color.clear // You can use any of your views.
+                    .modifier(CallModifier(viewModel: viewModel))
+            }
+        }
+    }
+
+    container {
+        @MainActor
+        final class CustomObject: UIViewController {
+            var callViewModel: CallViewModel { viewModel }
+            var selectedParticipants: [MemberRequest] = []
+            var text = ""
+
+            private func didTapStartButton() {
+                let next = CallViewController.make(with: callViewModel)
+                next.modalPresentationStyle = .fullScreen
+                next.startCall(callType: "default", callId: text, members: selectedParticipants)
+                self.navigationController?.present(next, animated: true)
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/15-migration-from-dolby.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/03-guides/15-migration-from-dolby.swift
@@ -1,0 +1,292 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        final class CustomObject {
+            private var client: StreamVideo
+            private let apiKey: String = "" // The API key can be found in the Credentials section
+            private let token: String = "" // The Token can be found in the Credentials section
+            private let userId: String = "" // The User Id can be found in the Credentials section
+            private let callId: String = "" // The CallId can be found in the Credentials section
+
+            init() {
+                let user = User(
+                   id: userId,
+                   name: "Obi-Wan Kenobi", // name and imageURL are used in the UI
+                   imageURL: .init(string: "https://picsum.photos/120")
+                )
+
+                // Initialize Stream Video client
+                self.client = StreamVideo(
+                    apiKey: apiKey,
+                    user: user,
+                    token: .init(stringLiteral: token)
+                )
+            }
+        }
+    }
+
+    container {
+        final class CustomObject {
+            var client: StreamVideo { streamVideo }
+            var call: Call?
+
+            init() {
+                self.call = client.call(callType: "audio_room", callId: callId)
+            }
+        }
+    }
+
+    asyncContainer {
+        try await call.join(
+            create: true,
+            options: .init(
+                members: [
+                    .init(userId: "john_smith"),
+                    .init(userId: "jane_doe"),
+                ],
+                custom: [
+                    "title": .string("SwiftUI heads"),
+                    "description": .string("Talking about SwiftUI")
+                ]
+            )
+        )
+    }
+
+    asyncContainer {
+        let response = try await call.request(permissions: [.sendAudio])
+    }
+
+    asyncContainer {
+        if let request = call.state.permissionRequests.first {
+            // reject it
+            request.reject()
+
+            // grant it
+            try await call.grant(request: request)
+        }
+    }
+
+    container {
+        struct AudioroomsApp: App {
+            @State var call: Call
+            @ObservedObject var state: CallState
+            @State private var callCreated: Bool = false
+
+            private var client: StreamVideo
+            private let apiKey: String = "" // The API key can be found in the Credentials section
+            private let userId: String = "" // The User Id can be found in the Credentials section
+            private let token: String = "" // The Token can be found in the Credentials section
+            private let callId: String = "" // The CallId can be found in the Credentials section
+
+            init() {
+                let user = User(
+                    id: userId,
+                    name: "Obi-Wan Kenobi", // name and imageURL are used in the UI
+                    imageURL: .init(string: "https://picsum.photos/120")
+                )
+
+                // Initialize Stream Video client
+                self.client = StreamVideo(
+                    apiKey: apiKey,
+                    user: user,
+                    token: .init(stringLiteral: token)
+                )
+
+                // Initialize the call object
+                let call = client.call(callType: "audio_room", callId: callId)
+
+                self.call = call
+                self.state = call.state
+            }
+
+            var body: some Scene {
+                WindowGroup {
+                    VStack {
+                        if callCreated {
+                            DescriptionView(
+                                title: call.state.custom["title"]?.stringValue,
+                                description: call.state.custom["description"]?.stringValue,
+                                participants: call.state.participants
+                            )
+                            ParticipantsView(
+                                participants: call.state.participants
+                            )
+                            Spacer()
+                            ControlsView(call: call, state: state)
+                        } else {
+                            Text("loading...")
+                        }
+                    }.task {
+                        Task {
+                            guard !callCreated else { return }
+                            try await call.join(
+                                create: true,
+                                options: .init(
+                                    members: [
+                                        .init(userId: "john_smith"),
+                                        .init(userId: "jane_doe"),
+                                    ],
+                                    custom: [
+                                        "title": .string("SwiftUI heads"),
+                                        "description": .string("talking about SwiftUI")
+                                    ]
+                                )
+                            )
+                            callCreated = true
+                        }
+                    }
+                }
+            }
+        }
+
+        struct ControlsView: View {
+            var call: Call
+            @ObservedObject var state: CallState
+
+            var body: some View {
+                HStack {
+                    MicButtonView(microphone: call.microphone)
+                    LiveButtonView(call: call, state: state)
+                }
+            }
+        }
+
+        struct DescriptionView: View {
+            var title: String?
+            var description: String?
+            var participants: [CallParticipant]
+
+            var body: some View {
+                VStack {
+                    VStack {
+                        Text("\(title ?? "")")
+                          .font(.title)
+                          .frame(maxWidth: .infinity, alignment: .leading)
+                          .lineLimit(1)
+                          .padding([.bottom], 8)
+
+                        Text("\(description ?? "")")
+                          .font(.body)
+                          .frame(maxWidth: .infinity, alignment: .leading)
+                          .lineLimit(1)
+                          .padding([.bottom], 4)
+
+                        Text("\(participants.count) participants")
+                          .font(.caption)
+                          .frame(maxWidth: .infinity, alignment: .leading)
+                    }.padding([.leading, .trailing])
+                }
+            }
+        }
+
+        struct LiveButtonView: View {
+            var call: Call
+            @ObservedObject var state: CallState
+
+            var body: some View {
+                if state.backstage {
+                    Button {
+                        Task {
+                            try await call.goLive()
+                        }
+                    } label: {
+                        Text("Go Live")
+                    }
+                    .buttonStyle(.borderedProminent).tint(.green)
+                } else {
+                    Button {
+                        Task {
+                            try await call.stopLive()
+                        }
+                    } label: {
+                        Text("Stop live")
+                    }
+                    .buttonStyle(.borderedProminent).tint(.red)
+                }
+            }
+        }
+
+        struct MicButtonView: View {
+            @ObservedObject var microphone: MicrophoneManager
+
+            var body: some View {
+                Button {
+                   Task {
+                       try await microphone.toggle()
+                   }
+                } label: {
+                    Image(systemName: microphone.status == .enabled ? "mic.circle" : "mic.slash.circle")
+                        .foregroundColor(microphone.status == .enabled ? .red : .primary)
+                        .font(.title)
+                }
+            }
+        }
+
+        struct ParticipantsView: View {
+            var participants: [CallParticipant]
+
+            var body: some View {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 100))], spacing: 20) {
+                    ForEach(participants) {
+                        ParticipantView(participant: $0)
+                    }
+                }
+            }
+        }
+
+        struct ParticipantView: View {
+            var participant: CallParticipant
+
+            var body: some View {
+                VStack{
+                    ZStack {
+                        Circle()
+                            .fill(participant.isSpeaking ? .green : .white)
+                            .frame(width: 68, height: 68)
+                        AsyncImage(
+                            url: participant.profileImageURL,
+                            content: { image in
+                                image.resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(maxWidth: 64, maxHeight: 64)
+                                    .clipShape(Circle())
+                            },
+                            placeholder: {
+                                Image(systemName: "person.crop.circle").font(.system(size: 60))
+                            }
+                        )
+                    }
+                    Text("\(participant.name)")
+                }
+            }
+        }
+
+        struct PermissionRequestsView: View {
+            var call: Call
+            @ObservedObject var state: CallState
+
+            var body: some View {
+                if let request = state.permissionRequests.first {
+                    HStack {
+                        Text("\(request.user.name) requested to \(request.permission)")
+                        Button {
+                           Task {
+                               try await call.grant(request: request)
+                           }
+                        } label: {
+                            Label("", systemImage: "hand.thumbsup.circle").tint(.green)
+                        }
+                        Button(action: request.reject) {
+                            Label("", systemImage: "hand.thumbsdown.circle.fill").tint(.red)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/02-video-renderer.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/02-video-renderer.swift
@@ -1,0 +1,141 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+import StreamWebRTC
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        VideoRendererView(
+            id: id,
+            size: availableSize,
+            contentMode: contentMode
+        ) { view in
+            view.handleViewRendering(for: participant) { size, participant in
+                // handle track size update
+            }
+        }
+    }
+
+    container {
+        final class CustomObject: UIView {
+
+            func add(track: RTCVideoTrack) {}
+
+            func handleViewRendering(
+                    for participant: CallParticipant,
+                    onTrackSizeUpdate: @escaping (CGSize, CallParticipant) -> ()
+                ) {
+                    if let track = participant.track {
+                        log.debug("adding track to a view \(self)")
+                        self.add(track: track)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                            let prev = participant.trackSize
+                            let scale = UIScreen.main.scale
+                            let newSize = CGSize(
+                                width: self.bounds.size.width * scale,
+                                height: self.bounds.size.height * scale
+                            )
+                            if prev != newSize {
+                                onTrackSizeUpdate(newSize, participant)
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    container {
+        struct VideoCallParticipantModifier: ViewModifier {
+
+            var participant: CallParticipant
+            var call: Call?
+            var availableFrame: CGRect
+            var ratio: CGFloat
+            var showAllInfo: Bool
+            var decorations: Set<VideoCallParticipantDecoration>
+
+            public init(
+                participant: CallParticipant,
+                call: Call?,
+                availableFrame: CGRect,
+                ratio: CGFloat,
+                showAllInfo: Bool,
+                decorations: [VideoCallParticipantDecoration] = VideoCallParticipantDecoration.allCases
+            ) {
+                self.participant = participant
+                self.call = call
+                self.availableFrame = availableFrame
+                self.ratio = ratio
+                self.showAllInfo = showAllInfo
+                self.decorations = .init(decorations)
+            }
+
+            public func body(content: Content) -> some View {
+                content
+                    .adjustVideoFrame(to: availableFrame.size.width, ratio: ratio)
+                    .overlay(
+                        ZStack {
+                            BottomView(content: {
+                                HStack {
+                                    ParticipantInfoView(
+                                        participant: participant,
+                                        isPinned: participant.isPinned
+                                    )
+
+                                    Spacer()
+
+                                    if showAllInfo {
+                                        ConnectionQualityIndicator(
+                                            connectionQuality: participant.connectionQuality
+                                        )
+                                    }
+                                }
+                            })
+                        }
+                    )
+                    .applyDecorationModifierIfRequired(
+                        VideoCallParticipantOptionsModifier(participant: participant, call: call),
+                        decoration: .options,
+                        availableDecorations: decorations
+                    )
+                    .applyDecorationModifierIfRequired(
+                        VideoCallParticipantSpeakingModifier(participant: participant, participantCount: participantCount),
+                        decoration: .speaking,
+                        availableDecorations: decorations
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .clipped()
+            }
+
+            @MainActor
+            private var participantCount: Int {
+                call?.state.participants.count ?? 0
+            }
+        }
+
+        viewContainer {
+            ForEach(participants) { participant in
+                viewFactory.makeVideoParticipantView(
+                    participant: participant,
+                    id: participant.id,
+                    availableFrame: availableFrame,
+                    contentMode: .scaleAspectFill,
+                    customData: [:],
+                    call: call
+                )
+                .modifier(
+                    viewFactory.makeVideoCallParticipantModifier(
+                        participant: participant,
+                        call: call,
+                        availableFrame: availableFrame,
+                        ratio: ratio,
+                        showAllInfo: true
+                    )
+                )
+            }
+        }
+    }
+}
+

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/03-video-theme.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/03-video-theme.swift
@@ -1,0 +1,36 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        let streamBlue = UIColor(red: 0, green: 108.0 / 255.0, blue: 255.0 / 255.0, alpha: 1)
+        var colors = Colors()
+        colors.tintColor = Color(streamBlue)
+        let appearance = Appearance(colors: colors)
+        let streamVideo = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+
+    container {
+        var images = Images()
+        images.hangup = Image("your_custom_hangup_icon")
+        let appearance = Appearance(images: images)
+        let streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+
+    container {
+        var fonts = Fonts()
+        fonts.footnoteBold = Font.footnote
+        let appearance = Appearance(fonts: fonts)
+        let streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+
+    container {
+        let sounds = Sounds()
+        sounds.incomingCallSound = "your_custom_sound"
+        let appearance = Appearance(sounds: sounds)
+        let streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/04-customizing-views.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/04-customizing-views.swift
@@ -1,0 +1,25 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeOutgoingCallView(viewModel: CallViewModel) -> some View {
+                CustomOutgoingCallView(viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        struct CustomView: View {
+            var body: some View {
+                YourHostingView()
+                    .modifier(CallModifier(viewFactory: CustomViewFactory(), viewModel: viewModel))
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/05-uikit-customizations.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/05-uikit-customizations.swift
@@ -1,0 +1,240 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import StreamVideoUIKit
+import SwiftUI
+import Combine
+import struct StreamChatSwiftUI.ChatChannelView
+import struct StreamChatSwiftUI.UnreadIndicatorView
+import class StreamChat.ChatChannelController
+
+@MainActor
+fileprivate func content() {
+
+    container {
+        class VideoWithChatViewFactory: ViewFactory {
+
+            static let shared = VideoWithChatViewFactory()
+
+            private init() {}
+
+            func makeCallControlsView(viewModel: CallViewModel) -> some View {
+                ChatCallControls(viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        class CallChatViewController: CallViewController {
+
+            class func makeCallChatController(with callViewModel: CallViewModel) -> CallChatViewController {
+                .init()
+            }
+
+            override func setupVideoView() {
+                let videoView = makeVideoView(with: VideoWithChatViewFactory.shared)
+                view.embed(videoView)
+            }
+
+        }
+
+        @MainActor
+        class CallViewHelper {
+
+            static let shared = CallViewHelper()
+
+            private var callView: UIView?
+
+            private init() {}
+
+            func add(callView: UIView) {
+                guard self.callView == nil else { return }
+                guard let window = UIApplication.shared.windows.first else {
+                    return
+                }
+                callView.isOpaque = false
+                callView.backgroundColor = UIColor.clear
+                self.callView = callView
+                window.addSubview(callView)
+            }
+
+            func removeCallView() {
+                callView?.removeFromSuperview()
+                callView = nil
+            }
+        }
+
+        final class CustomObject: UIViewController {
+            var callViewModel: CallViewModel { viewModel }
+            var selectedParticipants: [MemberRequest] = []
+            var text = ""
+            var cancellables: Set<AnyCancellable> = []
+
+            @objc func didTapStartButton() {
+                let next = CallChatViewController.makeCallChatController(with: self.callViewModel)
+                next.startCall(callType: "default", callId: text, members: selectedParticipants)
+                CallViewHelper.shared.add(callView: next.view)
+            }
+
+            private func listenToIncomingCalls() {
+                callViewModel.$callingState.sink { [weak self] newState in
+                    guard let self = self else { return }
+                    if case .incoming(_) = newState, self == self.navigationController?.topViewController {
+                        let next = CallChatViewController.makeCallChatController(with: self.callViewModel)
+                        CallViewHelper.shared.add(callView: next.view)
+                    } else if newState == .idle {
+                        CallViewHelper.shared.removeCallView()
+                    }
+                }
+                .store(in: &cancellables)
+            }
+        }
+    }
+
+    container {
+        struct ChatCallControls: View {
+
+            @Injected(\.streamVideo) var streamVideo
+
+            private let size: CGFloat = 50
+
+            @ObservedObject var viewModel: CallViewModel
+
+            @StateObject private var chatHelper = ChatHelper()
+
+            @Injected(\.images) var images
+            @Injected(\.colors) var colors
+
+            public init(viewModel: CallViewModel) {
+                self.viewModel = viewModel
+            }
+
+            public var body: some View {
+                VStack {
+                    HStack {
+                        Button(
+                            action: {
+                                withAnimation {
+                                    chatHelper.chatShown.toggle()
+                                }
+                            },
+                            label: {
+                                CallIconView(
+                                    icon: Image(systemName: "message"),
+                                    size: size,
+                                    iconStyle: chatHelper.chatShown ? .primary : .transparent
+                                )
+                                .overlay(
+                                    chatHelper.unreadCount > 0 ?
+                                    TopRightView(content: {
+                                        UnreadIndicatorView(unreadCount: chatHelper.unreadCount)
+                                    })
+                                    : nil
+                                )
+                            })
+                        .frame(maxWidth: .infinity)
+
+                        Button(
+                            action: {
+                                viewModel.toggleCameraEnabled()
+                            },
+                            label: {
+                                CallIconView(
+                                    icon: (viewModel.callSettings.videoOn ? images.videoTurnOn : images.videoTurnOff),
+                                    size: size,
+                                    iconStyle: (viewModel.callSettings.videoOn ? .primary : .transparent)
+                                )
+                            }
+                        )
+                        .frame(maxWidth: .infinity)
+
+                        Button(
+                            action: {
+                                viewModel.toggleMicrophoneEnabled()
+                            },
+                            label: {
+                                CallIconView(
+                                    icon: (viewModel.callSettings.audioOn ? images.micTurnOn : images.micTurnOff),
+                                    size: size,
+                                    iconStyle: (viewModel.callSettings.audioOn ? .primary : .transparent)
+                                )
+                            }
+                        )
+                        .frame(maxWidth: .infinity)
+
+                        Button(
+                            action: {
+                                viewModel.toggleCameraPosition()
+                            },
+                            label: {
+                                CallIconView(
+                                    icon: images.toggleCamera,
+                                    size: size,
+                                    iconStyle: .primary
+                                )
+                            }
+                        )
+                        .frame(maxWidth: .infinity)
+
+                        Button {
+                            viewModel.hangUp()
+                        } label: {
+                            images.hangup
+                                .applyCallButtonStyle(
+                                    color: colors.hangUpIconColor,
+                                    size: size
+                                )
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    if chatHelper.chatShown {
+                        if let channelController = chatHelper.channelController {
+                            ChatChannelView(
+                                viewFactory: ChatViewFactory.shared,
+                                channelController: channelController
+                            )
+                            .frame(height: chatHeight)
+                            .preferredColorScheme(.dark)
+                            .onAppear {
+                                chatHelper.markAsRead()
+                            }
+                        } else {
+                            Spacer()
+                            Text("Chat not available")
+                            Spacer()
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: chatHelper.chatShown ? chatHeight + 100 : 100)
+                .background(
+                    colors.callControlsBackground
+                        .cornerRadius(16)
+                        .edgesIgnoringSafeArea(.all)
+                )
+                .onReceive(viewModel.$callParticipants, perform: { output in
+                    if viewModel.callParticipants.count > 1 {
+                        chatHelper.update(memberIds: Set(viewModel.callParticipants.map(\.key)))
+                    }
+                })
+            }
+
+            private var chatHeight: CGFloat {
+                (UIScreen.main.bounds.height / 3 + 50)
+            }
+        }
+
+        final class ChatHelper: ObservableObject {
+            @Published var chatShown: Bool = false
+            @Published var unreadCount: Int = 0
+            @Published var channelController: ChatChannelController?
+
+            init() {}
+
+            func markAsRead() { /* Your implementation here */ }
+
+            func update(memberIds: Set<String>) { /* Your implementation here */ }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/06-view-model.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/06-view-model.swift
@@ -1,0 +1,23 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        Button {
+            viewModel.startCall(callType: "default", callId: callId, members: members, ring: false)
+        } label: {
+            Text("Start a call")
+        }
+    }
+
+    viewContainer {
+        Button {
+            viewModel.joinCall(callType: "default", callId: callId)
+        } label: {
+            Text("Join a call")
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/01-call-container.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/01-call-container.swift
@@ -1,0 +1,46 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            @StateObject var viewModel = CallViewModel()
+
+            public var body: some View {
+                ZStack {
+                    YourRootView()
+                    CallContainer(viewFactory: CustomViewFactory(), viewModel: viewModel)
+                }
+            }
+        }
+    }
+
+    container {
+        CallContainer(viewFactory: DefaultViewFactory.shared, viewModel: viewModel)
+    }
+
+    container {
+        struct CustomView: View {
+            @StateObject var viewModel = CallViewModel()
+
+            var body: some View {
+                YourRootView()
+                    .modifier(CallModifier(viewModel: viewModel))
+            }
+        }
+    }
+
+    container {
+        struct CustomView: View {
+            @StateObject var viewModel = CallViewModel()
+
+            var body: some View {
+                YourRootView()
+                    .modifier(CallModifier(viewFactory: CustomViewFactory(), viewModel: viewModel))
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/02-outgoing-call.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/02-outgoing-call.swift
@@ -1,0 +1,43 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+
+    container {
+        struct CustomView: View {
+            public var body: some View {
+                OutgoingCallView(
+                    outgoingCallMembers: outgoingCallMembers,
+                    callControls: callControls
+                )
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeOutgoingCallView(viewModel: CallViewModel) -> some View {
+                CustomOutgoingCallView(viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        let sounds = Sounds()
+        sounds.outgoingCallSound = "your_sounds.m4a"
+        let appearance = Appearance(sounds: sounds)
+        streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+
+    container {
+        let images = Images()
+        images.hangup = Image("custom_hangup_icon")
+        let appearance = Appearance(images: images)
+        streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/03-incoming-call.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/03-incoming-call.swift
@@ -1,0 +1,48 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            var callInfo: IncomingCall
+
+            public var body: some View {
+                IncomingCallView(
+                   callInfo: callInfo,
+                   onCallAccepted: { _ in
+                    // handle call accepted
+                   }, onCallRejected: { _ in
+                    // handle call rejected
+                   }
+                )
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeIncomingCallView(viewModel: CallViewModel, callInfo: IncomingCall) -> some View {
+                CustomIncomingCallView(viewModel: viewModel, callInfo: callInfo)
+            }
+
+        }
+    }
+
+    container {
+        let sounds = Sounds()
+        sounds.incomingCallSound = "your_sounds.m4a"
+        let appearance = Appearance(sounds: sounds)
+        streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+
+    container {
+        let images = Images()
+        images.hangup = Image("custom_hangup_icon")
+        let appearance = Appearance(images: images)
+        streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/04-active-call.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/04-active-call.swift
@@ -1,0 +1,106 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            var callInfo: IncomingCall
+
+            public var body: some View {
+                CallView(viewFactory: DefaultViewFactory.shared, viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeCallView(viewModel: CallViewModel) -> some View {
+                CustomCallView(viewFactory: self, viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeCallControlsView(viewModel: CallViewModel) -> some View {
+                CustomCallControlsView(viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoParticipantsView(
+                viewModel: CallViewModel,
+                availableFrame: CGRect,
+                onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
+            ) -> some View {
+                VideoParticipantsView(
+                    viewFactory: self,
+                    viewModel: viewModel,
+                    availableFrame: availableFrame,
+                    onChangeTrackVisibility: onChangeTrackVisibility
+                )
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoParticipantView(
+                participant: CallParticipant,
+                id: String,
+                availableFrame: CGRect,
+                contentMode: UIView.ContentMode,
+                customData: [String: RawJSON],
+                call: Call?
+            ) -> some View {
+                VideoCallParticipantView(
+                    participant: participant,
+                    id: id,
+                    availableFrame: availableFrame,
+                    contentMode: contentMode,
+                    customData: customData,
+                    call: call
+                )
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoCallParticipantModifier(
+                    participant: CallParticipant,
+                    call: Call?,
+                    availableFrame: CGRect,
+                    ratio: CGFloat,
+                    showAllInfo: Bool
+            ) -> some ViewModifier {
+                VideoCallParticipantModifier(
+                    participant: participant,
+                    call: call,
+                    availableFrame: availableFrame,
+                    ratio: ratio,
+                    showAllInfo: showAllInfo
+                )
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeCallTopView(viewModel: CallViewModel) -> some View {
+                CallTopView(viewModel: viewModel)
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/05-call-controls.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/05-call-controls.swift
@@ -1,0 +1,44 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            var callInfo: IncomingCall
+
+            public var body: some View {
+                CallControlsView(viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeCallControlsView(viewModel: CallViewModel) -> some View {
+                CustomCallControlsView(viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        struct CustomCallControlsView: View {
+
+            @ObservedObject var viewModel: CallViewModel
+
+            var body: some View {
+                HStack(spacing: 32) {
+                    VideoIconView(viewModel: viewModel)
+                    MicrophoneIconView(viewModel: viewModel)
+                    ToggleCameraIconView(viewModel: viewModel)
+                    HangUpIconView(viewModel: viewModel)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 85)
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/06-call-app-bar.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/06-call-app-bar.swift
@@ -1,0 +1,26 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            var callInfo: IncomingCall
+
+            var body: some View {
+                CallTopView(viewModel: viewModel)
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeCallTopView(viewModel: CallViewModel) -> some View {
+                CustomCallTopView(viewModel: viewModel)
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/07-screen-share-content.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/07-call/07-screen-share-content.swift
@@ -1,0 +1,35 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        @MainActor
+        func custom(screensharingSession: ScreenSharingSession) {
+            ScreenSharingView(
+                viewModel: viewModel,
+                screenSharing: screensharingSession,
+                availableFrame: availableFrame
+            )
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeScreenSharingView(
+                viewModel: CallViewModel,
+                screensharingSession: ScreenSharingSession,
+                availableFrame: CGRect
+            ) -> some View {
+                CustomScreenSharingView(
+                    viewModel: viewModel,
+                    screenSharing: screensharingSession,
+                    availableFrame: availableFrame
+                )
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/01-call-participant.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/01-call-participant.swift
@@ -1,0 +1,66 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        VideoCallParticipantView(
+            participant: participant,
+            id: id,
+            availableFrame: availableFrame,
+            contentMode: contentMode,
+            customData: customData,
+            call: call
+        )
+        .modifier(
+            VideoCallParticipantModifier(
+                participant: participant,
+                call: call,
+                availableFrame: availableFrame,
+                ratio: ratio,
+                showAllInfo: true
+            )
+        )
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoParticipantView(
+                participant: CallParticipant,
+                id: String,
+                availableFrame: CGRect,
+                contentMode: UIView.ContentMode,
+                customData: [String: RawJSON],
+                call: Call?
+            ) -> some View {
+                VideoCallParticipantView(
+                    participant: participant,
+                    id: id,
+                    availableFrame: availableFrame,
+                    contentMode: contentMode,
+                    customData: customData,
+                    call: call
+                )
+            }
+
+            public func makeVideoCallParticipantModifier(
+                participant: CallParticipant,
+                call: Call?,
+                availableFrame: CGRect,
+                ratio: CGFloat,
+                showAllInfo: Bool
+            ) -> some ViewModifier {
+                VideoCallParticipantModifier(
+                    participant: participant,
+                    call: call,
+                    availableFrame: availableFrame,
+                    ratio: ratio,
+                    showAllInfo: showAllInfo
+                )
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/02-call-participants.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/02-call-participants.swift
@@ -1,0 +1,70 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        VideoParticipantsView(
+            viewFactory: DefaultViewFactory.shared,
+            viewModel: viewModel,
+            availableFrame: availableFrame,
+            onChangeTrackVisibility: onChangeTrackVisibility
+        )
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeVideoParticipantsView(
+                viewModel: CallViewModel,
+                availableFrame: CGRect,
+                onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
+            ) -> some View {
+                CustomVideoParticipantsView(
+                    viewFactory: self,
+                    viewModel: viewModel,
+                    availableFrame: availableFrame,
+                    onChangeTrackVisibility: onChangeTrackVisibility
+                )
+            }
+        }
+    }
+
+    viewContainer {
+        ParticipantsGridLayout(
+            viewFactory: viewFactory,
+            call: viewModel.call,
+            participants: viewModel.participants,
+            availableFrame: availableFrame,
+            orientation: orientation,
+            onChangeTrackVisibility: onChangeTrackVisibility
+        )
+    }
+
+    viewContainer {
+        let first: CallParticipant = participant
+
+        ParticipantsSpotlightLayout(
+            viewFactory: viewFactory,
+            participant: first,
+            call: viewModel.call,
+            participants: Array(viewModel.participants.dropFirst()),
+            frame: availableFrame,
+            onChangeTrackVisibility: onChangeTrackVisibility
+        )
+    }
+
+    viewContainer {
+        let first: CallParticipant = participant
+        
+        ParticipantsFullScreenLayout(
+            viewFactory: viewFactory,
+            participant: first,
+            call: viewModel.call,
+            frame: availableFrame,
+            onChangeTrackVisibility: onChangeTrackVisibility
+        )
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/03-call-participants-info-menu.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/03-call-participants-info-menu.swift
@@ -1,0 +1,37 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        let view = CallParticipantsInfoView(callViewModel: viewModel, availableFrame: availableFrame)
+    }
+
+    container {
+        func makeParticipantsListView(
+            viewModel: CallViewModel,
+            availableFrame: CGRect
+        ) -> some View {
+            CustomCallParticipantsInfoView(
+                callViewModel: viewModel,
+                availableFrame: availableFrame
+            )
+        }
+    }
+
+    container {
+        final class CustomUserProvider: UserListProvider {
+            func loadNextUsers(pagination: Pagination) async throws -> [User] {
+                // load the users, based on the pagination parameter provided
+                return []
+            }
+        }
+    }
+
+    container {
+        let utils = Utils(userListProvider: MockUserListProvider())
+        let streamVideoUI = StreamVideoUI(streamVideo: streamVideo, utils: utils)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/04-local-video.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/08-participants/04-local-video.swift
@@ -1,0 +1,38 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        LocalVideoView(
+            viewFactory: viewFactory,
+            participant: localParticipant,
+            callSettings: viewModel.callSettings,
+            call: viewModel.call,
+            availableFrame: availableFrame
+        )
+    }
+
+    viewContainer {
+        CornerDraggableView(
+            content: { availableFrame in
+                LocalVideoView(
+                    viewFactory: viewFactory,
+                    participant: localParticipant,
+                    callSettings: viewModel.callSettings,
+                    call: viewModel.call,
+                    availableFrame: availableFrame
+                )
+            },
+            proxy: reader
+        ) {
+            withAnimation {
+                if participants.count == 1 {
+                    viewModel.localVideoPrimary.toggle()
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/02-sound-indicator.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/02-sound-indicator.swift
@@ -1,0 +1,19 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        SoundIndicator(participant: participant)
+    }
+
+    container {
+        let images = Images()
+        images.micTurnOn = Image("custom_mic_turn_on_icon")
+        images.micTurnOff = Image("custom_mic_turn_off_icon")
+        let appearance = Appearance(images: images)
+        streamVideoUI = StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/03-avatars.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/03-avatars.swift
@@ -1,0 +1,18 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            var body: some View {
+                VStack {
+                    UserAvatar(imageURL: participant.profileImageURL, size: 40)
+                    SomeOtherView()
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/04-connection-quality-indicator.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/04-connection-quality-indicator.swift
@@ -1,0 +1,11 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        ConnectionQualityIndicator(connectionQuality: participant.connectionQuality)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/05-call-background.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/09-utility/05-call-background.swift
@@ -1,0 +1,17 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomView: View {
+            var body: some View {
+                YourView()
+                    .background(CallBackground(imageURL: imageURL))
+            }
+        }
+    }
+}
+

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/02-replacing-call-controls.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/02-replacing-call-controls.swift
@@ -1,0 +1,103 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            public func makeCallControlsView(viewModel: CallViewModel) -> some View {
+                CustomCallControlsView(viewModel: viewModel)
+            }
+
+        }
+    }
+
+    container {
+        struct CustomCallControlsView: View {
+
+            @ObservedObject var viewModel: CallViewModel
+
+            var body: some View {
+                HStack(spacing: 32) {
+                    VideoIconView(viewModel: viewModel)
+                    MicrophoneIconView(viewModel: viewModel)
+                    ToggleCameraIconView(viewModel: viewModel)
+                    HangUpIconView(viewModel: viewModel)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 85)
+            }
+        }
+    }
+
+    container {
+        struct FBCallControlsView: View {
+
+            @ObservedObject var viewModel: CallViewModel
+
+            var body: some View {
+                HStack(spacing: 24) {
+                    Button {
+                        viewModel.toggleCameraEnabled()
+                    } label: {
+                        Image(systemName: "video.fill")
+                    }
+
+                    Spacer()
+
+                    Button {
+                        viewModel.toggleMicrophoneEnabled()
+                    } label: {
+                        Image(systemName: "mic.fill")
+                    }
+
+                    Spacer()
+
+                    Button {
+                        viewModel.toggleCameraPosition()
+                    } label: {
+                        Image(systemName: "arrow.triangle.2.circlepath.camera.fill")
+                    }
+
+                    Spacer()
+
+                    HangUpIconView(viewModel: viewModel)
+                }
+                .foregroundColor(.white)
+                .padding(.vertical, 8)
+                .padding(.horizontal)
+                .modifier(BackgroundModifier())
+                .padding(.horizontal, 32)
+            }
+
+            struct BackgroundModifier: ViewModifier {
+
+                func body(content: Content) -> some View {
+                    if #available(iOS 15, *) {
+                        content
+                            .background(
+                                .ultraThinMaterial,
+                                in: RoundedRectangle(cornerRadius: 24)
+                            )
+                    } else {
+                        content
+                            .background(Color.black.opacity(0.8))
+                            .cornerRadius(24)
+                    }
+                }
+
+            }
+
+            class CustomViewFactory: ViewFactory {
+
+                func makeCallControlsView(viewModel: CallViewModel) -> some View {
+                    FBCallControlsView(viewModel: viewModel)
+                }
+
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/03-custom-label.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/03-custom-label.swift
@@ -1,0 +1,76 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomParticipantModifier: ViewModifier {
+
+            var participant: CallParticipant
+            var call: Call?
+            var availableFrame: CGRect
+            var ratio: CGFloat
+            var showAllInfo: Bool
+
+            public init(
+                participant: CallParticipant,
+                call: Call?,
+                availableFrame: CGRect,
+                ratio: CGFloat,
+                showAllInfo: Bool
+            ) {
+                self.participant = participant
+                self.call = call
+                self.availableFrame = availableFrame
+                self.ratio = ratio
+                self.showAllInfo = showAllInfo
+            }
+
+            public func body(content: Content) -> some View {
+                content
+                    .adjustVideoFrame(to: availableFrame.size.width, ratio: ratio)
+                    .overlay(
+                        ZStack {
+                            VStack {
+                                Spacer()
+                                HStack {
+                                    Text(participant.name)
+                                        .foregroundColor(.white)
+                                        .bold()
+                                    Spacer()
+                                    ConnectionQualityIndicator(
+                                        connectionQuality: participant.connectionQuality
+                                    )
+                                }
+                                .padding(.bottom, 2)
+                            }
+                            .padding()
+                        }
+                        .modifier(VideoCallParticipantSpeakingModifier(participant: participant, participantCount: 1))
+                    )
+            }
+        }
+
+        class CustomViewFactory: ViewFactory {
+
+            func makeVideoCallParticipantModifier(
+                participant: CallParticipant,
+                call: Call?,
+                availableFrame: CGRect,
+                ratio: CGFloat,
+                showAllInfo: Bool
+            ) -> some ViewModifier {
+                CustomParticipantModifier(
+                    participant: participant,
+                    call: call,
+                    availableFrame: availableFrame,
+                    ratio: ratio,
+                    showAllInfo: showAllInfo
+                )
+            }
+
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/04-video-layout.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/04-video-layout.swift
@@ -1,0 +1,153 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+
+    container {
+        struct JoinCallView: View {
+
+            @State var callId = ""
+            @ObservedObject var viewModel: CallViewModel
+
+            var body: some View {
+                VStack {
+                    TextField("Insert call id", text: $callId)
+                    Button {
+                        resignFirstResponder()
+                        viewModel.startCall(callType: .default, callId: callId, members: [])
+                    } label: {
+                        Text("Join call")
+                    }
+                    Spacer()
+                }
+                .padding()
+            }
+
+        }
+
+        struct HomeView<Factory: ViewFactory>: View {
+
+            @ObservedObject var appState: AppState
+
+            var viewFactory: Factory
+            @StateObject var viewModel = CallViewModel()
+
+            var body: some View {
+                ZStack {
+                    JoinCallView(viewModel: viewModel)
+
+                    if viewModel.callingState == .joining {
+                        ProgressView()
+                    } else if viewModel.callingState == .inCall {
+                        CallView(viewFactory: viewFactory, viewModel: viewModel)
+                    }
+                }
+            }
+        }
+
+        container {
+            @MainActor
+            struct CustomView {
+                var participants: [CallParticipant] {
+                    viewModel.callParticipants
+                        .map(\.value)
+                        .sorted(by: defaultComparators)
+                }
+            }
+        }
+
+        container {
+            struct CustomCallControlsView: View {
+
+                @ObservedObject var viewModel: CallViewModel
+
+                var body: some View {
+                    HStack(spacing: 32) {
+                        VideoIconView(viewModel: viewModel)
+                        MicrophoneIconView(viewModel: viewModel)
+                        ToggleCameraIconView(viewModel: viewModel)
+                        HangUpIconView(viewModel: viewModel)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 85)
+                }
+            }
+
+            struct BottomParticipantView: View {
+
+                var participant: CallParticipant
+
+                var body: some View {
+                    UserAvatar(imageURL: participant.profileImageURL, size: 80)
+                        .overlay(
+                            !participant.hasAudio ?
+                                BottomRightView {
+                                    MuteIndicatorView()
+                                }
+                            : nil
+                        )
+                }
+
+            }
+
+            struct MuteIndicatorView: View {
+
+                var body: some View {
+                    Image(systemName: "mic.slash.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 14)
+                        .padding(.all, 12)
+                        .foregroundColor(.gray)
+                        .background(Color.black)
+                        .clipShape(Circle())
+                        .offset(x: 4, y: 8)
+                }
+            }
+
+            struct CustomView: View {
+                var body: some View {
+                    VStack {
+                        ZStack {
+                            GeometryReader { reader in
+                                if let dominantSpeaker = participants.first {
+                                    VideoCallParticipantView(
+                                        participant: dominantSpeaker,
+                                        availableFrame: reader.frame(in: .global),
+                                        contentMode: .scaleAspectFit,
+                                        customData: customData,
+                                        call: call
+                                    )
+                                }
+
+                                VStack {
+                                    Spacer()
+                                    CustomCallControlsView(viewModel: viewModel)
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .cornerRadius(32)
+                        .padding(.bottom)
+                        .padding(.horizontal)
+
+                        ScrollView(.horizontal) {
+                            HStack {
+                                ForEach(participants.dropFirst()) { participant in
+                                    BottomParticipantView(participant: participant)
+                                }
+                            }
+                        }
+                        .padding(.all, 32)
+                        .frame(height: 100)
+                        .frame(maxWidth: .infinity)
+                    }
+                    .background(Color.black)
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/06-lobby-preview.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/06-lobby-preview.swift
@@ -1,0 +1,338 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+
+    container {
+        struct CustomLobbyView: View {
+
+            @StateObject var viewModel: LobbyViewModel
+            @StateObject var microphoneChecker = MicrophoneChecker()
+
+            var callId: String
+            var callType: String
+            @Binding var callSettings: CallSettings
+            var onJoinCallTap: () -> ()
+            var onCloseLobby: () -> ()
+
+            public init(
+                callId: String,
+                callType: String,
+                callSettings: Binding<CallSettings>,
+                onJoinCallTap: @escaping () -> (),
+                onCloseLobby: @escaping () -> ()
+            ) {
+                self.callId = callId
+                self.callType = callType
+                self.onJoinCallTap = onJoinCallTap
+                self.onCloseLobby = onCloseLobby
+                _callSettings = callSettings
+                _viewModel = StateObject(
+                    wrappedValue: LobbyViewModel(
+                        callType: callType,
+                        callId: callId
+                    )
+                )
+            }
+
+            public var body: some View {
+                CustomLobbyContentView(
+                    viewModel: viewModel,
+                    microphoneChecker: microphoneChecker,
+                    callId: callId,
+                    callType: callType,
+                    callSettings: $callSettings,
+                    onJoinCallTap: onJoinCallTap,
+                    onCloseLobby: onCloseLobby
+                )
+            }
+        }
+
+        struct CustomLobbyContentView: View {
+
+            @Injected(\.images) var images
+            @Injected(\.colors) var colors
+            @Injected(\.streamVideo) var streamVideo
+
+            @ObservedObject var viewModel: LobbyViewModel
+            @ObservedObject var microphoneChecker: MicrophoneChecker
+
+            var callId: String
+            var callType: String
+            @Binding var callSettings: CallSettings
+            var onJoinCallTap: () -> ()
+            var onCloseLobby: () -> ()
+
+            var body: some View {
+                GeometryReader { reader in
+                    ZStack {
+                        VStack {
+                            Spacer()
+                            Text("Before Joining")
+                                .font(.title)
+                                .foregroundColor(colors.text)
+                                .bold()
+
+                            Text("Setup your audio and video")
+                                .font(.body)
+                                .foregroundColor(Color(colors.textLowEmphasis))
+
+                            CameraCheckView(
+                                viewModel: viewModel,
+                                microphoneChecker: microphoneChecker,
+                                callSettings: callSettings,
+                                availableSize: reader.size
+                            )
+
+                            if microphoneChecker.isSilent {
+                                Text("Your microphone doesn't seem to be working. Make sure you have all permissions accepted.")
+                                    .font(.caption)
+                                    .foregroundColor(colors.text)
+                            }
+
+                            CallSettingsView(callSettings: $callSettings)
+
+                            JoinCallView(
+                                callId: callId,
+                                callType: callType,
+                                callParticipants: viewModel.participants,
+                                onJoinCallTap: onJoinCallTap
+                            )
+                        }
+                        .padding()
+
+                        TopRightView {
+                            Button {
+                                onCloseLobby()
+                            } label: {
+                                Image(systemName: "xmark")
+                                    .foregroundColor(colors.text)
+                            }
+                            .padding()
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(colors.lobbyBackground.edgesIgnoringSafeArea(.all))
+                }
+                .onAppear {
+                    viewModel.startCamera(front: true)
+                }
+                .onDisappear {
+                    viewModel.stopCamera()
+                }
+            }
+        }
+
+        struct CameraCheckView: View {
+
+            @Injected(\.images) var images
+            @Injected(\.colors) var colors
+            @Injected(\.streamVideo) var streamVideo
+
+            @ObservedObject var viewModel: LobbyViewModel
+            @ObservedObject var microphoneChecker: MicrophoneChecker
+            var callSettings: CallSettings
+            var availableSize: CGSize
+
+            var body: some View {
+                Group {
+                    if let image = viewModel.viewfinderImage, callSettings.videoOn {
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: availableSize.width - 32, height: cameraSize)
+                            .cornerRadius(16)
+                            .accessibility(identifier: "cameraCheckView")
+                            .streamAccessibility(value: "1")
+                    } else {
+                        ZStack {
+                            Rectangle()
+                                .fill(colors.lobbySecondaryBackground)
+                                .frame(width: availableSize.width - 32, height: cameraSize)
+                                .cornerRadius(16)
+
+                            if #available(iOS 14.0, *) {
+                                UserAvatar(imageURL: streamVideo.user.imageURL, size: 80)
+                                    .accessibility(identifier: "cameraCheckView")
+                                    .streamAccessibility(value: "0")
+                            }
+                        }
+                        .opacity(callSettings.videoOn ? 0 : 1)
+                        .frame(width: availableSize.width - 32, height: cameraSize)
+                    }
+                }
+                .overlay(
+                    VStack {
+                        Spacer()
+                        HStack {
+                            MicrophoneCheckView(
+                                audioLevels: microphoneChecker.audioLevels,
+                                microphoneOn: callSettings.audioOn,
+                                isSilent: microphoneChecker.isSilent, 
+                                isPinned: false
+                            )
+                            .accessibility(identifier: "microphoneCheckView")
+                            Spacer()
+                        }
+                        .padding()
+                    }
+                )
+            }
+
+            private var cameraSize: CGFloat {
+                if viewModel.participants.count > 0 {
+                    return availableSize.height / 2 - 64
+                } else {
+                    return availableSize.height / 2
+                }
+            }
+        }
+
+        struct CallSettingsView: View {
+
+            @Injected(\.images) var images
+
+            @Binding var callSettings: CallSettings
+
+            private let iconSize: CGFloat = 50
+
+            var body: some View {
+                HStack(spacing: 32) {
+                    Button {
+                        callSettings = CallSettings(
+                            audioOn: !callSettings.audioOn,
+                            videoOn: callSettings.videoOn,
+                            speakerOn: callSettings.speakerOn
+                        )
+                    } label: {
+                        CallIconView(
+                            icon: (callSettings.audioOn ? images.micTurnOn : images.micTurnOff),
+                            size: iconSize,
+                            iconStyle: (callSettings.audioOn ? .primary : .transparent)
+                        )
+                        .accessibility(identifier: "microphoneToggle")
+                        .streamAccessibility(value: callSettings.audioOn ? "1" : "0")
+                    }
+
+                    Button {
+                        callSettings = CallSettings(
+                            audioOn: callSettings.audioOn,
+                            videoOn: !callSettings.videoOn,
+                            speakerOn: callSettings.speakerOn
+                        )
+                    } label: {
+                        CallIconView(
+                            icon: (callSettings.videoOn ? images.videoTurnOn : images.videoTurnOff),
+                            size: iconSize,
+                            iconStyle: (callSettings.videoOn ? .primary : .transparent)
+                        )
+                        .accessibility(identifier: "cameraToggle")
+                        .streamAccessibility(value: callSettings.videoOn ? "1" : "0")
+                    }
+                }
+                .padding()
+            }
+        }
+        
+        struct JoinCallView: View {
+
+            @Injected(\.colors) var colors
+
+            var callId: String
+            var callType: String
+            var callParticipants: [User]
+            var onJoinCallTap: () -> ()
+
+            var body: some View {
+                VStack(spacing: 16) {
+                    Text("You are about to join a call.")
+                        .font(.headline)
+                        .accessibility(identifier: "otherParticipantsCount")
+                        .streamAccessibility(value: "\(otherParticipantsCount)")
+
+                    if #available(iOS 14, *) {
+                        if callParticipants.count > 0 {
+                            ParticipantsInCallView(
+                                callParticipants: callParticipants
+                            )
+                        }
+                    }
+
+                    Button {
+                        onJoinCallTap()
+                    } label: {
+                        Text("Join Call")
+                            .bold()
+                            .frame(maxWidth: .infinity)
+                            .accessibility(identifier: "joinCall")
+                    }
+                    .frame(height: 50)
+                    .background(colors.primaryButtonBackground)
+                    .cornerRadius(16)
+                    .foregroundColor(.white)
+                }
+                .padding()
+                .background(colors.lobbySecondaryBackground)
+                .cornerRadius(16)
+            }
+
+            private var otherParticipantsCount: Int {
+                let count = callParticipants.count - 1
+                if count > 0 {
+                    return count
+                } else {
+                    return 0
+                }
+            }
+        }
+
+        @available(iOS 14.0, *)
+        struct ParticipantsInCallView: View {
+
+            struct ParticipantInCall: Identifiable {
+                let id: String
+                let user: User
+            }
+
+            var callParticipants: [User]
+
+            var participantsInCall: [ParticipantInCall] {
+                var result = [ParticipantInCall]()
+                for (index, participant) in callParticipants.enumerated() {
+                    let id = "\(index)-\(participant.id)"
+                    let participant = ParticipantInCall(id: id, user: participant)
+                    result.append(participant)
+                }
+                return result
+            }
+
+            private let viewSize: CGFloat = 64
+
+            var body: some View {
+                VStack(spacing: 4) {
+                    Text("There are \(callParticipants.count) more people in the call.")
+                        .font(.headline)
+
+                    ScrollView(.horizontal) {
+                        LazyHStack {
+                            ForEach(participantsInCall) { participant in
+                                VStack {
+                                    UserAvatar(
+                                        imageURL: participant.user.imageURL,
+                                        size: 40
+                                    )
+                                    Text(participant.user.name)
+                                        .font(.caption)
+                                }
+                                .frame(width: viewSize, height: viewSize)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/07-video-fallback.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/07-video-fallback.swift
@@ -1,0 +1,90 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeVideoParticipantView(
+                participant: CallParticipant,
+                id: String,
+                availableFrame: CGRect,
+                contentMode: UIView.ContentMode,
+                customData: [String: RawJSON],
+                call: Call?
+            ) -> some View {
+                CustomVideoCallParticipantView(
+                    participant: participant,
+                    id: id,
+                    availableFrame: availableFrame,
+                    contentMode: contentMode,
+                    call: call
+                )
+            }
+        }
+
+        struct CustomVideoCallParticipantView: View {
+
+            @Injected(\.images) var images
+            @Injected(\.streamVideo) var streamVideo
+
+            let participant: CallParticipant
+            var id: String
+            var availableFrame: CGRect
+            var contentMode: UIView.ContentMode
+            var edgesIgnoringSafeArea: Edge.Set
+            var call: Call?
+
+            public init(
+                participant: CallParticipant,
+                id: String? = nil,
+                availableFrame: CGRect,
+                contentMode: UIView.ContentMode,
+                edgesIgnoringSafeArea: Edge.Set = .all,
+                call: Call?
+            ) {
+                self.participant = participant
+                self.id = id ?? participant.id
+                self.availableFrame = availableFrame
+                self.contentMode = contentMode
+                self.edgesIgnoringSafeArea = edgesIgnoringSafeArea
+                self.call = call
+            }
+
+            public var body: some View {
+                VideoRendererView(
+                    id: id,
+                    size: availableFrame.size,
+                    contentMode: contentMode,
+                    handleRendering: { view in
+                        view.handleViewRendering(for: participant) { size, participant in
+                            Task {
+                                await call?.updateTrackSize(size, for: participant)
+                            }
+                        }
+                    }
+                )
+                .opacity(showVideo ? 1 : 0)
+                .edgesIgnoringSafeArea(edgesIgnoringSafeArea)
+                .accessibility(identifier: "callParticipantView")
+                .streamAccessibility(value: showVideo ? "1" : "0")
+                .overlay(
+                    CallParticipantImageView(
+                        id: participant.id,
+                        name: participant.name,
+                        imageURL: participant.profileImageURL
+                    )
+                    .frame(width: availableFrame.size.width)
+                    .opacity(showVideo ? 0 : 1)
+                )
+            }
+
+            private var showVideo: Bool {
+                participant.shouldDisplayTrack || customData["videoOn"]?.boolValue == true
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/08-permission-requests.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/08-permission-requests.swift
@@ -1,0 +1,52 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+
+    container {
+        final class CustomCallViewModel: CallViewModel {
+            var permissionRequest: PermissionRequestEvent?
+            @Published var permissionPopupShown = false
+
+            func subscribeForPermissionsRequests() {
+                Task {
+                    for await request in call!.subscribe(for: PermissionRequestEvent.self) {
+                        self.permissionRequest = request
+                    }
+                }
+            }
+
+            func grantUserPermissions() async throws {
+                guard let request = permissionRequest else { return }
+                let permissionRequests = request.permissions.map { PermissionRequest(permission: $0, user: request.user.toUser, requestedAt: request.createdAt) }
+                for permissionRequest in permissionRequests {
+                    try await call?.grant(request: permissionRequest)
+                }
+            }
+        }
+
+        struct CustomView: View {
+            @ObservedObject var viewModel: CustomCallViewModel
+            var body: some View {
+                YourHostView()
+                    .alert(isPresented: $viewModel.permissionPopupShown) {
+                        Alert(
+                            title: Text("Permission request"),
+                            message: Text("\(viewModel.permissionRequest?.user.name ?? "Someone") raised their hand to speak."),
+                            primaryButton: .default(Text("Allow")) {
+                                Task {
+                                    try await viewModel.grantUserPermissions()
+                                }
+                            },
+                            secondaryButton: .cancel()
+                        )
+                }
+            }
+        }
+
+
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/09-audio-volume-indicator.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/09-audio-volume-indicator.swift
@@ -1,0 +1,32 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        AudioVolumeIndicator(
+            audioLevels: [0.8, 0.9, 0.7],
+            maxHeight: 14,
+            minValue: 0,
+            maxValue: 1
+        )
+    }
+
+    container {
+        @StateObject var microphoneChecker = MicrophoneChecker()
+    }
+
+    viewContainer {
+        var callViewModel = viewModel
+        var microphoneChecker = MicrophoneChecker()
+
+        MicrophoneCheckView(
+            audioLevels: microphoneChecker.audioLevels,
+            microphoneOn: callViewModel.callSettings.audioOn,
+            isSilent: microphoneChecker.isSilent, 
+            isPinned: false
+        )
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/10-network-quality-indicator.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/10-network-quality-indicator.swift
@@ -1,0 +1,11 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        ConnectionQualityIndicator(connectionQuality: participant.connectionQuality)
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/11-speaking-while-muted.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/11-speaking-while-muted.swift
@@ -1,0 +1,74 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CustomCallView<Factory: ViewFactory>: View {
+
+            @Injected(\.colors) var colors
+
+            var viewFactory: Factory
+            @ObservedObject var viewModel: CallViewModel
+
+            @StateObject var microphoneChecker = MicrophoneChecker()
+            @State var mutedIndicatorShown = false
+
+            var body: some View {
+                CallView(viewFactory: viewFactory, viewModel: viewModel)
+                    .onReceive(viewModel.$callSettings) { callSettings in
+                        updateMicrophoneChecker()
+                    }
+                    .onReceive(microphoneChecker.$audioLevels, perform: { values in
+                        guard !viewModel.callSettings.audioOn else { return }
+                        for value in values {
+                            if (value > -50 && value < 0) && !mutedIndicatorShown {
+                                mutedIndicatorShown = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: {
+                                    mutedIndicatorShown = false
+                                })
+                                return
+                            }
+                        }
+                    })
+                    .overlay(
+                        mutedIndicatorShown ?
+                        VStack {
+                            Spacer()
+                            Text("You are muted.")
+                                .padding(8)
+                                .background(Color(UIColor.systemBackground))
+                                .foregroundColor(colors.text)
+                                .cornerRadius(16)
+                                .padding()
+                        }
+                        : nil
+                    )
+                    .onDisappear {
+                        microphoneChecker.stopListening()
+                    }
+                    .onAppear {
+                        updateMicrophoneChecker()
+                    }
+            }
+
+            private func updateMicrophoneChecker() {
+                if !viewModel.callSettings.audioOn {
+                    microphoneChecker.startListening()
+                } else {
+                    microphoneChecker.stopListening()
+                }
+            }
+        }
+
+        class CustomViewFactory: ViewFactory {
+
+            func makeCallView(viewModel: CallViewModel) -> some View {
+                CustomCallView(viewFactory: self, viewModel: viewModel)
+            }
+
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/12-connection-unstable.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/12-connection-unstable.swift
@@ -1,0 +1,24 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        YourView()
+            .overlay(
+                participant.connectionQuality == .poor ? Text("Your network connection is bad.") : nil
+            )
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeReconnectionView(viewModel: CallViewModel) -> some View {
+                ReconnectionView(viewModel: viewModel, viewFactory: self)
+            }
+
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/13-pinning-users.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/13-pinning-users.swift
@@ -1,0 +1,68 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        try await call.pin(sessionId: "pinned_user_session_id")
+    }
+
+    asyncContainer {
+        try await call.unpin(sessionId: "pinned_user_session_id")
+    }
+
+    asyncContainer {
+        let response = try await call.pinForEveryone(userId: "pinned_user_id", sessionId: "pinned_user_session_id")
+    }
+
+    asyncContainer {
+        let response = try await call.unpinForEveryone(userId: "pinned_user_id", sessionId: "pinned_user_session_id")
+    }
+
+    container {
+        struct CustomVideoCallParticipantModifier: ViewModifier {
+
+            var participant: CallParticipant
+            var call: Call?
+            var availableFrame: CGRect
+            var ratio: CGFloat
+            var showAllInfo: Bool
+
+            public init(
+                participant: CallParticipant,
+                call: Call?,
+                availableFrame: CGRect,
+                ratio: CGFloat,
+                showAllInfo: Bool
+            ) {
+                self.participant = participant
+                self.call = call
+                self.availableFrame = availableFrame
+                self.ratio = ratio
+                self.showAllInfo = showAllInfo
+            }
+
+            public func body(content: Content) -> some View {
+                content
+            }
+        }
+
+        func makeVideoCallParticipantModifier(
+            participant: CallParticipant,
+            call: Call?,
+            availableFrame: CGRect,
+            ratio: CGFloat,
+            showAllInfo: Bool
+        ) -> some ViewModifier {
+            CustomVideoCallParticipantModifier(
+                participant: participant,
+                call: call,
+                availableFrame: availableFrame,
+                ratio: ratio,
+                showAllInfo: showAllInfo
+            )
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/14-livestream-player.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/14-livestream-player.swift
@@ -1,0 +1,19 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    viewContainer {
+        LivestreamPlayer(type: "livestream", id: "some_id")
+    }
+
+    viewContainer {
+        NavigationLink {
+            LivestreamPlayer(type: "livestream", id: "vQyteZAnDYYk")
+        } label: {
+            Text("Join stream")
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/15-long-press-to-focus.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/15-long-press-to-focus.swift
@@ -1,0 +1,88 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        // Create the call with the callType and id
+        let call = streamVideo.call(callType: "default", callId: "123")
+
+        // Create the call on server side
+        let creationResult = try await call.create()
+
+        // Join the call
+        let joinResult = try await call.join()
+    }
+
+    asyncContainer {
+        // Retrieve the desired focus point(e.g using a tap or longPress gesture)
+        let focusPoint: CGPoint = CGPoint(x: 50, y: 50)
+
+        // and pass it to our call
+        try call.focus(at: focusPoint)
+    }
+
+    container {
+        struct LongPressToFocusViewModifier: ViewModifier {
+
+            var availableFrame: CGRect
+
+            var handler: (CGPoint) -> Void
+
+            func body(content: Content) -> some View {
+                content
+                    .gesture(
+                        LongPressGesture(minimumDuration: 0.5)
+                            .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .local))
+                            .onEnded { value in
+                                switch value {
+                                case .second(true, let drag):
+                                    if let location = drag?.location {
+                                        handler(convertToPointOfInterest(location))
+                                    }
+                                default:
+                                    break
+                                }
+                            }
+                    )
+            }
+
+            func convertToPointOfInterest(_ point: CGPoint) -> CGPoint {
+                CGPoint(
+                    x: point.y / availableFrame.height,
+                    y: 1.0 - point.x / availableFrame.width
+                )
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeVideoParticipantView(
+                participant: CallParticipant,
+                id: String,
+                availableFrame: CGRect,
+                contentMode: UIView.ContentMode,
+                customData: [String : RawJSON],
+                call: Call?
+            ) -> some View {
+                DefaultViewFactory.shared.makeVideoParticipantView(
+                    participant: participant,
+                    id: id,
+                    availableFrame: availableFrame,
+                    contentMode: contentMode,
+                    customData: customData,
+                    call: call
+                )
+                .longPressToFocus(availableFrame: availableFrame) {
+                    guard call?.state.sessionId == participant.sessionId else { return } // We are using this to only allow long pressing on our local video feed
+                    try? call?.focus(at: $0)
+                }
+            }
+
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/00-ringing.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/00-ringing.swift
@@ -1,0 +1,37 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: callId)
+        let callResponse = try await call.create(members: members, ring: true)
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: callId)
+        let callResponse = try await call.get(ring: true)
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: callId)
+        let callResponse = try await call.ring()
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: callId)
+        let callResponse = try await call.create(members: members, notify: true)
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: callId)
+        let callResponse = try await call.get(notify: true)
+    }
+
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: callId)
+        let callResponse = try await call.notify()
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/01-deeplinking.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/01-deeplinking.swift
@@ -1,0 +1,36 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        YourView()
+            .onOpenURL { url in
+                handleDeepLink(from: url)
+            }
+
+        func handleDeepLink(from url: URL) {
+            if appState.userState == .notLoggedIn {
+                return
+            }
+            let callId = url.lastPathComponent
+            let queryParams = url.queryParameters
+            let callType = queryParams["type"] ?? "default"
+            appState.deeplinkInfo = DeeplinkInfo(callId: callId, callType: callType)
+        }
+    }
+
+    viewContainer {
+        var callViewModel = viewModel
+
+        ViewThatHostsCall()
+            .onReceive(appState.$deeplinkInfo, perform: { deeplinkInfo in
+                if deeplinkInfo != .empty {
+                    callViewModel.joinCall(callType: deeplinkInfo.callType, callId: deeplinkInfo.callId)
+                    appState.deeplinkInfo = .empty
+                }
+            })
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/02-push-notifications.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/02-push-notifications.swift
@@ -1,0 +1,29 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+import CallKit
+import PushKit
+
+@MainActor
+fileprivate func content() {
+    container {
+        class VoIPPushService: NSObject, PKPushRegistryDelegate {
+
+            @Injected(\.streamVideo) var streamVideo
+
+            private let queue: DispatchQueue
+            private let registry: PKPushRegistry
+            private let tokenHandler: VoIPTokenHandler
+
+            var onReceiveIncomingPush: VoIPPushHandler
+
+            init(voIPTokenHandler: VoIPTokenHandler, pushHandler: @escaping VoIPPushHandler) {
+                self.tokenHandler = voIPTokenHandler
+                self.queue = DispatchQueue(label: "io.getstream.voip")
+                self.registry = PKPushRegistry(queue: queue)
+                self.onReceiveIncomingPush = pushHandler
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/02-push-notifications.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/02-push-notifications.swift
@@ -5,6 +5,8 @@ import Combine
 import CallKit
 import PushKit
 
+typealias VoIPPushHandler = ((PKPushPayload, PKPushType, () -> Void)) -> ()
+
 @MainActor
 fileprivate func content() {
     container {
@@ -23,6 +25,83 @@ fileprivate func content() {
                 self.queue = DispatchQueue(label: "io.getstream.voip")
                 self.registry = PKPushRegistry(queue: queue)
                 self.onReceiveIncomingPush = pushHandler
+            }
+
+            func registerForVoIPPushes() {
+                self.registry.delegate = self
+                self.registry.desiredPushTypes = [.voIP]
+            }
+
+            func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
+                print(credentials.token)
+                let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()
+                log.debug("pushRegistry deviceToken = \(deviceToken)")
+                Task {
+                    await MainActor.run(body: {
+                        AppState.shared.voIPPushToken = deviceToken
+                    })
+                }
+            }
+
+            func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
+                log.debug("pushRegistry:didInvalidatePushTokenForType:")
+                if let savedToken = tokenHandler.currentVoIPPushToken() {
+                    Task {
+                        try await streamVideo.deleteDevice(id: savedToken)
+                        tokenHandler.save(voIPPushToken: nil)
+                    }
+                }
+            }
+
+            func pushRegistry(
+                _ registry: PKPushRegistry,
+                didReceiveIncomingPushWith payload: PKPushPayload,
+                for type: PKPushType,
+                completion: @escaping () -> Void
+            ) {
+                self.onReceiveIncomingPush((payload, type, completion))
+            }
+        }
+
+        final class CallService {
+
+            static let shared = CallService()
+
+            let callService = CallKitService()
+            lazy var voIPPushService = makeVoIPPushService()
+
+            private init() {}
+
+            func registerForIncomingCalls() {
+            #if targetEnvironment(simulator)
+                log.info("CallKit notifications not working on a simulator")
+            #else
+                voIPPushService.registerForVoIPPushes()
+            #endif
+            }
+
+            private func makeVoIPPushService() -> VoIPPushService {
+                let defaultCallText = "Unknown Caller"
+
+                return .init(voIPTokenHandler: AppState.shared.unsecureRepository) { [weak self] payload, type, completion in
+                    guard let self = self else {
+                        completion()
+                        return
+                    }
+
+                    let streamDict = payload.dictionaryPayload["stream"] as? [String: Any]
+                    let callCid = streamDict?["call_cid"] as? String ?? "unknown"
+                    let createdByName = streamDict?["created_by_display_name"] as? String ?? defaultCallText
+                    let createdById = streamDict?["created_by_id"] as? String ?? defaultCallText
+
+                    self.callService.reportIncomingCall(
+                        callCid: callCid,
+                        displayName: createdByName,
+                        callerId: createdById
+                    ) { _ in
+                        completion()
+                    }
+                }
             }
         }
     }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -1,0 +1,8 @@
+//
+//  03-callkit-integration.swift
+//  DocumentationTests
+//
+//  Created by Ilias Pavlidakis on 29/1/24.
+//
+
+import Foundation

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/04-screensharing.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/04-screensharing.swift
@@ -1,0 +1,110 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        Task {
+            let call = streamVideo.call(callType: "default", callId: "123")
+            try await call.join()
+            try await call.startScreensharing(type: .inApp)
+        }
+    }
+
+    asyncContainer {
+        Task {
+            try await call.stopScreensharing()
+        }
+    }
+
+    viewContainer {
+        VideoRendererView(
+            id: "\(participant.id)-screenshare",
+            size: videoSize,
+            contentMode: .scaleAspectFit
+        ) { view in
+            if let track = participant.screenshareTrack {
+                log.debug("adding screensharing track to a view \(view)")
+                view.add(track: track)
+            }
+        }
+    }
+
+    container {
+        class CustomViewFactory: ViewFactory {
+
+            func makeScreenSharingView(
+                    viewModel: CallViewModel,
+                    screensharingSession: ScreenSharingSession,
+                    availableFrame: CGRect
+            ) -> some View {
+                CustomScreenSharingView(
+                    viewModel: viewModel,
+                    screenSharing: screensharingSession,
+                    availableFrame: availableFrame
+                )
+            }
+        }
+    }
+
+    viewContainer {
+        ScreenshareIconView(viewModel: viewModel)
+    }
+
+    viewContainer {
+        BroadcastIconView(
+            viewModel: viewModel,
+            preferredExtension: "bundle_id_of_broadcast_upload_extension"
+        )
+    }
+
+    container {
+        struct BroadcastIconView: View {
+
+            var call: Call
+            @StateObject var broadcastObserver = BroadcastObserver()
+            let size: CGFloat
+            let preferredExtension: String
+
+            public init(
+                call: Call,
+                preferredExtension: String,
+                size: CGFloat = 50
+            ) {
+                self.call = call
+                self.preferredExtension = preferredExtension
+                self.size = size
+            }
+
+            public var body: some View {
+                BroadcastPickerView(
+                    preferredExtension: preferredExtension
+                )
+                .onChange(of: broadcastObserver.broadcastState, perform: { newValue in
+                    if newValue == .started {
+                        startScreensharing()
+                    } else if newValue == .finished {
+                        stopScreensharing()
+                    }
+                })
+                .onAppear {
+                    broadcastObserver.observe()
+                }
+            }
+
+            private func startScreensharing() {
+                Task {
+                    try await call.startScreensharing(type: .broadcast)
+                }
+            }
+
+            private func stopScreensharing() {
+                Task {
+                    try await call.stopScreensharing()
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/05-picture-in-picture.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/05-picture-in-picture.swift
@@ -1,0 +1,18 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        struct CallView<Factory: ViewFactory>: View {
+            @ObservedObject var viewModel: CallViewModel
+
+            public var body: some View {
+                YourHostView()
+                    .enablePictureInPicture(viewModel.isPictureInPictureEnabled)
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/08-recording.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/08-recording.swift
@@ -1,0 +1,73 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+import AVKit
+
+@MainActor
+fileprivate func content() {
+    container {
+        func startRecording() {
+            Task {
+                try await call.startRecording()
+            }
+        }
+    }
+
+    container {
+        func stopRecording() {
+            Task {
+                try await call.stopRecording()
+            }
+        }
+    }
+
+    container {
+        func subscribeToRecordingEvents() {
+            Task {
+                for await event in call.subscribe() {
+                    switch event {
+                        case .typeCallRecordingStartedEvent(let recordingStartedEvent):
+                            log.debug("received an event \(recordingStartedEvent)")
+                            /* handle recording event */
+                        case .typeCallRecordingStoppedEvent(let recordingStoppedEvent):
+                            log.debug("received an event \(recordingStoppedEvent)")
+                            /* handle recording event */
+                        default:
+                            break
+                    }
+                }
+            }
+        }
+    }
+
+    container {
+        final class CustomObject {
+
+            var recordings: [CallRecording] = []
+
+            func loadRecordings() {
+                Task {
+                    self.recordings = try await call.listRecordings()
+                }
+            }
+        }
+    }
+
+    container {
+        struct PlayerView: View {
+
+            let recording: CallRecording
+
+            var body: some View {
+                Group {
+                    if let url = URL(string: recording.url) {
+                        VideoPlayer(player: AVPlayer(url:  url))
+                    } else {
+                        Text("Video can't be loaded")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/09-broadcasting.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/09-broadcasting.swift
@@ -1,0 +1,37 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        let call = streamVideo.call(callType: .default, callId: callId)
+        Task {
+            try await call.join()
+        }
+    }
+
+    asyncContainer {
+        let call = try await call.create(members: members, custom: [:], startsAt: Date(), ring: false)
+    }
+
+    asyncContainer {
+        try await call.startHLS()
+    }
+
+    asyncContainer {
+        for await event in call.subscribe() {
+            switch event {
+                case .typeCallHLSBroadcastingStartedEvent(let broadcastingStartedEvent):
+                    log.debug("received an event \(broadcastingStartedEvent)")
+                    /* handle recording event */
+                case .typeCallHLSBroadcastingStoppedEvent(let broadcastingStoppedEvent):
+                    log.debug("received an event \(broadcastingStoppedEvent)")
+                    /* handle recording event */
+                default:
+                    break
+            }
+        }
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/ChatGloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/ChatGloballyUsedVariables.swift
@@ -1,0 +1,12 @@
+import StreamChatSwiftUI
+import StreamChat
+
+final class ChatViewFactory: ViewFactory {
+    var chatClient: ChatClient
+
+    init(chatClient: ChatClient) {
+        self.chatClient = chatClient
+    }
+
+    static let shared = ChatViewFactory(chatClient: .init(config: .init(apiKey: .init(""))))
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/DocumentationTests.h
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/DocumentationTests.h
@@ -1,0 +1,18 @@
+//
+//  DocumentationTests.h
+//  DocumentationTests
+//
+//  Created by Ilias Pavlidakis on 26/1/24.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for DocumentationTests.
+FOUNDATION_EXPORT double DocumentationTestsVersionNumber;
+
+//! Project version string for DocumentationTests.
+FOUNDATION_EXPORT const unsigned char DocumentationTestsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <DocumentationTests/PublicHeader.h>
+
+

--- a/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
@@ -1,0 +1,33 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+
+var apiKey = ""
+var user = User(id: "")
+var token = UserToken(stringLiteral: "")
+var tokenProvider: UserTokenProvider = { _ in }
+var streamVideo = StreamVideo(apiKey: apiKey, user: user, token: token)
+var call = streamVideo.call(callType: "default", callId: UUID().uuidString)
+@MainActor var viewModel = CallViewModel()
+@MainActor var viewFactory = DefaultViewFactory.shared
+
+func container(_ content: () -> Void) {}
+func asyncContainer(_ content: () async throws -> Void) {}
+func viewContainer(@ViewBuilder _ content: () -> some View) {}
+
+struct UserCredentials {
+    let user: User
+    let token: UserToken
+}
+
+extension UserCredentials {
+    static let demoUser = UserCredentials(
+        user: User(
+            id: "testuser",
+            name: "Test User",
+            imageURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg")!,
+            customData: [:]
+        ),
+        token: UserToken(rawValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlYW0tdmlkZW8tZ29AdjAuMS4wIiwic3ViIjoidXNlci90ZXN0dXNlciIsImlhdCI6MTY2NjY5ODczMSwidXNlcl9pZCI6InRlc3R1c2VyIn0.h4lnaF6OFYaNPjeK8uFkKirR5kHtj1vAKuipq3A5nM0")
+    )
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
@@ -62,10 +62,10 @@ extension UserCredentials {
         user: User(
             id: "testuser",
             name: "Test User",
-            imageURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg")!,
+            imageURL: URL(string: "")!,
             customData: [:]
         ),
-        token: UserToken(rawValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlYW0tdmlkZW8tZ29AdjAuMS4wIiwic3ViIjoidXNlci90ZXN0dXNlciIsImlhdCI6MTY2NjY5ODczMSwidXNlcl9pZCI6InRlc3R1c2VyIn0.h4lnaF6OFYaNPjeK8uFkKirR5kHtj1vAKuipq3A5nM0")
+        token: UserToken(rawValue: "")
     )
 }
 
@@ -127,6 +127,11 @@ struct CustomCallTopView: View {
     var body: some View { EmptyView() }
 }
 
+struct HomeView: View {
+    var viewModel: CallViewModel
+    var body: some View { EmptyView() }
+}
+
 struct CustomScreenSharingView: View {
     var viewModel: CallViewModel
     var screenSharing: ScreenSharingSession
@@ -158,6 +163,7 @@ struct SomeOtherView: View { var body: some View { EmptyView() } }
 struct YourView: View { var body: some View { EmptyView() } }
 struct YourHostingView: View { var body: some View { EmptyView() } }
 struct YourHostView: View { var body: some View { EmptyView() } }
+struct ViewThatHostsCall: View { var body: some View { EmptyView() } }
 struct ViewThatHostsCall: View { var body: some View { EmptyView() } }
 
 struct LongPressToFocusViewModifier: ViewModifier {

--- a/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
@@ -15,6 +15,7 @@ var utils = Utils()
 @MainActor var viewFactory = DefaultViewFactory.shared
 var availableFrame = CGRect.zero
 var availableSize = CGSize.zero
+var videoSize = CGSize.zero
 var participant = CallParticipant(
     id: "",
     userId: "",
@@ -228,7 +229,19 @@ final class AppState: ObservableObject {
     var voIPPushToken: String?
     var pushToken: String?
 
+    let unsecureRepository = UnsecureRepository()
+
     static var shared = AppState()
+}
+
+final class UnsecureRepository: VoIPTokenHandler {
+    func save(voIPPushToken: String?) {
+
+    }
+    
+    func currentVoIPPushToken() -> String? {
+        nil
+    }
 }
 
 var appState = AppState()
@@ -251,4 +264,14 @@ protocol VoIPTokenHandler {
 
     func currentVoIPPushToken() -> String?
 
+}
+
+final class CallKitService {
+    
+    func reportIncomingCall(
+        callCid: String,
+        displayName: String,
+        callerId: String,
+        completion: @escaping (Error?) -> Void
+    ) {}
 }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
@@ -157,7 +157,7 @@ struct SomeOtherView: View { var body: some View { EmptyView() } }
 struct YourView: View { var body: some View { EmptyView() } }
 struct YourHostingView: View { var body: some View { EmptyView() } }
 struct YourHostView: View { var body: some View { EmptyView() } }
-final class AppState: ObservableObject {}
+struct ViewThatHostsCall: View { var body: some View { EmptyView() } }
 
 struct LongPressToFocusViewModifier: ViewModifier {
 
@@ -204,4 +204,51 @@ extension View {
             )
         )
     }
+}
+
+struct DeeplinkInfo: Equatable {
+    var url: URL?
+    var callId: String
+    var callType: String
+
+    static let empty = DeeplinkInfo(callId: "", callType: "")
+}
+
+final class AppState: ObservableObject {
+
+    enum UserState { case notLoggedIn, loggedIn }
+
+    var apiKey: String = ""
+    var userState: UserState = .notLoggedIn
+    @Published var deeplinkInfo: DeeplinkInfo = .empty
+    var currentUser: User?
+    var loading = false
+    var activeCall: Call?
+    var activeAnonymousCallId: String = ""
+    var voIPPushToken: String?
+    var pushToken: String?
+
+    static var shared = AppState()
+}
+
+var appState = AppState()
+
+extension URL {
+
+    var queryParameters: [String: String] {
+        guard
+            let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+            let queryItems = components.queryItems else { return [:] }
+        return queryItems.reduce(into: [String: String]()) { (result, item) in
+            result[item.name] = item.value
+        }
+    }
+}
+
+protocol VoIPTokenHandler {
+
+    func save(voIPPushToken: String?)
+
+    func currentVoIPPushToken() -> String?
+
 }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
@@ -5,15 +5,51 @@ import SwiftUI
 var apiKey = ""
 var user = User(id: "")
 var token = UserToken(stringLiteral: "")
+var callId = ""
 var tokenProvider: UserTokenProvider = { _ in }
 var streamVideo = StreamVideo(apiKey: apiKey, user: user, token: token)
+var streamVideoUI = StreamVideoUI(streamVideo: streamVideo)
 var call = streamVideo.call(callType: "default", callId: UUID().uuidString)
+var utils = Utils()
 @MainActor var viewModel = CallViewModel()
 @MainActor var viewFactory = DefaultViewFactory.shared
+var availableFrame = CGRect.zero
+var availableSize = CGSize.zero
+var participant = CallParticipant(
+    id: "",
+    userId: "",
+    roles: [],
+    name: "",
+    profileImageURL: nil,
+    trackLookupPrefix: nil,
+    hasVideo: false,
+    hasAudio: false,
+    isScreenSharing: false,
+    showTrack: false,
+    isDominantSpeaker: false,
+    sessionId: "",
+    connectionQuality: .unknown,
+    joinedAt: .init(),
+    audioLevel: 0,
+    audioLevels: [],
+    pin: nil
+)
+var contentMode = UIView.ContentMode.scaleAspectFit
+var id = ""
+var customData = [String: RawJSON]()
+var ratio: CGFloat = 0
+var onChangeTrackVisibility: @MainActor(CallParticipant, Bool) -> Void = { _, _ in }
+var orientation: UIInterfaceOrientation = .unknown
+var localParticipant = participant
+var reader: GeometryProxy!
+var participants = [participant]
+var imageURL: URL!
+var members: [MemberRequest] = []
 
 func container(_ content: () -> Void) {}
 func asyncContainer(_ content: () async throws -> Void) {}
 func viewContainer(@ViewBuilder _ content: () -> some View) {}
+func classContainer<V: AnyObject>(_ content: (V) -> Void) {}
 
 struct UserCredentials {
     let user: User
@@ -30,4 +66,142 @@ extension UserCredentials {
         ),
         token: UserToken(rawValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlYW0tdmlkZW8tZ29AdjAuMS4wIiwic3ViIjoidXNlci90ZXN0dXNlciIsImlhdCI6MTY2NjY5ODczMSwidXNlcl9pZCI6InRlc3R1c2VyIn0.h4lnaF6OFYaNPjeK8uFkKirR5kHtj1vAKuipq3A5nM0")
     )
+}
+
+class CustomType {
+    // your custom logic here
+}
+struct CustomInjectionKey: InjectionKey {
+    static var currentValue: CustomType = CustomType()
+}
+extension InjectedValues {
+    /// Provides access to the `CustomType` instance in the views and view models.
+    var customType: CustomType {
+        get {
+            Self[CustomInjectionKey.self]
+        }
+        set {
+            Self[CustomInjectionKey.self] = newValue
+        }
+    }
+}
+
+final class CustomViewFactory: ViewFactory {}
+final class VideoWithChatViewFactory: ViewFactory {
+    static let shared = VideoWithChatViewFactory()
+}
+struct YourRootView: View { @ViewBuilder var body: some View { EmptyView() } }
+var outgoingCallMembers = [Member]()
+@MainActor var callControls = CallControlsView(viewModel: viewModel)
+@MainActor var callTopView = CallTopView(viewModel: viewModel)
+struct CustomOutgoingCallView: View {
+    var viewModel: CallViewModel
+    var body: some View { EmptyView() }
+}
+
+struct CustomIncomingCallView: View {
+    var viewModel: CallViewModel
+    var callInfo: IncomingCall
+    var body: some View { EmptyView() }
+}
+
+struct CustomCallView<Factory: ViewFactory>: View {
+    var viewFactory: Factory
+    var viewModel: CallViewModel
+    var body: some View { EmptyView() }
+}
+
+struct CustomCallControlsView: View {
+    var viewModel: CallViewModel
+    var body: some View { EmptyView() }
+}
+
+struct ChatCallControls: View {
+    var viewModel: CallViewModel
+    var body: some View { EmptyView() }
+}
+
+struct CustomCallTopView: View {
+    var viewModel: CallViewModel
+    var body: some View { EmptyView() }
+}
+
+struct CustomScreenSharingView: View {
+    var viewModel: CallViewModel
+    var screenSharing: ScreenSharingSession
+    var availableFrame: CGRect
+    var body: some View { EmptyView() }
+}
+
+struct CustomVideoParticipantsView<Factory: ViewFactory>: View {
+    var viewFactory: Factory
+    var viewModel: CallViewModel
+    var availableFrame: CGRect
+    var onChangeTrackVisibility: (CallParticipant, Bool) -> Void
+    var body: some View { EmptyView() }
+}
+
+struct CustomCallParticipantsInfoView: View {
+    var callViewModel: CallViewModel
+    var availableFrame: CGRect
+    var body: some View { EmptyView() }
+}
+
+final class MockUserListProvider: UserListProvider {
+    func loadNextUsers(pagination: StreamVideoSwiftUI.Pagination) async throws -> [User] {
+        []
+    }
+}
+
+struct SomeOtherView: View { var body: some View { EmptyView() } }
+struct YourView: View { var body: some View { EmptyView() } }
+struct YourHostingView: View { var body: some View { EmptyView() } }
+struct YourHostView: View { var body: some View { EmptyView() } }
+final class AppState: ObservableObject {}
+
+struct LongPressToFocusViewModifier: ViewModifier {
+
+    var availableFrame: CGRect
+
+    var handler: (CGPoint) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .gesture(
+                LongPressGesture(minimumDuration: 0.5)
+                    .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .local))
+                    .onEnded { value in
+                        switch value {
+                        case .second(true, let drag):
+                            if let location = drag?.location {
+                                handler(convertToPointOfInterest(location))
+                            }
+                        default:
+                            break
+                        }
+                    }
+            )
+    }
+
+    func convertToPointOfInterest(_ point: CGPoint) -> CGPoint {
+        CGPoint(
+            x: point.y / availableFrame.height,
+            y: 1.0 - point.x / availableFrame.width
+        )
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func longPressToFocus(
+        availableFrame: CGRect,
+        handler: @escaping (CGPoint) -> Void
+    ) -> some View {
+        modifier(
+            LongPressToFocusViewModifier(
+                availableFrame: availableFrame,
+                handler: handler
+            )
+        )
+    }
 }

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -11,6 +11,18 @@ public struct PermissionRequest: @unchecked Sendable, Identifiable {
     public let requestedAt: Date
     let onReject: (PermissionRequest) -> Void
     
+    public init(
+        permission: String,
+        user: User,
+        requestedAt: Date,
+        onReject: @escaping (PermissionRequest) -> Void = { _ in }
+    ) {
+        self.permission = permission
+        self.user = user
+        self.requestedAt = requestedAt
+        self.onReject = onReject
+    }
+
     public func reject() -> Void {
         onReject(self)
     }

--- a/Sources/StreamVideo/Models/PushNotificationsConfig.swift
+++ b/Sources/StreamVideo/Models/PushNotificationsConfig.swift
@@ -39,4 +39,9 @@ public extension PushNotificationsConfig {
 public struct PushProviderInfo: Sendable {
     public let name: String
     public let pushProvider: PushNotificationsProvider
+
+    public init(name: String, pushProvider: PushNotificationsProvider) {
+        self.name = name
+        self.pushProvider = pushProvider
+    }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
@@ -5,15 +5,21 @@
 import StreamVideo
 import SwiftUI
 
-struct CallParticipantImageView: View {
-    
+public struct CallParticipantImageView: View {
+
     @Injected(\.colors) var colors
     
     var id: String
     var name: String
     var imageURL: URL?
-    
-    var body: some View {
+
+    public init(id: String, name: String, imageURL: URL? = nil) {
+        self.id = id
+        self.name = name
+        self.imageURL = imageURL
+    }
+
+    public var body: some View {
         ZStack {
             CallParticipantBackground(imageURL: imageURL) {
                 Color(colors.participantBackground)

--- a/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
+++ b/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
@@ -7,7 +7,7 @@ import StreamVideo
 
 /// Represents an incoming call.
 public struct IncomingCall: Identifiable, Sendable, Equatable {
-    
+
     public static func == (lhs: IncomingCall, rhs: IncomingCall) -> Bool {
         lhs.id == rhs.id
     }
@@ -17,4 +17,18 @@ public struct IncomingCall: Identifiable, Sendable, Equatable {
     public let type: String
     public let members: [Member]
     public let timeout: TimeInterval
+
+    public init(
+        id: String,
+        caller: User,
+        type: String,
+        members: [Member],
+        timeout: TimeInterval
+    ) {
+        self.id = id
+        self.caller = caller
+        self.type = type
+        self.members = members
+        self.timeout = timeout
+    }
 }

--- a/docusaurus/docs/iOS/01-basics/03-quickstart.mdx
+++ b/docusaurus/docs/iOS/01-basics/03-quickstart.mdx
@@ -141,8 +141,8 @@ struct ContentView: View {
             Button {
                 resignFirstResponder()
                 callViewModel.startCall(
+                    callType: "default",
                     callId: callId,
-                    type: "default",
                     members: [/* Your list of participants goes here. */]
                 )
             } label: {
@@ -216,9 +216,7 @@ Next, when you attach the `CallModifier` to your hosting view, you need to injec
 In order to inject the `ViewFactory`, you will need to update the `CallModifier` initializer.
 
 ```swift
-struct ContentView: View {
-
-    @StateObject var callViewModel = CallViewModel()
+@StateObject var callViewModel = CallViewModel()
     @State var callId = ""
 
     var body: some View {
@@ -230,8 +228,8 @@ struct ContentView: View {
             Button {
                 resignFirstResponder()
                 callViewModel.startCall(
+                    callType: "default",
                     callId: callId,
-                    type: "default",
                     members: [/* Your list of participants goes here. */]
                 )
             } label: {
@@ -241,7 +239,6 @@ struct ContentView: View {
         .padding()
         .modifier(CallModifier(viewFactory: CustomViewFactory(), viewModel: callViewModel))
     }
-}
 ```
 
 For the full list of supported view slots that can be swapped, please refer to this [page](../../guides/view-slots).

--- a/docusaurus/docs/iOS/01-basics/03-quickstart.mdx
+++ b/docusaurus/docs/iOS/01-basics/03-quickstart.mdx
@@ -216,7 +216,7 @@ Next, when you attach the `CallModifier` to your hosting view, you need to injec
 In order to inject the `ViewFactory`, you will need to update the `CallModifier` initializer.
 
 ```swift
-@StateObject var callViewModel = CallViewModel()
+    @StateObject var callViewModel = CallViewModel()
     @State var callId = ""
 
     var body: some View {

--- a/docusaurus/docs/iOS/03-guides/02-joining-creating-calls.mdx
+++ b/docusaurus/docs/iOS/03-guides/02-joining-creating-calls.mdx
@@ -62,7 +62,7 @@ let result = try await call.create(
     startsAt: Calendar.current.date(byAdding: .day, value: 1, to: Date()),
     team: "stream",
     ring: true,
-    notify: false,
+    notify: false
 )
 ```
 
@@ -88,7 +88,7 @@ The following options are supported when creating a call:
 You can query the members of the call. This is helpful if you have thousands of members in a call and want to paginate.
 
 ```swift
-let filters = ["user_id": .string("jaewoong")]
+let filters: [String: RawJSON] = ["user_id": .string("jaewoong")]
 let response = try await call.queryMembers(
     filters: filters,
     sort: [SortParamRequest.descending("created_at")],

--- a/docusaurus/docs/iOS/03-guides/06-querying-calls.mdx
+++ b/docusaurus/docs/iOS/03-guides/06-querying-calls.mdx
@@ -17,14 +17,14 @@ let sort = [SortParamRequest.descending("created_at")]
 let limit = 10
 
 // Fetch the first page of calls 
-let (firstPageCalls, secondPageCursor) = try await client.queryCalls(
+let (firstPageCalls, secondPageCursor) = try await streamVideo.queryCalls(
     filters: filters, 
     sort: sort, 
     limit: limit
 )
 
 // Use the cursor we received from the previous call to fetch the second page
-let (secondPageCalls, _) = try await client.queryCalls(next: secondPageCursor)
+let (secondPageCalls, _) = try await streamVideo.queryCalls(next: secondPageCursor)
 ```
 
 ### CallsController
@@ -77,19 +77,71 @@ You can find the supported operators [here](https://getstream.io/chat/docs/ios-s
 
 #### Pagination
 
-You can fetch the next calls from the specified query, by calling the `loadNextCalls` method. For example, if you are doing pagination in SwiftUI, you can use the `onAppear` modifier on each entry, and based on its index fetch the next calls.
+You can encapsulae the querying calls login into an object `CallsViewModel` for simplicity and state management.
+```swift
+@MainActor
+final class CallsViewModel: ObservableObject {
+
+    @Injected(\.streamVideo) internal var streamVideo
+
+    @Published internal var calls = [Call]()
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private lazy var callsController: CallsController = {
+        let sortParam = CallSortParam(direction: .descending, field: .createdAt)
+        let filters: [String: RawJSON] = ["type": .dictionary(["$eq": .string("audio_room")])]
+        let callsQuery = CallsQuery(sortParams: [sortParam], filters: filters, watch: true)
+        return streamVideo.makeCallsController(callsQuery: callsQuery)
+    }()
+
+    init() {
+        subscribeToCallsUpdates()
+        loadCalls()
+    }
+
+    func onCallAppear(_ call: Call) {
+        let index = calls.firstIndex { callData in
+            callData.cId == call.cId
+        }
+        guard let index else { return }
+
+        if index < calls.count - 10 {
+            return
+        }
+
+        loadCalls()
+    }
+
+    func loadCalls() {
+        Task {
+            try await callsController.loadNextCalls()
+        }
+    }
+
+    func subscribeToCallsUpdates() {
+        callsController.$calls.sink { calls in
+            DispatchQueue.main.async {
+                self.calls = calls
+            }
+        }
+        .store(in: &cancellables)
+    }
+}
+```
+
+You can then fetch the next calls from the specified query, by calling the `loadNextCalls` method. For example, if you are doing pagination in SwiftUI, you can use the `onAppear` modifier on each entry, and based on its index fetch the next calls.
 
 First, in your SwiftUI view, you can call a method from your presentation layer (for example a view model), on the view item appearance:
 
 ```swift
+let callsViewModel = CallsViewModel()
+
 ScrollView {
     LazyVStack {
-        ForEach(viewModel.calls) { call in
-        	CallView(call: call)
-            	.padding(.vertical, 4)
-            	.onAppear {
-                	viewModel.onCallAppear(call)
-            	}
+        ForEach(callsViewModel.calls, id: \.callId) { call in
+            CallView(viewFactory: viewFactory, viewModel: viewModel)
+                .padding(.vertical, 4)
         }
     }
 }

--- a/docusaurus/docs/iOS/03-guides/06-querying-calls.mdx
+++ b/docusaurus/docs/iOS/03-guides/06-querying-calls.mdx
@@ -77,7 +77,7 @@ You can find the supported operators [here](https://getstream.io/chat/docs/ios-s
 
 #### Pagination
 
-You can encapsulae the querying calls login into an object `CallsViewModel` for simplicity and state management.
+You can encapsulate the querying calls login into an object `CallsViewModel` for simplicity and state management.
 ```swift
 @MainActor
 final class CallsViewModel: ObservableObject {
@@ -135,8 +135,6 @@ You can then fetch the next calls from the specified query, by calling the `load
 First, in your SwiftUI view, you can call a method from your presentation layer (for example a view model), on the view item appearance:
 
 ```swift
-let callsViewModel = CallsViewModel()
-
 ScrollView {
     LazyVStack {
         ForEach(callsViewModel.calls, id: \.callId) { call in

--- a/docusaurus/docs/iOS/03-guides/08-permissions-and-moderation.mdx
+++ b/docusaurus/docs/iOS/03-guides/08-permissions-and-moderation.mdx
@@ -36,7 +36,7 @@ if let request = call.state.permissionRequests.first {
 You can also grant permissions directly using call.grantPermissions() method like the example below:
 
 ```swift
-call.grant(permissions: [.sendAudio] for: "thrierry")
+try await call.grant(permissions: [.sendAudio], for: "thrierry")
 ```
 
 You can request the following 3 permissions: `send-audio`, `send-video`, and `screenshare`.

--- a/docusaurus/docs/iOS/03-guides/10-view-slots.mdx
+++ b/docusaurus/docs/iOS/03-guides/10-view-slots.mdx
@@ -11,6 +11,7 @@ In most of these slots, the whole `CallViewModel` is provided, allowing you to u
 In order to swap the outgoing call view, we will need to implement the `makeOutgoingCallView(viewModel: CallViewModel) -> some View` in the `ViewFactory`:
 
 ```swift
+
 class CustomViewFactory: ViewFactory {
 
 	func makeOutgoingCallView(viewModel: CallViewModel) -> some View {
@@ -60,12 +61,13 @@ The video participants view slot presents the grid of users that are in the call
 
 ```swift
 public func makeVideoParticipantsView(
-    participants: [CallParticipant],
+    viewModel: CallViewModel,
     availableFrame: CGRect,
     onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
 ) -> some View {
     VideoParticipantsView(
-        participants: participants,
+        viewFactory: self,
+        viewModel: viewModel,
         availableFrame: availableFrame,
         onChangeTrackVisibility: onChangeTrackVisibility
     )
@@ -74,7 +76,7 @@ public func makeVideoParticipantsView(
 
 In the method, the following parameters are provided:
 
-- `participants` - the list of participants.
+- `viewModel` - the viewModel that manages the call.
 - `availableFrame` - the available frame for the participants view.
 - `onChangeTrackVisibility` - callback when the track changes its visibility.
 
@@ -96,6 +98,7 @@ func makeVideoParticipantView(
         id: id,
         availableFrame: availableFrame,
         contentMode: contentMode,
+        customData: customData, 
         call: call
     )
 }
@@ -104,7 +107,7 @@ func makeVideoParticipantView(
 Additionally, you can change the modifier applied to the view, by implementing the `makeVideoCallParticipantModifier`:
 
 ```swift
-public makeVideoCallParticipantModifier(
+public func makeVideoCallParticipantModifier(
         participant: CallParticipant,
         call: Call?,
         availableFrame: CGRect,

--- a/docusaurus/docs/iOS/03-guides/12-call-state.mdx
+++ b/docusaurus/docs/iOS/03-guides/12-call-state.mdx
@@ -48,6 +48,7 @@ public var body: some View {
 Similarly, you can listen to the UI changes via the `@Published` property in UIKit:
 
 ```swift
+@MainActor
 private func listenToIncomingCalls() {
     callViewModel.$callingState.sink { [weak self] newState in
         guard let self = self else { return }
@@ -61,6 +62,37 @@ private func listenToIncomingCalls() {
     .store(in: &cancellables)
 }
 ```
+
+:::note
+An example implementation of `CallViewHelper` can be seen below:
+
+```swift
+class CallViewHelper {
+    
+    static let shared = CallViewHelper()
+    
+    private var callView: UIView?
+    
+    private init() {}
+    
+    func add(callView: UIView) {
+        guard self.callView == nil else { return }
+        guard let window = UIApplication.shared.windows.first else {
+            return
+        }
+        callView.isOpaque = false
+        callView.backgroundColor = UIColor.clear
+        self.callView = callView
+        window.addSubview(callView)
+    }
+    
+    func removeCallView() {
+        callView?.removeFromSuperview()
+        callView = nil
+    }
+}
+```
+:::
 
 ### Call Settings
 

--- a/docusaurus/docs/iOS/03-guides/14-swiftui-vs-uikit.mdx
+++ b/docusaurus/docs/iOS/03-guides/14-swiftui-vs-uikit.mdx
@@ -26,11 +26,10 @@ struct CallView: View {
     }
 
     var body: some View {
-        HomeView(viewModel: viewModel)
+        Color.clear // You can use any of your views.
             .modifier(CallModifier(viewModel: viewModel))
     }
 }
-
 ```
 
 With this setup, the `CallViewModel` will listen to incoming call events and present the appropriate UI, based on the state.
@@ -49,7 +48,7 @@ The UIKit SDK provides UIKit wrappers around the SwiftUI views. Its main integra
 private func didTapStartButton() {
     let next = CallViewController.make(with: callViewModel)
     next.modalPresentationStyle = .fullScreen
-    next.startCall(callId: text, type: "default", members: selectedParticipants)
+    next.startCall(callType: "default", callId: text, members: selectedParticipants)
     self.navigationController?.present(next, animated: true)
 }
 ```

--- a/docusaurus/docs/iOS/03-guides/14-swiftui-vs-uikit.mdx
+++ b/docusaurus/docs/iOS/03-guides/14-swiftui-vs-uikit.mdx
@@ -26,7 +26,7 @@ struct CallView: View {
     }
 
     var body: some View {
-        Color.clear // You can use any of your views.
+        HomeView(viewModel: viewModel)
             .modifier(CallModifier(viewModel: viewModel))
     }
 }

--- a/docusaurus/docs/iOS/03-guides/15-migration-from-dolby.mdx
+++ b/docusaurus/docs/iOS/03-guides/15-migration-from-dolby.mdx
@@ -102,8 +102,6 @@ private let token: String = "" // The Token can be found in the Credentials sect
 private let userId: String = "" // The User Id can be found in the Credentials section
 private let callId: String = "" // The CallId can be found in the Credentials section
 
-/// ...
-
 let user = User(
    id: userId,
    name: "Obi-Wan Kenobi", // name and imageURL are used in the UI

--- a/docusaurus/docs/iOS/03-guides/15-migration-from-dolby.mdx
+++ b/docusaurus/docs/iOS/03-guides/15-migration-from-dolby.mdx
@@ -102,6 +102,8 @@ private let token: String = "" // The Token can be found in the Credentials sect
 private let userId: String = "" // The User Id can be found in the Credentials section
 private let callId: String = "" // The CallId can be found in the Credentials section
 
+/// ...
+
 let user = User(
    id: userId,
    name: "Obi-Wan Kenobi", // name and imageURL are used in the UI
@@ -221,7 +223,7 @@ import SwiftUI
 import StreamVideo
 
 @main
-struct Audio roomsApp: App {
+struct AudioroomsApp: App {
     @State var call: Call
     @ObservedObject var state: CallState
     @State private var callCreated: Bool = false

--- a/docusaurus/docs/iOS/04-ui-components/02-video-renderer.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/02-video-renderer.mdx
@@ -22,7 +22,7 @@ VideoRendererView(
     size: availableSize,
     contentMode: contentMode
 ) { view in
-	view.handleViewRendering(participant) { size, participant in
+	view.handleViewRendering(for: participant) { size, participant in
 		// handle track size update
 	}
 }
@@ -53,7 +53,6 @@ extension VideoRenderer {
             }
         }
     }
-
 }
 ```
 

--- a/docusaurus/docs/iOS/04-ui-components/05-uikit-customizations.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/05-uikit-customizations.mdx
@@ -48,6 +48,7 @@ One option is to use the standard navigation patterns, such as pushing or presen
 Here's one example implementation that adds the view in the application window (this is needed in case you want to also navigate throughout your app while in a call):
 
 ```swift
+@MainActor
 class CallViewHelper {
 
     static let shared = CallViewHelper()
@@ -79,7 +80,7 @@ Finally, in your app, you can add the `CallViewController` with the following co
 ```swift
 @objc private func didTapStartButton() {
     let next = CallChatViewController.makeCallChatController(with: self.callViewModel)
-    next.startCall(callId: text, type: "default", members: selectedParticipants)
+    next.startCall(callType: "default", callId: text, members: selectedParticipants)
     CallViewHelper.shared.add(callView: next.view)
 }
 ```
@@ -133,43 +134,44 @@ struct ChatCallControls: View {
 
     public var body: some View {
         VStack {
-            EqualSpacingHStack(views: [
-                AnyView(
-                    Button(
-                        action: {
-                            withAnimation {
-                                chatHelper.chatShown.toggle()
-                            }
-                        },
-                        label: {
-                            CallIconView(
-                                icon: Image(systemName: "message"),
-                                size: size,
-                                iconStyle: chatHelper.chatShown ? .primary : .transparent
-                            )
-                            .overlay(
-                                chatHelper.unreadCount > 0 ?
-                                    TopRightView(content: {
-                                        UnreadIndicatorView(unreadCount: chatHelper.unreadCount)
-                                    })
-                                : nil
-                            )
+            HStack {
+                Button(
+                    action: {
+                        withAnimation {
+                            chatHelper.chatShown.toggle()
                         }
-                    )),
-                AnyView(
-                    Button(
-                        action: {
-                            viewModel.toggleCameraEnabled()
-                        },
-                        label: {
-                            CallIconView(
-                                icon: (viewModel.callSettings.videoOn ? images.videoTurnOn : images.videoTurnOff),
-                                size: size,
-                                iconStyle: (viewModel.callSettings.videoOn ? .primary : .transparent)
-                            )
-                        }
-                    )),
-                AnyView(Button(
+                    },
+                    label: {
+                        CallIconView(
+                            icon: Image(systemName: "message"),
+                            size: size,
+                            iconStyle: chatHelper.chatShown ? .primary : .transparent
+                        )
+                        .overlay(
+                            chatHelper.unreadCount > 0 ?
+                            TopRightView(content: {
+                                UnreadIndicatorView(unreadCount: chatHelper.unreadCount)
+                            })
+                            : nil
+                        )
+                    })
+                .frame(maxWidth: .infinity)
+
+                Button(
+                    action: {
+                        viewModel.toggleCameraEnabled()
+                    },
+                    label: {
+                        CallIconView(
+                            icon: (viewModel.callSettings.videoOn ? images.videoTurnOn : images.videoTurnOff),
+                            size: size,
+                            iconStyle: (viewModel.callSettings.videoOn ? .primary : .transparent)
+                        )
+                    }
+                )
+                .frame(maxWidth: .infinity)
+
+                Button(
                     action: {
                         viewModel.toggleMicrophoneEnabled()
                     },
@@ -180,8 +182,10 @@ struct ChatCallControls: View {
                             iconStyle: (viewModel.callSettings.audioOn ? .primary : .transparent)
                         )
                     }
-                )),
-                AnyView(Button(
+                )
+                .frame(maxWidth: .infinity)
+
+                Button(
                     action: {
                         viewModel.toggleCameraPosition()
                     },
@@ -192,8 +196,10 @@ struct ChatCallControls: View {
                             iconStyle: .primary
                         )
                     }
-                )),
-                AnyView(Button {
+                )
+                .frame(maxWidth: .infinity)
+
+                Button {
                     viewModel.hangUp()
                 } label: {
                     images.hangup
@@ -201,8 +207,9 @@ struct ChatCallControls: View {
                             color: colors.hangUpIconColor,
                             size: size
                         )
-                })
-            ])
+                }
+                .frame(maxWidth: .infinity)
+            }
 
             if chatHelper.chatShown {
                 if let channelController = chatHelper.channelController {
@@ -255,6 +262,17 @@ struct EqualSpacingHStack: View {
             }
         }
     }
+}
 
+final class ChatHelper: ObservableObject {
+    @Published var chatShown: Bool = false
+    @Published var unreadCount: Int = 0
+    @Published var channelController: ChatChannelController?
+
+    init() {}
+
+    func markAsRead() { /* Your implementation here */ }
+
+    func update(memberIds: Set<String>) { /* Your implementation here */ }
 }
 ```

--- a/docusaurus/docs/iOS/04-ui-components/06-view-model.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/06-view-model.mdx
@@ -28,7 +28,7 @@ Here's an example usage:
 
 ```swift
 Button {
-    viewModel.startCall(callId: callId, type: "default", members: members, ring: false)
+    viewModel.startCall(callType: "default", callId: callId, members: members, ring: false)
 } label: {
     Text("Start a call")
 }
@@ -47,7 +47,7 @@ Here's an example usage:
 
 ```swift
 Button {
-    viewModel.joinCall(callId: callId, type: "default")
+    viewModel.joinCall(callType: "default", callId: callId)
 } label: {
     Text("Join a call")
 }

--- a/docusaurus/docs/iOS/04-ui-components/07-call/04-active-call.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/07-call/04-active-call.mdx
@@ -42,12 +42,13 @@ The video participants view slot presents the grid of users that are in the call
 
 ```swift
 public func makeVideoParticipantsView(
-    participants: [CallParticipant],
+    viewModel: CallViewModel,
     availableFrame: CGRect,
     onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
 ) -> some View {
     VideoParticipantsView(
-        participants: participants,
+        viewFactory: self,
+        viewModel: viewModel,
         availableFrame: availableFrame,
         onChangeTrackVisibility: onChangeTrackVisibility
     )
@@ -78,6 +79,7 @@ public func makeVideoParticipantView(
         id: id,
         availableFrame: availableFrame,
         contentMode: contentMode,
+        customData: customData,
         call: call
     )
 }

--- a/docusaurus/docs/iOS/04-ui-components/07-call/07-screen-share-content.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/07-call/07-screen-share-content.mdx
@@ -16,7 +16,7 @@ Here's an example how to create a `ScreenSharingView`:
 ScreenSharingView(
     viewModel: viewModel,
     screenSharing: screensharingSession,
-    availableFrame: CGRect
+    availableFrame: availableFrame
 )
 ```
 

--- a/docusaurus/docs/iOS/04-ui-components/08-participants/03-call-participants-info-menu.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/08-participants/03-call-participants-info-menu.mdx
@@ -29,6 +29,7 @@ func makeParticipantsListView(
         callViewModel: viewModel, 
         availableFrame: availableFrame
     )
+}
 ```
 
 The component also provides a view that you can use to invite members to the call. You can provide your own list of users that should be browsable in the view. In order to do that, you should implement the `UserListProvider` protocol.

--- a/docusaurus/docs/iOS/04-ui-components/09-utility/04-connection-quality-indicator.mdx
+++ b/docusaurus/docs/iOS/04-ui-components/09-utility/04-connection-quality-indicator.mdx
@@ -28,7 +28,7 @@ public enum ConnectionQuality: Sendable {
 You can build your own UI to display this value, or use our default `ConnectionQualityIndicator` view. The `ConnectionQualityIndicator` view expects the `connectionQuality` parameter, and changes its UI depending on the value. Here's an example usage:
 
 ```swift
-ConnectionQualityIndicator(connectionQuality: viewModel.connectionQuality)
+ConnectionQualityIndicator(connectionQuality: participant.connectionQuality)
 ```
 
 Additionally, you can change the size and the width of the connection quality ticks, by passing the `size` and `width` parameters to the `ConnectionQualityIndicator` view.

--- a/docusaurus/docs/iOS/05-ui-cookbook/03-custom-label.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/03-custom-label.mdx
@@ -36,17 +36,20 @@ struct CustomParticipantModifier: ViewModifier {
     var call: Call?
     var availableFrame: CGRect
     var ratio: CGFloat
-    
+    var showAllInfo: Bool
+
     public init(
         participant: CallParticipant,
         call: Call?,
         availableFrame: CGRect,
-        ratio: CGFloat
+        ratio: CGFloat,
+        showAllInfo: Bool
     ) {
         self.participant = participant
         self.call = call
         self.availableFrame = availableFrame
         self.ratio = ratio
+        self.showAllInfo = showAllInfo
     }
     
     public func body(content: Content) -> some View {
@@ -69,7 +72,7 @@ struct CustomParticipantModifier: ViewModifier {
                     }
                     .padding()
                 }
-                .modifier(VideoCallParticipantSpeakingModifier(participant: participant, call: call))
+                .modifier(VideoCallParticipantSpeakingModifier(participant: participant, participantCount: 1))
             )
     }
 }

--- a/docusaurus/docs/iOS/05-ui-cookbook/04-video-layout.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/04-video-layout.mdx
@@ -34,7 +34,7 @@ struct JoinCallView: View {
             TextField("Insert call id", text: $callId)
             Button {
                 resignFirstResponder()
-                viewModel.startCall(callId: callId, type: .default, members: [])
+                viewModel.startCall(callType: .default, callId: callId, members: [])
             } label: {
                 Text("Join call")
             }
@@ -53,10 +53,11 @@ Note the `viewModel.startCall` method, which is called on a tap of the "Join cal
 Next, let's use this view in a container view, called `HomeView`, that will also present our calling screen.
 
 ```swift
-struct HomeView: View {
+struct HomeView<Factory: ViewFactory>: View {
 
     @ObservedObject var appState: AppState
 
+    var viewFactory: Factory
     @StateObject var viewModel = CallViewModel()
 
     var body: some View {
@@ -66,7 +67,7 @@ struct HomeView: View {
             if viewModel.callingState == .joining {
                 ProgressView()
             } else if viewModel.callingState == .inCall {
-                CallView(viewModel: viewModel)
+                CallView(viewFactory: viewFactory, viewModel: viewModel)
             }
         }
     }
@@ -85,9 +86,9 @@ First, let's see how we can access the participants.
 
 ```swift
 var participants: [CallParticipant] {
-    viewModel
-        .callParticipants.map(\.value)
-        .sorted(using: defaultComparators)
+    viewModel.callParticipants
+        .map(\.value)
+        .sorted(by: defaultComparators)
 }
 ```
 
@@ -96,8 +97,14 @@ The call participants are exposed via the `CallViewModel`'s `callParticipants` d
 There are default sort comparators, that you can use to sort the participants. The default comparators prioritize the pinned user, then the dominant speaker etc:
 
 ```swift
-public let defaultComparators: [Comparator<CallParticipant>] = [
-    pinned, screensharing, dominantSpeaker, publishingVideo, publishingAudio, userId
+public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
+    pinned,
+    screensharing,
+    dominantSpeaker,
+    ifInvisible(isSpeaking),
+    ifInvisible(publishingVideo),
+    ifInvisible(publishingAudio),
+    ifInvisible(userId)
 ]
 ```
 
@@ -117,6 +124,7 @@ var body: some View {
                         participant: dominantSpeaker,
                         availableFrame: reader.frame(in: .global),
                         contentMode: .scaleAspectFit,
+                        customData: customData,
                         call: call
                     )
                 }

--- a/docusaurus/docs/iOS/05-ui-cookbook/05-incoming-call.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/05-incoming-call.mdx
@@ -46,7 +46,7 @@ struct CustomIncomingCallView: View {
                 .foregroundColor(Color(colors.textLowEmphasis))
                 .padding()
             
-            LazyImage(imageURL: callInfo.caller.imageURL)
+            LazyImage(url: callInfo.caller.imageURL)
                 .frame(width: 80, height: 80)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding()
@@ -62,7 +62,7 @@ struct CustomIncomingCallView: View {
                 Spacer()
                 
                 Button {
-                    callViewModel.rejectCall(callId: callInfo.id, type: callInfo.type)
+                    callViewModel.rejectCall(callType: callInfo.type, callId: callInfo.id)
                 } label: {
                     Image(systemName: "phone.down.fill")
                         .foregroundColor(.white)
@@ -76,7 +76,7 @@ struct CustomIncomingCallView: View {
                 .padding(.all, 8)
                                 
                 Button {
-                    callViewModel.acceptCall(callId: callInfo.id, type: callInfo.type)
+                    callViewModel.acceptCall(callType: callInfo.type, callId: callInfo.id)
                 } label: {
                     Image(systemName: "phone.fill")
                         .foregroundColor(.white)
@@ -97,7 +97,7 @@ struct CustomIncomingCallView: View {
         .background(Color.white.edgesIgnoringSafeArea(.all))
         .onChange(of: viewModel.hideIncomingCallScreen) { newValue in
             if newValue {
-                callViewModel.rejectCall(callId: callInfo.id, type: callInfo.type)
+                callViewModel.rejectCall(callType: callInfo.type, callId: callInfo.id)
             }
         }
         .onDisappear {

--- a/docusaurus/docs/iOS/05-ui-cookbook/06-lobby-preview.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/06-lobby-preview.mdx
@@ -54,55 +54,56 @@ public struct CustomLobbyView: View {
             onCloseLobby: onCloseLobby
         )
     }
+}
 ```
 
 Next, let's define the `CustomLobbyContentView`:
 
 ```swift
 struct CustomLobbyContentView: View {
-    
+
     @Injected(\.images) var images
     @Injected(\.colors) var colors
     @Injected(\.streamVideo) var streamVideo
-    
+
     @ObservedObject var viewModel: LobbyViewModel
     @ObservedObject var microphoneChecker: MicrophoneChecker
-    
+
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
     var onJoinCallTap: () -> ()
     var onCloseLobby: () -> ()
-    
+
     var body: some View {
         GeometryReader { reader in
             ZStack {
                 VStack {
                     Spacer()
-                    Text(L10n.WaitingRoom.title)
+                    Text("Before Joining")
                         .font(.title)
                         .foregroundColor(colors.text)
                         .bold()
-                    
-                    Text(L10n.WaitingRoom.subtitle)
+
+                    Text("Setup your audio and video")
                         .font(.body)
                         .foregroundColor(Color(colors.textLowEmphasis))
-                    
+
                     CameraCheckView(
                         viewModel: viewModel,
                         microphoneChecker: microphoneChecker,
                         callSettings: callSettings,
                         availableSize: reader.size
                     )
-                    
+
                     if microphoneChecker.isSilent {
-                        Text(L10n.WaitingRoom.Mic.notWorking)
+                        Text("Your microphone doesn't seem to be working. Make sure you have all permissions accepted.")
                             .font(.caption)
                             .foregroundColor(colors.text)
                     }
-                                        
+
                     CallSettingsView(callSettings: $callSettings)
-                    
+
                     JoinCallView(
                         callId: callId,
                         callType: callType,
@@ -111,7 +112,7 @@ struct CustomLobbyContentView: View {
                     )
                 }
                 .padding()
-                
+
                 TopRightView {
                     Button {
                         onCloseLobby()
@@ -183,7 +184,8 @@ struct CameraCheckView: View {
                     MicrophoneCheckView(
                         audioLevels: microphoneChecker.audioLevels,
                         microphoneOn: callSettings.audioOn,
-                        isSilent: microphoneChecker.isSilent
+                        isSilent: microphoneChecker.isSilent, 
+                        isPinned: false
                     )
                     .accessibility(identifier: "microphoneCheckView")
                     Spacer()
@@ -260,20 +262,22 @@ In this view, we are using the `CallIconView` component from the SwiftUI SDK, fo
 Next, we need the `JoinCallView`, which displays the button that allows users to join the call:
 
 ```swift
+struct JoinCallView: View {
+
     @Injected(\.colors) var colors
-    
+
     var callId: String
     var callType: String
     var callParticipants: [User]
     var onJoinCallTap: () -> ()
-    
+
     var body: some View {
         VStack(spacing: 16) {
-            Text("\(L10n.WaitingRoom.description)")
+            Text("You are about to join a call.")
                 .font(.headline)
                 .accessibility(identifier: "otherParticipantsCount")
                 .streamAccessibility(value: "\(otherParticipantsCount)")
-            
+
             if #available(iOS 14, *) {
                 if callParticipants.count > 0 {
                     ParticipantsInCallView(
@@ -281,11 +285,11 @@ Next, we need the `JoinCallView`, which displays the button that allows users to
                     )
                 }
             }
-            
+
             Button {
                 onJoinCallTap()
             } label: {
-                Text(L10n.WaitingRoom.join)
+                Text("Join Call")
                     .bold()
                     .frame(maxWidth: .infinity)
                     .accessibility(identifier: "joinCall")
@@ -299,7 +303,7 @@ Next, we need the `JoinCallView`, which displays the button that allows users to
         .background(colors.lobbySecondaryBackground)
         .cornerRadius(16)
     }
-    
+
     private var otherParticipantsCount: Int {
         let count = callParticipants.count - 1
         if count > 0 {
@@ -308,6 +312,7 @@ Next, we need the `JoinCallView`, which displays the button that allows users to
             return 0
         }
     }
+}
 ``` 
 
 Finally, let's see the view that displays the users that are already in the call:
@@ -315,14 +320,14 @@ Finally, let's see the view that displays the users that are already in the call
 ```swift
 @available(iOS 14.0, *)
 struct ParticipantsInCallView: View {
-    
+
     struct ParticipantInCall: Identifiable {
         let id: String
         let user: User
     }
-    
+
     var callParticipants: [User]
-    
+
     var participantsInCall: [ParticipantInCall] {
         var result = [ParticipantInCall]()
         for (index, participant) in callParticipants.enumerated() {
@@ -332,14 +337,14 @@ struct ParticipantsInCallView: View {
         }
         return result
     }
-    
+
     private let viewSize: CGFloat = 64
-    
+
     var body: some View {
         VStack(spacing: 4) {
-            Text("\(L10n.WaitingRoom.numberOfParticipants) (\(callParticipants.count)):")
+            Text("There are \(callParticipants.count) more people in the call.")
                 .font(.headline)
-            
+
             ScrollView(.horizontal) {
                 LazyHStack {
                     ForEach(participantsInCall) { participant in

--- a/docusaurus/docs/iOS/05-ui-cookbook/07-video-fallback.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/07-video-fallback.mdx
@@ -35,18 +35,18 @@ func makeVideoParticipantView(
 The implementation of the `CustomVideoCallParticipantView` looks like this:
 
 ```swift
-public struct CustomVideoCallParticipantView: View {
-    
+struct CustomVideoCallParticipantView: View {
+
     @Injected(\.images) var images
     @Injected(\.streamVideo) var streamVideo
-        
+
     let participant: CallParticipant
     var id: String
     var availableFrame: CGRect
     var contentMode: UIView.ContentMode
     var edgesIgnoringSafeArea: Edge.Set
     var call: Call?
-    
+
     public init(
         participant: CallParticipant,
         id: String? = nil,
@@ -62,7 +62,7 @@ public struct CustomVideoCallParticipantView: View {
         self.edgesIgnoringSafeArea = edgesIgnoringSafeArea
         self.call = call
     }
-    
+
     public var body: some View {
         VideoRendererView(
             id: id,
@@ -90,7 +90,7 @@ public struct CustomVideoCallParticipantView: View {
             .opacity(showVideo ? 0 : 1)
         )
     }
-    
+
     private var showVideo: Bool {
         participant.shouldDisplayTrack || customData["videoOn"]?.boolValue == true
     }

--- a/docusaurus/docs/iOS/05-ui-cookbook/08-permission-requests.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/08-permission-requests.mdx
@@ -5,31 +5,63 @@ description: Permission Requests
 
 Different call participants can have different capabilities and permissions. Depending on your app's requirements, some users might be able to request additional permissions during a call. More details about permissions [here](../../guides/permissions-and-moderation).
 
+Consider the following custom implementation of CallViewModel that manages permision requests:
+```swift
+final class CustomCallViewModel: CallViewModel {
+	var permissionRequest: PermissionRequestEvent?
+	@Published var permissionPopupShown = false
+
+	func subscribeForPermissionsRequests() {
+		Task {
+			for await request in call!.subscribe(for: PermissionRequestEvent.self) {
+				self.permissionRequest = request
+			}
+		}
+	}
+
+	func grantUserPermissions() async throws {
+		guard let request = permissionRequest else { return }
+		let permissionRequests = request.permissions.map { PermissionRequest(permission: $0, user: request.user.toUser, requestedAt: request.createdAt) }
+		for permissionRequest in permissionRequests {
+			try await call?.grant(request: permissionRequest)
+		}
+	}
+}
+```
+
 When a user asks for additional capabilities, the hosts of the call receive an event that they can react to (approve or deny the request). You can listen to these events by subscribing to the `subscribe(for:)` async stream:
 
 ```swift
 func subscribeForPermissionsRequests() {
-    Task {
-        for await request in call.subscribe(for: PermissionRequestEvent.self) {
-            self.permissionRequest = request
-        }
-    }
+	Task {
+		for await request in call!.subscribe(for: PermissionRequestEvent.self) {
+			self.permissionRequest = request
+		}
+	}
 }
 ```
 
 The simplest way to present these is via alerts in SwiftUI, with two buttons for approving or denying the permission request.
 
 ```swift
-YourHostView()
-	.alert(isPresented: $viewModel.permissionPopupShown) {
-    	Alert(
-        	title: Text("Permission request"),
-        	message: Text("\(viewModel.permissionRequest?.user.name ?? "Someone") raised their hand to speak."),
-        	primaryButton: .default(Text("Allow")) {
-            	viewModel.grantUserPermissions()
-        	},
-        	secondaryButton: .cancel()
-    	)
+struct CustomView: View {
+	@ObservedObject var viewModel: CustomCallViewModel
+
+	var body: some View {
+		YourHostView()
+			.alert(isPresented: $viewModel.permissionPopupShown) {
+				Alert(
+					title: Text("Permission request"),
+					message: Text("\(viewModel.permissionRequest?.user.name ?? "Someone") raised their hand to speak."),
+					primaryButton: .default(Text("Allow")) {
+						Task {
+							try await viewModel.grantUserPermissions()
+						}
+					},
+					secondaryButton: .cancel()
+				)
+		}
+	}
 }
 ```
 

--- a/docusaurus/docs/iOS/05-ui-cookbook/09-audio-volume-indicator.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/09-audio-volume-indicator.mdx
@@ -16,7 +16,7 @@ Here's an example how to do that:
 ```swift
 AudioVolumeIndicator(
 	audioLevels: [0.8, 0.9, 0.7],
-	maxHeight: 14
+	maxHeight: 14,
     minValue: 0,
     maxValue: 1
 )
@@ -50,6 +50,7 @@ Then, in the `MicrophoneCheckView`, you pass the audioLevels array, as well as t
 MicrophoneCheckView(
 	audioLevels: microphoneChecker.audioLevels,
 	microphoneOn: callViewModel.callSettings.audioOn,
-    isSilent: microphoneChecker.isSilent                    
+    isSilent: microphoneChecker.isSilent, 
+	isPinned: false                    
 )
 ```

--- a/docusaurus/docs/iOS/05-ui-cookbook/10-network-quality-indicator.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/10-network-quality-indicator.mdx
@@ -21,7 +21,7 @@ public enum ConnectionQuality: Sendable {
 By default, the SwiftUI SDK displays this information in the `VideoCallParticipantModifier`, via the `ConnectionQualityIndicator` view.
 
 ```swift
-ConnectionQualityIndicator(connectionQuality: viewModel.connectionQuality)
+ConnectionQualityIndicator(connectionQuality: participant.connectionQuality)
 ```
 
 Additionally, you can change the size and the width of the connection quality ticks, by passing the `size` and `width` parameters to the `ConnectionQualityIndicator` view.

--- a/docusaurus/docs/iOS/05-ui-cookbook/11-speaking-while-muted.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/11-speaking-while-muted.mdx
@@ -25,7 +25,7 @@ struct CustomCallView<Factory: ViewFactory>: View {
             .onReceive(viewModel.$callSettings) { callSettings in
                 updateMicrophoneChecker()
             }
-            .onReceive(microphoneChecker.$decibels, perform: { values in
+            .onReceive(microphoneChecker.$$audioLevels, perform: { values in
                 guard !viewModel.callSettings.audioOn else { return }
                 for value in values {
                     if (value > -50 && value < 0) && !mutedIndicatorShown {

--- a/docusaurus/docs/iOS/05-ui-cookbook/15-long-press-to-focus.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/15-long-press-to-focus.mdx
@@ -105,19 +105,21 @@ extension View {
 In order to use our ViewModifier and we can leverage the ViewFactory that the SDK ships with. By subclassing it we can override the method that provides the `VideoCallParticipantModifier` like below:
 
 ```swift
-override func makeVideoCallParticipantModifier(
+func makeVideoParticipantView(
     participant: CallParticipant,
-    call: Call?,
+    id: String,
     availableFrame: CGRect,
-    ratio: CGFloat,
-    showAllInfo: Bool
-) -> some ViewModifier {
-    super.makeVideoCallParticipantModifier(
+    contentMode: UIView.ContentMode,
+    customData: [String : RawJSON],
+    call: Call?
+) -> some View {
+    DefaultViewFactory.shared.makeVideoParticipantView(
         participant: participant,
-        call: call,
+        id: id,
         availableFrame: availableFrame,
-        ratio: ratio,
-        showAllInfo: showAllInfo
+        contentMode: contentMode,
+        customData: customData,
+        call: call
     )
     .longPressToFocus(availableFrame: availableFrame) {
         guard call?.state.sessionId == participant.sessionId else { return } // We are using this to only allow long pressing on our local video feed

--- a/docusaurus/docs/iOS/06-advanced/01-deeplinking.mdx
+++ b/docusaurus/docs/iOS/06-advanced/01-deeplinking.mdx
@@ -67,10 +67,10 @@ Next, your SwiftUI view that hosts the calling functionality, can react to chang
 ```swift
 ViewThatHostsCall()
     .onReceive(appState.$deeplinkInfo, perform: { deeplinkInfo in
-        if let deeplinkInfo {
-            callViewModel.joinCall(callId: deeplinkInfo.callId, type: deeplinkInfo.callType)
-            appState.deeplinkInfo = nil
-        }
+        if deeplinkInfo != .empty {
+              callViewModel.joinCall(callType: deeplinkInfo.callType, callId: deeplinkInfo.callId)
+              appState.deeplinkInfo = .empty
+          }
     })
 ``` 
 

--- a/docusaurus/docs/iOS/06-advanced/02-push-notifications.mdx
+++ b/docusaurus/docs/iOS/06-advanced/02-push-notifications.mdx
@@ -26,9 +26,9 @@ When you initialize the SDK, you should provide the notifications config as a pa
 
 ```swift
 let streamVideo = StreamVideo(
-    apiKey: Config.apiKey,
-    user: user.userInfo,
-    token: user.token,
+    apiKey: apiKey,
+    user: user,
+    token: token,
     videoConfig: VideoConfig(),
     pushNotificationsConfig: notificationsConfig,
     tokenProvider: tokenProvider

--- a/docusaurus/docs/iOS/06-advanced/08-recording.mdx
+++ b/docusaurus/docs/iOS/06-advanced/08-recording.mdx
@@ -92,7 +92,7 @@ import AVKit
 
 struct PlayerView: View {
     
-    let recording: CallRecordingInfo
+    let recording: CallRecording
     
     var body: some View {
         Group {

--- a/docusaurus/docs/iOS/06-advanced/09-broadcasting.mdx
+++ b/docusaurus/docs/iOS/06-advanced/09-broadcasting.mdx
@@ -19,7 +19,7 @@ Task {
 The code above will create and join the call. If you just want to create it (and not join it), you can use the method `create`:
 
 ```swift
-let call = try await call.create(members: members, startsAt: Date(), custom: [:], ring: false)
+let call = try await call.create(members: members, custom: [:], startsAt: Date(), ring: false)
 ```
 
 ### Start HLS
@@ -37,10 +37,10 @@ You can listen to the broadcasting events on the call by subscribing to its `Asy
 ```swift
 for await event in call.subscribe() {
     switch event {
-        case .typeCallBroadcastingStartedEvent(let broadcastingStartedEvent):
+        case .typeCallHLSBroadcastingStartedEvent(let broadcastingStartedEvent):
             log.debug("received an event \(broadcastingStartedEvent)")
             /* handle recording event */
-        case .typeCallBroadcastingStoppedEvent(let broadcastingStoppedEvent):
+        case .typeCallHLSBroadcastingStoppedEvent(let broadcastingStoppedEvent):
             log.debug("received an event \(broadcastingStoppedEvent)")
             /* handle recording event */
         default:


### PR DESCRIPTION
### 🎯 Goal

Provide a way to automate docs validity.

### 📝 Summary

Our docs - that live here (chat shares the same structure) - contain code snippets that as we evolve our products tend to contain errors (e.g due to changes on the API). This approach aims to provide a consistent way to validate those docs. 

### Implementation

Through the magical brute-force i have added (almost) all snippets in an XCode project that we can build on every PR. Whenever changes on the API affecting the docs the build will fail and that should be our indication to update the docs. Any new snippets that will be added in our docs will also need to be added in the project.

Note: We will need another PR to automate the process and have it running as part of our PR checks.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)