### PR TITLE
Fix encoding of dates as parameters in the requests

### DIFF
--- a/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
+++ b/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
@@ -66,12 +66,20 @@ open class DefaultAPI: DefaultAPIEndpoints, @unchecked Sendable {
     internal var middlewares: [DefaultAPIClientMiddleware]
     internal var basePath: String
     internal var jsonDecoder: JSONDecoder
+    internal var jsonEncoder: JSONEncoder
 
-    init(basePath: String, transport: DefaultAPITransport, middlewares: [DefaultAPIClientMiddleware], jsonDecoder: JSONDecoder = JSONDecoder.default) {
+    init(
+        basePath: String,
+        transport: DefaultAPITransport,
+        middlewares: [DefaultAPIClientMiddleware],
+        jsonDecoder: JSONDecoder = JSONDecoder.default,
+        jsonEncoder: JSONEncoder = JSONEncoder.default
+    ) {
         self.basePath = basePath
         self.transport = transport
         self.middlewares = middlewares
         self.jsonDecoder = jsonDecoder
+        self.jsonEncoder = jsonEncoder
     }
 
     func send<Response: Codable>(
@@ -145,7 +153,7 @@ open class DefaultAPI: DefaultAPIEndpoints, @unchecked Sendable {
         request: T
     ) throws -> Request {
         var r = try makeRequest(uriPath: uriPath, queryParams: queryParams, httpMethod: httpMethod)
-        r.body = try JSONEncoder().encode(request)
+        r.body = try jsonEncoder.encode(request)
         return r
     }
 


### PR DESCRIPTION
### 🎯 Goal

We don't encode dates properly atm. Therefore, if you want to e.g. create a meeting in the future, it doesn't work.

Will also fix it in the generator, but that's a separate place.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
