### PR TITLE
Re-enable swiftformat and swiftlint

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -219,5 +219,5 @@ jobs:
     - uses: actions/checkout@v3.1.0
     - uses: ./.github/actions/bootstrap
     - run: bundle exec fastlane rubocop
-    - run: bundle exec fastlane run_linter
+    - run: bundle exec fastlane run_swift_format lintOnly:true
     - run: bundle exec fastlane pod_lint

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -219,5 +219,5 @@ jobs:
     - uses: actions/checkout@v3.1.0
     - uses: ./.github/actions/bootstrap
     - run: bundle exec fastlane rubocop
-    - run: bundle exec fastlane run_swift_format lintOnly:true
+    - run: bundle exec fastlane run_swift_format lint:true
     - run: bundle exec fastlane pod_lint

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Run Fastlane Linting
       run: bundle exec fastlane rubocop
     - name: Run SwiftFormat Linting
-      run: bundle exec fastlane run_linter
+      run: bundle exec fastlane run_swift_format lintOnly:true
     - name: Run Podspec Linting
       run: bundle exec fastlane pod_lint
 

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Run Fastlane Linting
       run: bundle exec fastlane rubocop
     - name: Run SwiftFormat Linting
-      run: bundle exec fastlane run_swift_format lintOnly:true
+      run: bundle exec fastlane run_swift_format lint:true
     - name: Run Podspec Linting
       run: bundle exec fastlane pod_lint
 

--- a/Sources/StreamVideo/CallSettings/CallSettingsManager.swift
+++ b/Sources/StreamVideo/CallSettings/CallSettingsManager.swift
@@ -11,8 +11,8 @@ protocol CallSettingsManager {
     func updateState(
         newState state: Bool,
         current: Bool,
-        action: (Bool) async throws  -> (),
-        onUpdate: @Sendable (Bool) -> ()
+        action: (Bool) async throws -> Void,
+        onUpdate: @Sendable(Bool) -> Void
     ) async throws
 }
 
@@ -20,8 +20,8 @@ extension CallSettingsManager {
     func updateState(
         newState state: Bool,
         current: Bool,
-        action: (Bool) async throws  -> (),
-        onUpdate: @Sendable (Bool) -> ()
+        action: (Bool) async throws -> Void,
+        onUpdate: @Sendable(Bool) -> Void
     ) async throws {
         let updatingState = await self.state.updatingState
         if state == current || updatingState == state {

--- a/Sources/StreamVideo/CallSettings/CameraManager.swift
+++ b/Sources/StreamVideo/CallSettings/CameraManager.swift
@@ -18,8 +18,8 @@ public final class CameraManager: ObservableObject, CallSettingsManager, @unchec
         initialDirection: CameraPosition
     ) {
         self.callController = callController
-        self.status = initialStatus
-        self.direction = initialDirection
+        status = initialStatus
+        direction = initialDirection
     }
 
     /// Toggles the camera state.
@@ -31,7 +31,7 @@ public final class CameraManager: ObservableObject, CallSettingsManager, @unchec
     public func flip() async throws {
         let next = direction.next()
         try await callController.changeCameraMode(position: next)
-        self.direction = next
+        direction = next
     }
 
     /// Enables the camera.
@@ -53,7 +53,7 @@ public final class CameraManager: ObservableObject, CallSettingsManager, @unchec
             action: { [unowned self] state in
                 try await callController.changeVideoState(isEnabled: state)
             },
-            onUpdate: { value in
+            onUpdate: { _ in
                 self.status = status
             }
         )

--- a/Sources/StreamVideo/CallSettings/MicrophoneManager.swift
+++ b/Sources/StreamVideo/CallSettings/MicrophoneManager.swift
@@ -14,7 +14,7 @@ public final class MicrophoneManager: ObservableObject, CallSettingsManager, @un
 
     init(callController: CallController, initialStatus: CallSettingsStatus) {
         self.callController = callController
-        self.status = initialStatus
+        status = initialStatus
     }
 
     /// Toggles the microphone state.
@@ -41,7 +41,7 @@ public final class MicrophoneManager: ObservableObject, CallSettingsManager, @un
             action: { [unowned self] state in
                 try await callController.changeAudioState(isEnabled: state)
             },
-            onUpdate: { value in
+            onUpdate: { _ in
                 self.status = status
             }
         )

--- a/Sources/StreamVideo/CallSettings/SpeakerManager.swift
+++ b/Sources/StreamVideo/CallSettings/SpeakerManager.swift
@@ -18,8 +18,8 @@ public final class SpeakerManager: ObservableObject, CallSettingsManager, @unche
         initialAudioOutputStatus: CallSettingsStatus
     ) {
         self.callController = callController
-        self.status = initialSpeakerStatus
-        self.audioOutputStatus = initialAudioOutputStatus
+        status = initialSpeakerStatus
+        audioOutputStatus = initialAudioOutputStatus
     }
     
     /// Toggles the speaker during a call.
@@ -56,7 +56,7 @@ public final class SpeakerManager: ObservableObject, CallSettingsManager, @unche
             action: { [unowned self] state in
                 try await callController.changeSpeakerState(isEnabled: state)
             },
-            onUpdate: { value in
+            onUpdate: { _ in
                 self.status = status
             }
         )
@@ -65,11 +65,11 @@ public final class SpeakerManager: ObservableObject, CallSettingsManager, @unche
     private func updateAudioOutputStatus(_ status: CallSettingsStatus) async throws {
         try await updateState(
             newState: status.boolValue,
-            current: self.audioOutputStatus.boolValue,
+            current: audioOutputStatus.boolValue,
             action: { [unowned self] state in
                 try await callController.changeSoundState(isEnabled: state)
             },
-            onUpdate: { value in
+            onUpdate: { _ in
                 self.audioOutputStatus = status
             }
         )

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -45,7 +45,7 @@ class CallController {
         self.callType = callType
         self.apiKey = apiKey
         self.videoConfig = videoConfig
-        self.sfuReconnectionTime = environment.sfuReconnectionTime
+        sfuReconnectionTime = environment.sfuReconnectionTime
         self.environment = environment
         self.defaultAPI = defaultAPI
         self.cachedLocation = cachedLocation
@@ -84,7 +84,7 @@ class CallController {
             notify: notify
         )
 
-        self.currentSFU = response.credentials.server.edgeName
+        currentSFU = response.credentials.server.edgeName
         let settings = callSettings ?? response.call.settings.toCallSettings
         
         try await connectToEdge(
@@ -188,24 +188,24 @@ class CallController {
 
     /// Initiates a focus operation at a specific point on the camera's view.
     ///
-    /// This method attempts to focus the camera at the given point by calling the `focus(at:)` 
+    /// This method attempts to focus the camera at the given point by calling the `focus(at:)`
     /// method on the current WebRTC client. The focus point is specified as a `CGPoint` within the
     /// coordinate space of the view.
     ///
-    /// - Parameter point: A `CGPoint` value representing the location within the view where the 
+    /// - Parameter point: A `CGPoint` value representing the location within the view where the
     /// camera should attempt to focus. The coordinate space of the point is typically normalized to the
     /// range [0, 1], where (0, 0) represents the top-left corner of the view, and (1, 1) represents the
     /// bottom-right corner.
-    /// - Throws: An error if the focus operation cannot be completed. This might occur if there is no 
+    /// - Throws: An error if the focus operation cannot be completed. This might occur if there is no
     /// current WebRTC client available, if the camera does not support tap to focus, or if an internal error
     /// occurs within the WebRTC client.
     ///
-    /// - Note: Before calling this method, ensure that the device's camera supports tap to focus 
+    /// - Note: Before calling this method, ensure that the device's camera supports tap to focus
     /// functionality and that the current WebRTC client is properly configured and connected. Otherwise,
     /// the method may throw an error.
-   func focus(at point: CGPoint) throws {
-       try currentWebRTCClient().focus(at: point)
-   }
+    func focus(at point: CGPoint) throws {
+        try currentWebRTCClient().focus(at: point)
+    }
 
     /// Cleans up the call controller.
     func cleanUp() {
@@ -309,7 +309,7 @@ class CallController {
     
     private func handleSignalChannelConnectionStateChange(_ state: WebSocketConnectionState) {
         switch state {
-        case .disconnected(let source):
+        case let .disconnected(source):
             log.debug("Signal channel disconnected")
             executeOnMain { [weak self] in
                 self?.handleSignalChannelDisconnect(source: source)
@@ -339,7 +339,7 @@ class CallController {
             return
         }
         guard (call.state.reconnectionStatus != .reconnecting || isRetry),
-                source != .userInitiated else {
+              source != .userInitiated else {
             return
         }
         if reconnectionDate == nil {
@@ -382,8 +382,8 @@ class CallController {
     
     private func handleReconnectionError() {
         log.error("Error while reconnecting to the call")
-        self.call?.update(reconnectionStatus: .disconnected)
-        self.cleanUp()
+        call?.update(reconnectionStatus: .disconnected)
+        cleanUp()
     }
     
     private func handleSessionMigrationEvent() {

--- a/Sources/StreamVideo/Controllers/CallsController.swift
+++ b/Sources/StreamVideo/Controllers/CallsController.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 /// Controller used for querying and watching calls.
 public class CallsController: ObservableObject {
@@ -39,8 +39,8 @@ public class CallsController: ObservableObject {
     init(streamVideo: StreamVideo, callsQuery: CallsQuery) {
         self.callsQuery = callsQuery
         self.streamVideo = streamVideo
-        self.subscribeToWatchEvents()
-        self.subscribeToConnectionUpdates()
+        subscribeToWatchEvents()
+        subscribeToConnectionUpdates()
     }
     
     /// Loads the next page of calls.
@@ -62,7 +62,7 @@ public class CallsController: ObservableObject {
     private func subscribeToConnectionUpdates() {
         streamVideo.state.$connection.sink { [weak self] status in
             guard let self = self else { return }
-            if case .disconnected(_) = status {
+            if case .disconnected = status {
                 self.socketDisconnected = true
             } else if status == .disconnecting {
                 self.socketDisconnected = true

--- a/Sources/StreamVideo/Errors/Errors.swift
+++ b/Sources/StreamVideo/Errors/Errors.swift
@@ -85,7 +85,7 @@ extension ClientError {
     public class MissingPermissions: ClientError {}
     
     /// Invalid url error.
-    public class InvalidURL: ClientError {}    
+    public class InvalidURL: ClientError {}
 }
 
 // This should probably live only in the test target since it's not "true" equatable
@@ -124,7 +124,7 @@ extension Error {
     
     var hasClientErrors: Bool {
         if let apiError = self as? APIError,
-            ClosedRange.clientErrorCodes ~= apiError.statusCode {
+           ClosedRange.clientErrorCodes ~= apiError.statusCode {
             return false
         }
         return true

--- a/Sources/StreamVideo/HTTPClient/HTTPClient.swift
+++ b/Sources/StreamVideo/HTTPClient/HTTPClient.swift
@@ -94,14 +94,20 @@ final class URLSessionClient: HTTPClient, @unchecked Sendable {
                             continuation.resume(throwing: ClientError.InvalidToken())
                         } else {
                             let requestURLString = request.url?.absoluteString ?? ""
-                            log.debug("Error executing request \(requestURLString) \(String(describing: errorResponse))", subsystems: .httpRequests)
+                            log.debug(
+                                "Error executing request \(requestURLString) \(String(describing: errorResponse))",
+                                subsystems: .httpRequests
+                            )
                             continuation.resume(throwing: ClientError.NetworkError(response.description))
                         }
                         return
                     } else if response.statusCode >= 400 {
                         let requestURLString = request.url?.absoluteString ?? ""
                         let errorResponse = Self.errorResponse(from: data, response: response) as? [String: Any]
-                        log.error("Error executing request \(requestURLString) \(String(describing: errorResponse))", subsystems: .httpRequests)
+                        log.error(
+                            "Error executing request \(requestURLString) \(String(describing: errorResponse))",
+                            subsystems: .httpRequests
+                        )
                         continuation.resume(throwing: ClientError.NetworkError(response.description))
                         return
                     }

--- a/Sources/StreamVideo/Models/CallSettings.swift
+++ b/Sources/StreamVideo/Models/CallSettings.swift
@@ -61,7 +61,6 @@ extension CallSettingsResponse {
             cameraPosition: video.cameraFacing == .back ? .back : .front
         )
     }
-    
 }
 
 public extension CallSettings {

--- a/Sources/StreamVideo/Models/CallsQuery.swift
+++ b/Sources/StreamVideo/Models/CallsQuery.swift
@@ -25,7 +25,7 @@ public struct CallsQuery {
     public init(
         pageSize: Int = 25,
         sortParams: [CallSortParam],
-        filters: [String : RawJSON]? = nil,
+        filters: [String: RawJSON]? = nil,
         watch: Bool
     ) {
         self.pageSize = pageSize

--- a/Sources/StreamVideo/Models/CoordinatorModels.swift
+++ b/Sources/StreamVideo/Models/CoordinatorModels.swift
@@ -48,7 +48,7 @@ public struct CreateCallOptions: Sendable {
     public init(
         memberIds: [String]? = nil,
         members: [MemberRequest]? = nil,
-        custom: [String : RawJSON]? = nil,
+        custom: [String: RawJSON]? = nil,
         settings: CallSettingsRequest? = nil,
         startsAt: Date? = nil,
         team: String? = nil

--- a/Sources/StreamVideo/Models/Member.swift
+++ b/Sources/StreamVideo/Models/Member.swift
@@ -10,6 +10,7 @@ public struct Member: Identifiable, Equatable, Sendable, Codable {
     public var id: String {
         user.id
     }
+
     /// The underlying user.
     public let user: User
     /// The role of the member in the call.
@@ -18,7 +19,7 @@ public struct Member: Identifiable, Equatable, Sendable, Codable {
     public let customData: [String: RawJSON]
     public let updatedAt: Date
 
-    public init(user: User, role: String? = nil, customData: [String : RawJSON] = [:], updatedAt: Date) {
+    public init(user: User, role: String? = nil, customData: [String: RawJSON] = [:], updatedAt: Date) {
         self.user = user
         self.role = role ?? user.role
         self.customData = customData

--- a/Sources/StreamVideo/Models/Token.swift
+++ b/Sources/StreamVideo/Models/Token.swift
@@ -36,5 +36,4 @@ extension ClientError {
 public extension UserToken {
     
     static let empty = UserToken(rawValue: "")
-    
 }

--- a/Sources/StreamVideo/Models/VideoOptions.swift
+++ b/Sources/StreamVideo/Models/VideoOptions.swift
@@ -25,23 +25,23 @@ struct VideoOptions: Sendable {
         self.preferredFormat = preferredFormat
         self.preferredFps = preferredFps
         if let targetResolution {
-            self.preferredDimensions = CMVideoDimensions(
+            preferredDimensions = CMVideoDimensions(
                 width: Int32(targetResolution.width),
                 height: Int32(targetResolution.height)
             )
             do {
-                self.supportedCodecs = try VideoCapturingUtils.codecs(
+                supportedCodecs = try VideoCapturingUtils.codecs(
                     preferredFormat: preferredFormat,
                     preferredDimensions: preferredDimensions,
                     preferredFps: preferredFps,
                     preferredBitrate: targetResolution.bitrate
                 )
             } catch {
-                self.supportedCodecs = VideoCodec.defaultCodecs
+                supportedCodecs = VideoCodec.defaultCodecs
             }
         } else {
-            self.preferredDimensions = .full
-            self.supportedCodecs = VideoCodec.defaultCodecs
+            preferredDimensions = .full
+            supportedCodecs = VideoCodec.defaultCodecs
         }
     }
 }

--- a/Sources/StreamVideo/Utils/EndpointConfig.swift
+++ b/Sources/StreamVideo/Utils/EndpointConfig.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct EndpointConfig {
     let hostname: String
-    let wsEndpoint: String    
+    let wsEndpoint: String
     var baseVideoURL: String {
         "\(hostname)video"
     }

--- a/Sources/StreamVideo/Utils/IntExtensions.swift
+++ b/Sources/StreamVideo/Utils/IntExtensions.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-extension FixedWidthInteger {    
+extension FixedWidthInteger {
     func roundUp(toMultipleOf powerOfTwo: Self) -> Self {
         precondition(powerOfTwo > 0 && powerOfTwo & (powerOfTwo &- 1) == 0)
         return (self + (powerOfTwo &- 1)) & (0 &- powerOfTwo)

--- a/Sources/StreamVideo/Utils/LocationFetcher.swift
+++ b/Sources/StreamVideo/Utils/LocationFetcher.swift
@@ -21,5 +21,4 @@ class LocationFetcher {
         }
         throw FetchingLocationError()
     }
-    
 }

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -135,13 +135,14 @@ func comparison<Value>(
 }
 
 // MARK: - Comparators
+
 // MARK: Aggregators
 
 /// Combines multiple comparators into a single comparator.
 /// It uses the first comparator to compare two elements. If they are deemed "equal" (i.e., orderedSame),
 /// it moves to the next comparator, and so on, until a decision can be made or all comparators have been exhausted.
 public func combineComparators<T>(_ comparators: [StreamSortComparator<T>]) -> StreamSortComparator<T> {
-    return { a, b in
+    { a, b in
         for comparator in comparators {
             let result = comparator(a, b)
             if result != .orderedSame {
@@ -154,9 +155,10 @@ public func combineComparators<T>(_ comparators: [StreamSortComparator<T>]) -> S
 
 /// Returns a new comparator that only applies the given comparator if the predicate returns true.
 /// If the predicate returns false, it deems the two elements "equal" (i.e., orderedSame).
-public func conditional<T>(_ predicate: @escaping (T, T) -> Bool) -> (@escaping StreamSortComparator<T>) -> StreamSortComparator<T> {
-    return { comparator in
-        return { a, b in
+public func conditional<T>(_ predicate: @escaping (T, T) -> Bool)
+    -> (@escaping StreamSortComparator<T>) -> StreamSortComparator<T> {
+    { comparator in
+        { a, b in
             if !predicate(a, b) {
                 return .orderedSame
             }
@@ -184,10 +186,10 @@ public var pinned: StreamSortComparator<CallParticipant> = { a, b in
     switch (a.pin, b.pin) {
     case (nil, _?): return .orderedDescending
     case (_?, nil): return .orderedAscending
-    case (let aPin?, let bPin?) where aPin.isLocal && !bPin.isLocal: return .orderedAscending
-    case (let aPin?, let bPin?) where !aPin.isLocal && bPin.isLocal: return .orderedDescending
-    case (let aPin?, let bPin?) where aPin.pinnedAt > bPin.pinnedAt: return .orderedAscending
-    case (let aPin?, let bPin?) where aPin.pinnedAt < bPin.pinnedAt: return .orderedDescending
+    case let (aPin?, bPin?) where aPin.isLocal && !bPin.isLocal: return .orderedAscending
+    case let (aPin?, bPin?) where !aPin.isLocal && bPin.isLocal: return .orderedDescending
+    case let (aPin?, bPin?) where aPin.pinnedAt > bPin.pinnedAt: return .orderedAscending
+    case let (aPin?, bPin?) where aPin.pinnedAt < bPin.pinnedAt: return .orderedDescending
     default: return .orderedSame
     }
 }
@@ -206,7 +208,7 @@ public var name: StreamSortComparator<CallParticipant> = { comparison($0, $1, ke
 
 /// A comparator creator which will set up a comparator which prioritizes participants who have a specific role.
 public func roles(_ priorityRoles: [String] = ["admin", "host", "speaker"]) -> StreamSortComparator<CallParticipant> {
-    return { (p1, p2) in
+    { (p1, p2) in
         if p1.roles == p2.roles { return .orderedSame }
         for role in priorityRoles {
             if p1.roles.contains(role) && !p2.roles.contains(role) {

--- a/Sources/StreamVideo/Utils/StringExtensions.swift
+++ b/Sources/StreamVideo/Utils/StringExtensions.swift
@@ -7,7 +7,7 @@ import Foundation
 extension String {
     
     var preferredRedCodec: String {
-        let parts = self.components(separatedBy: "\r\n")
+        let parts = components(separatedBy: "\r\n")
         var redId: String = ""
         var opusId: String = ""
         for part in parts {
@@ -25,7 +25,7 @@ extension String {
         if !redId.isEmpty && !opusId.isEmpty {
             let redOpusPair = "\(redId) \(opusId)"
             let opusRedPair = "\(opusId) \(redId)"
-            let updatedResult = self.replacingOccurrences(
+            let updatedResult = replacingOccurrences(
                 of: opusRedPair,
                 with: redOpusPair
             )
@@ -44,5 +44,4 @@ extension String {
         guard components.count > 1 else { return "" }
         return components[1]
     }
-    
 }

--- a/Sources/StreamVideo/Utils/SystemEnvironment+XStreamClient.swift
+++ b/Sources/StreamVideo/Utils/SystemEnvironment+XStreamClient.swift
@@ -93,7 +93,7 @@ extension SystemEnvironment {
 }
 
 extension Array {
-  private subscript(safe index: Int) -> Element? {
-    return indices ~= index ? self[index] : nil
-  }
+    private subscript(safe index: Int) -> Element? {
+        indices ~= index ? self[index] : nil
+    }
 }

--- a/Sources/StreamVideo/Utils/ThermalStateObserver.swift
+++ b/Sources/StreamVideo/Utils/ThermalStateObserver.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 extension LogSubsystem {
     public static let thermalState = Self(rawValue: 1 << 6)
@@ -72,10 +72,9 @@ final class ThermalStateObserver: ObservableObject, ThermalStateObserving {
         self.init { ProcessInfo.processInfo.thermalState }
     }
 
-
     init(thermalStateProvider: @escaping () -> ProcessInfo.ThermalState) {
         // Initialize the thermal state with the current process's thermal state
-        self.state = thermalStateProvider()
+        state = thermalStateProvider()
         self.thermalStateProvider = thermalStateProvider
 
         // Set up a publisher to monitor thermal state changes

--- a/Sources/StreamVideo/Utils/Utils.swift
+++ b/Sources/StreamVideo/Utils/Utils.swift
@@ -22,14 +22,14 @@ public enum CallNotification {
     public static let participantLeft = "StreamVideo.Call.ParticipantLeft"
 }
 
-typealias EventHandling = ((WrappedEvent) -> ())?
+typealias EventHandling = ((WrappedEvent) -> Void)?
 
-func executeOnMain(_ task: @escaping @MainActor () -> ()) {
+func executeOnMain(_ task: @escaping @MainActor() -> Void) {
     Task {
         await task()
     }
 }
 
 func infoPlistValue(for key: String) -> String? {
-    return Bundle.main.infoDictionary?[key] as? String
+    Bundle.main.infoDictionary?[key] as? String
 }

--- a/Sources/StreamVideo/WebRTC/AudioSession.swift
+++ b/Sources/StreamVideo/WebRTC/AudioSession.swift
@@ -41,7 +41,6 @@ actor AudioSession {
         defer { audioSession.unlockForConfiguration() }
         audioSession.isAudioEnabled = enabled
     }
-    
 }
 
 extension RTCAudioSessionConfiguration {

--- a/Sources/StreamVideo/WebRTC/PeerConnection.swift
+++ b/Sources/StreamVideo/WebRTC/PeerConnection.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftProtobuf
 import StreamWebRTC
+import SwiftProtobuf
 
 enum PeerConnectionType: String {
     case subscriber
@@ -183,7 +183,10 @@ class PeerConnection: NSObject, RTCPeerConnectionDelegate, @unchecked Sendable {
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {}
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
-        log.debug("New stream added with id = \(stream.streamId) for \(type.rawValue), sfu = \(signalService.hostname)", subsystems: .webRTC)
+        log.debug(
+            "New stream added with id = \(stream.streamId) for \(type.rawValue), sfu = \(signalService.hostname)",
+            subsystems: .webRTC
+        )
         if stream.streamId.contains(WebRTCClient.Constants.screenshareTrackType) {
             screensharingStreams.append(stream)
         }
@@ -265,11 +268,11 @@ class PeerConnection: NSObject, RTCPeerConnectionDelegate, @unchecked Sendable {
 
     func update(configuration: RTCConfiguration?) {
         guard let configuration else { return }
-        self.pc.setConfiguration(configuration)
+        pc.setConfiguration(configuration)
     }
 
     func statsReport() async throws -> RTCStatisticsReport {
-        return try await withCheckedThrowingContinuation { [weak self] continuation in
+        try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self else {
                 return continuation.resume(throwing: ClientError.Unexpected())
             }

--- a/Sources/StreamVideo/WebRTC/Retries.swift
+++ b/Sources/StreamVideo/WebRTC/Retries.swift
@@ -43,7 +43,6 @@ func executeTask<Output>(
             throw error
         }
     }
-
 }
 
 struct RetryPolicy {
@@ -76,6 +75,6 @@ extension RetryPolicy {
     }
     
     static func delay(retries: Int) -> TimeInterval {
-        return TimeInterval.random(in: 0.5...2.5)
+        TimeInterval.random(in: 0.5...2.5)
     }
 }

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferConnection.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferConnection.swift
@@ -57,7 +57,7 @@ class BroadcastBufferConnection: NSObject {
         scheduleStreams()
     }
     
-    //MARK: - private
+    // MARK: - private
     
     private func scheduleStreams() {
         shouldKeepRunning = true

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferReader.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferReader.swift
@@ -2,9 +2,9 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
-import CoreVideo
 import CoreImage
+import CoreVideo
+import Foundation
 import StreamWebRTC
 
 private class Message {
@@ -38,7 +38,7 @@ private class Message {
             framedMessage,
             BroadcastConstants.contentLength as CFString
         )?.takeRetainedValue(),
-              let body = CFHTTPMessageCopyBody(framedMessage)?.takeRetainedValue()
+            let body = CFHTTPMessageCopyBody(framedMessage)?.takeRetainedValue()
         else {
             return -1
         }
@@ -49,7 +49,7 @@ private class Message {
         let missingBytesCount = contentLength - bodyLength
         if missingBytesCount == 0 {
             let success = unwrapMessage(framedMessage)
-            self.onComplete?(success, self)
+            onComplete?(success, self)
             self.framedMessage = nil
         }
         
@@ -57,7 +57,7 @@ private class Message {
     }
     
     private func imageContext() -> CIContext? {
-        return Message.imageContextVar
+        Message.imageContextVar
     }
     
     private func unwrapMessage(_ framedMessage: CFHTTPMessage) -> Bool {
@@ -81,7 +81,7 @@ private class Message {
         
         let width = Int(CFStringGetIntValue(widthStr))
         let height = Int(CFStringGetIntValue(heightStr))
-        self.imageOrientation = CGImagePropertyOrientation(
+        imageOrientation = CGImagePropertyOrientation(
             rawValue: UInt32(CFStringGetIntValue(imageOrientationStr))
         ) ?? .up
         
@@ -208,7 +208,6 @@ final class BroadcastBufferReader: NSObject {
         
         onCapture?(pixelBuffer, rotation)
     }
-    
 }
 
 extension BroadcastBufferReader: StreamDelegate {

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferReaderConnection.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferReaderConnection.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import Darwin
+import Foundation
 
 final class BroadcastBufferReaderConnection: BroadcastBufferConnection {
     private let streamDelegate: StreamDelegate
@@ -61,7 +61,7 @@ final class BroadcastBufferReaderConnection: BroadcastBufferConnection {
         Darwin.close(socketHandle)
     }
     
-    //MARK: - private
+    // MARK: - private
     
     private func setupAddress() -> Bool {
         var addr = sockaddr_un()

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferUploadConnection.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferUploadConnection.swift
@@ -25,8 +25,8 @@ class BroadcastBufferUploadConnection: BroadcastBufferConnection {
     
     func open() -> Bool {
         guard FileManager.default.fileExists(atPath: filePath),
-                setupAddress(),
-                connectSocket() else {
+              setupAddress(),
+              connectSocket() else {
             return false
         }
         
@@ -40,7 +40,7 @@ class BroadcastBufferUploadConnection: BroadcastBufferConnection {
         return true
     }
     
-    //MARK: - private
+    // MARK: - private
     
     private func setupAddress() -> Bool {
         var addr = sockaddr_un()

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferUploader.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastBufferUploader.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import StreamWebRTC
 import ReplayKit
+import StreamWebRTC
 
 actor BroadcastBufferUploader {
     

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastObserver.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastObserver.swift
@@ -16,11 +16,11 @@ public class BroadcastObserver: ObservableObject {
     
     public init() {}
     
-    lazy var broadcastStarted: CFNotificationCallback = { center, observer, name, object, userInfo in
+    lazy var broadcastStarted: CFNotificationCallback = { _, _, _, _, _ in
         postNotification(with: BroadcastConstants.broadcastStartedNotification)
     }
     
-    lazy var broadcastStopped: CFNotificationCallback = { center, observer, name, object, userInfo in
+    lazy var broadcastStopped: CFNotificationCallback = { _, _, _, _, _ in
         postNotification(with: BroadcastConstants.broadcastStoppedNotification)
     }
     
@@ -61,10 +61,10 @@ public class BroadcastObserver: ObservableObject {
     }
 
     @objc func handleBroadcastStarted() {
-        self.broadcastState = .started
+        broadcastState = .started
     }
     
     @objc func handleBroadcastStopped() {
-        self.broadcastState = .finished
+        broadcastState = .finished
     }
 }

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastSampleHandler.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastSampleHandler.swift
@@ -9,7 +9,7 @@ open class BroadcastSampleHandler: RPBroadcastSampleHandler {
     
     private var clientConnection: BroadcastBufferUploadConnection?
     private var uploader: BroadcastBufferUploader?
-    private let notificationCenter: CFNotificationCenter    
+    private let notificationCenter: CFNotificationCenter
     private var socketFilePath: String {
         guard let appGroupIdentifier = infoPlistValue(for: BroadcastConstants.broadcastAppGroupIdentifier),
               let sharedContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
@@ -23,20 +23,20 @@ open class BroadcastSampleHandler: RPBroadcastSampleHandler {
         .path
     }
     
-    public override init() {
+    override public init() {
         notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
         super.init()
         
-        if let connection = BroadcastBufferUploadConnection(filePath: self.socketFilePath) {
-            self.clientConnection = connection
-            self.setupConnection()
-            self.uploader = BroadcastBufferUploader(connection: connection)
+        if let connection = BroadcastBufferUploadConnection(filePath: socketFilePath) {
+            clientConnection = connection
+            setupConnection()
+            uploader = BroadcastBufferUploader(connection: connection)
         }
     }
     
     override public func broadcastStarted(withSetupInfo setupInfo: [String: NSObject]?) {
         postNotification(BroadcastConstants.broadcastStartedNotification)
-        self.openConnection()
+        openConnection()
     }
     
     override public func broadcastPaused() {}
@@ -59,7 +59,7 @@ open class BroadcastSampleHandler: RPBroadcastSampleHandler {
         }
     }
     
-    //MARK: - private
+    // MARK: - private
     
     private func setupConnection() {
         clientConnection?.onClose = { [weak self] error in

--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastScreenCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastScreenCapturer.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import StreamWebRTC
 import ReplayKit
+import StreamWebRTC
 
 class BroadcastScreenCapturer: VideoCapturing {
     
@@ -23,13 +23,13 @@ class BroadcastScreenCapturer: VideoCapturing {
     ) {
         self.videoOptions = videoOptions
         self.videoSource = videoSource
-#if targetEnvironment(simulator)
+        #if targetEnvironment(simulator)
         videoCapturer = RTCFileVideoCapturer(delegate: videoSource)
-#else
+        #else
         let handler = StreamVideoCaptureHandler(source: videoSource, filters: videoFilters, handleRotation: false)
         videoCaptureHandler = handler
         videoCapturer = RTCCameraVideoCapturer(delegate: handler)
-#endif
+        #endif
     }
     
     func startCapture(device: AVCaptureDevice?) async throws {
@@ -38,7 +38,7 @@ class BroadcastScreenCapturer: VideoCapturing {
         }
         
         guard let identifier = infoPlistValue(for: BroadcastConstants.broadcastAppGroupIdentifier),
-              let filePath = self.filePathForIdentifier(identifier)
+              let filePath = filePathForIdentifier(identifier)
         else {
             return
         }
@@ -93,14 +93,14 @@ class BroadcastScreenCapturer: VideoCapturing {
     }
     
     func stopCapture() async throws {
-        guard self.bufferReader != nil else {
+        guard bufferReader != nil else {
             // already stopped
             return
         }
         
-        self.bufferReader?.stopCapturing()
-        self.bufferReader = nil
-        await (videoCapturer as? RTCCameraVideoCapturer)?.stopCapture()
+        bufferReader?.stopCapturing()
+        bufferReader = nil
+        await(videoCapturer as? RTCCameraVideoCapturer)?.stopCapture()
     }
     
     private func filePathForIdentifier(_ identifier: String) -> String? {

--- a/Sources/StreamVideo/WebRTC/Screensharing/ScreenshareCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/ScreenshareCapturer.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import StreamWebRTC
 import ReplayKit
+import StreamWebRTC
 
 class ScreenshareCapturer: VideoCapturing {
     private var videoCapturer: RTCVideoCapturer
@@ -42,7 +42,7 @@ class ScreenshareCapturer: VideoCapturing {
         RPScreenRecorder.shared().isMicrophoneEnabled = false
         
         return try await withCheckedThrowingContinuation { continuation in
-            RPScreenRecorder.shared().startCapture(handler: { [weak self] sampleBuffer, type, error in
+            RPScreenRecorder.shared().startCapture(handler: { [weak self] sampleBuffer, type, _ in
                 guard let self else { return }
                 self.handle(sampleBuffer: sampleBuffer, type: type, for: device)
             }) { error in
@@ -57,7 +57,7 @@ class ScreenshareCapturer: VideoCapturing {
     
     func stopCapture() async throws {
         try await stopScreensharing()
-        await (videoCapturer as? RTCCameraVideoCapturer)?.stopCapture()
+        await(videoCapturer as? RTCCameraVideoCapturer)?.stopCapture()
     }
     
     func handle(sampleBuffer: CMSampleBuffer, type: RPSampleBufferType, for device: AVCaptureDevice) {
@@ -89,9 +89,9 @@ class ScreenshareCapturer: VideoCapturing {
                 timeStampNs: timeStampNs
             )
 
-            self.videoCaptureHandler?.capturer(self.videoCapturer, didCapture: rtcFrame)
+            videoCaptureHandler?.capturer(videoCapturer, didCapture: rtcFrame)
             if let dimensions = outputFormat.dimensions {
-                self.videoSource.adaptOutputFormat(
+                videoSource.adaptOutputFormat(
                     toWidth: dimensions.width,
                     height: dimensions.height,
                     fps: Int32(outputFormat.fps)
@@ -101,7 +101,7 @@ class ScreenshareCapturer: VideoCapturing {
     }
     
     private func stopScreensharing() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             guard RPScreenRecorder.shared().isRecording else {
                 continuation.resume(returning: ())
                 return
@@ -115,5 +115,4 @@ class ScreenshareCapturer: VideoCapturing {
             }
         }
     }
-
 }

--- a/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
+++ b/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
@@ -15,9 +15,9 @@ class SfuMiddleware: EventMiddleware {
     private var subscriber: PeerConnection?
     private var publisher: PeerConnection?
     var onSocketConnected: ((Bool) -> Void)?
-    var onParticipantCountUpdated: ((UInt32) -> ())?
+    var onParticipantCountUpdated: ((UInt32) -> Void)?
     var onSessionMigrationEvent: (() -> Void)?
-    var onPinsChanged: (([Stream_Video_Sfu_Models_Pin]) -> ())?
+    var onPinsChanged: (([Stream_Video_Sfu_Models_Pin]) -> Void)?
     
     init(
         sessionID: String,
@@ -52,43 +52,43 @@ class SfuMiddleware: EventMiddleware {
                 return
             }
             switch event {
-            case .subscriberOffer(let event):
+            case let .subscriberOffer(event):
                 await handleSubscriberEvent(event)
-            case .publisherAnswer(_):
+            case .publisherAnswer:
                 log.warning("Publisher answer event shouldn't be sent")
-            case .connectionQualityChanged(let event):
+            case let .connectionQualityChanged(event):
                 await handleConnectionQualityChangedEvent(event)
-            case .audioLevelChanged(let event):
+            case let .audioLevelChanged(event):
                 await handleAudioLevelsChanged(event)
-            case .iceTrickle(let event):
+            case let .iceTrickle(event):
                 try await handleICETrickle(event)
-            case .changePublishQuality(let event):
+            case let .changePublishQuality(event):
                 handleChangePublishQualityEvent(event)
-            case .participantJoined(let event):
+            case let .participantJoined(event):
                 await handleParticipantJoined(event)
-            case .participantLeft(let event):
+            case let .participantLeft(event):
                 await handleParticipantLeft(event)
-            case .dominantSpeakerChanged(let event):
+            case let .dominantSpeakerChanged(event):
                 await handleDominantSpeakerChanged(event)
-            case .joinResponse(let event):
+            case let .joinResponse(event):
                 onSocketConnected?(event.reconnected)
                 await loadParticipants(from: event)
-            case .healthCheckResponse(let event):
+            case let .healthCheckResponse(event):
                 onParticipantCountUpdated?(event.participantCount.total)
-            case .trackPublished(let event):
+            case let .trackPublished(event):
                 await handleTrackPublishedEvent(event)
-            case .trackUnpublished(let event):
+            case let .trackUnpublished(event):
                 await handleTrackUnpublishedEvent(event)
-            case .error(let event):
+            case let .error(event):
                 log.error(event.error.message, error: event.error)
-            case .callGrantsUpdated(_):
+            case .callGrantsUpdated:
                 log.warning("TODO: callGrantsUpdated")
-            case .goAway(let event):
+            case let .goAway(event):
                 log.info("Received go away event with reason: \(event.reason.rawValue)")
                 onSessionMigrationEvent?()
-            case .iceRestart(_):
+            case .iceRestart:
                 log.info("Received ice restart message")
-            case .pinsUpdated(let event):
+            case let .pinsUpdated(event):
                 log.debug("Pins changed \(event.pins.map(\.sessionID))")
                 onPinsChanged?(event.pins)
             }

--- a/Sources/StreamVideo/WebRTC/SimulatorScreenCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/SimulatorScreenCapturer.swift
@@ -45,7 +45,8 @@ final class SimulatorScreenCapturer: RTCVideoCapturer {
             track: track,
             outputSettings: [
                 kCVPixelBufferPixelFormatTypeKey as String: NSNumber(value: kCVPixelFormatType_32BGRA)
-            ])
+            ]
+        )
         do {
             assetReader = try AVAssetReader(asset: asset)
             assetReader?.add(trackOutput)
@@ -65,15 +66,19 @@ final class SimulatorScreenCapturer: RTCVideoCapturer {
             let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)!
             let frameTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
             let videoFrame = RTCCVPixelBuffer(pixelBuffer: pixelBuffer)
-            let rtcVideoFrame = RTCVideoFrame(buffer: videoFrame, rotation: ._0, timeStampNs: Int64(CMTimeGetSeconds(frameTime) * 1e9))
+            let rtcVideoFrame = RTCVideoFrame(
+                buffer: videoFrame,
+                rotation: ._0,
+                timeStampNs: Int64(CMTimeGetSeconds(frameTime) * 1e9)
+            )
 
             DispatchQueue.main.async {
                 self.delegate?.capturer(self, didCapture: rtcVideoFrame)
             }
         } else {
             // Reached the end of the video file, restart from the beginning
-            self.assetReader?.cancelReading()
-            self.setupAssetReader()
+            assetReader?.cancelReading()
+            setupAssetReader()
         }
     }
 }

--- a/Sources/StreamVideo/WebRTC/StatsReporter.swift
+++ b/Sources/StreamVideo/WebRTC/StatsReporter.swift
@@ -41,7 +41,7 @@ enum StatsReporter {
                 for (_, value) in values {
                     let stats = value.values
                     if let trackIdentifier = stats[StatsConstants.trackIdentifier] as? String,
-                        stats[StatsConstants.kind] as? String == "video" {
+                       stats[StatsConstants.kind] as? String == "video" {
                         if var existing = current[trackIdentifier] {
                             for (key, value) in stats {
                                 existing[key] = value
@@ -52,7 +52,7 @@ enum StatsReporter {
                         }
                     }
                     if let codecId = stats[StatsConstants.codecId] as? String,
-                        stats[StatsConstants.kind] as? String == "video" {
+                       stats[StatsConstants.kind] as? String == "video" {
                         fallbackCodecId = codecId
                     }
                 }

--- a/Sources/StreamVideo/WebRTC/StreamVideoCaptureHandler.swift
+++ b/Sources/StreamVideo/WebRTC/StreamVideoCaptureHandler.swift
@@ -49,8 +49,8 @@ final class StreamVideoCaptureHandler: NSObject, RTCVideoCapturerDelegate {
             }
 
             let updatedFrame = handleRotation
-            ? adjustRotation(capturer, for: _buffer, frame: frame)
-            : frame
+                ? adjustRotation(capturer, for: _buffer, frame: frame)
+                : frame
 
             self.source.capturer(capturer, didCapture: updatedFrame)
         }
@@ -100,11 +100,11 @@ final class StreamVideoCaptureHandler: NSObject, RTCVideoCapturerDelegate {
     }
     
     deinit {
-       NotificationCenter.default.removeObserver(
+        NotificationCenter.default.removeObserver(
             self,
             name: UIDevice.orientationDidChangeNotification,
             object: nil
-       )
+        )
     }
 }
 

--- a/Sources/StreamVideo/WebRTC/VideoCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturer.swift
@@ -53,7 +53,7 @@ class VideoCapturer: CameraVideoCapturing {
     }
     
     func startCapture(device: AVCaptureDevice?) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             guard let videoCapturer = videoCapturer as? RTCCameraVideoCapturer, let device else {
                 continuation.resume(throwing: ClientError.Unexpected())
                 return
@@ -94,7 +94,7 @@ class VideoCapturer: CameraVideoCapturing {
     }
     
     func stopCapture() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             if let capturer = videoCapturer as? RTCCameraVideoCapturer {
                 capturer.stopCapture {
                     continuation.resume(returning: ())
@@ -107,18 +107,18 @@ class VideoCapturer: CameraVideoCapturing {
 
     /// Initiates a focus and exposure operation at the specified point on the camera's view.
     ///
-    /// This method attempts to focus the camera and set the exposure at a specific point by interacting 
+    /// This method attempts to focus the camera and set the exposure at a specific point by interacting
     /// with the device's capture session.
-    /// It requires the `videoCapturer` property to be cast to `RTCCameraVideoCapturer`, and for 
+    /// It requires the `videoCapturer` property to be cast to `RTCCameraVideoCapturer`, and for
     /// a valid `AVCaptureDeviceInput` to be accessible.
     /// If these conditions are not met, it throws a `ClientError.Unexpected` error.
     ///
-    /// - Parameter point: A `CGPoint` representing the location within the view where the camera 
+    /// - Parameter point: A `CGPoint` representing the location within the view where the camera
     /// should adjust focus and exposure.
-    /// - Throws: A `ClientError.Unexpected` error if the necessary video capture components are 
+    /// - Throws: A `ClientError.Unexpected` error if the necessary video capture components are
     /// not available or properly configured.
     ///
-    /// - Note: Ensure that the `point` is normalized to the camera's coordinate space, ranging 
+    /// - Note: Ensure that the `point` is normalized to the camera's coordinate space, ranging
     /// from (0,0) at the top-left to (1,1) at the bottom-right.
     func focus(at point: CGPoint) throws {
         guard
@@ -159,7 +159,7 @@ class VideoCapturer: CameraVideoCapturing {
         }
     }
 
-    //MARK: - private
+    // MARK: - private
     
     private func checkForBackgroundCameraAccess() {
         if #available(iOS 16, *) {
@@ -196,8 +196,8 @@ extension AVCaptureDevice.Format {
         videoSupportedFrameRateRanges
             .map { $0.toRange() }
             .reduce(into: 0...0) { result, current in
-            result = merge(range: result, with: current)
-        }
+                result = merge(range: result, with: current)
+            }
     }
 }
 

--- a/Sources/StreamVideo/WebRTC/VideoCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturer.swift
@@ -90,7 +90,7 @@ class VideoCapturer: CameraVideoCapturing {
                     continuation.resume(returning: ())
                 }
             }
-        }
+        } as Void
     }
     
     func stopCapture() async throws {

--- a/Sources/StreamVideo/WebRTC/VideoCapturing.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturing.swift
@@ -10,7 +10,7 @@ protocol VideoCapturing {
     func stopCapture() async throws
 }
 
-protocol CameraVideoCapturing: VideoCapturing {    
+protocol CameraVideoCapturing: VideoCapturing {
     func setCameraPosition(_ cameraPosition: AVCaptureDevice.Position) async throws
     func setVideoFilter(_ videoFilter: VideoFilter?)
     func capturingDevice(for cameraPosition: AVCaptureDevice.Position) -> AVCaptureDevice?

--- a/Sources/StreamVideo/WebRTC/VideoCapturingUtils.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturingUtils.swift
@@ -72,7 +72,7 @@ enum VideoCapturingUtils {
             selectedFormat = foundFormat
         } else {
             selectedFormat = sortedFormats.first(where: { $0.dimensions.area >= preferredDimensions.area
-                && $0.format.fpsRange().contains(preferredFps)
+                    && $0.format.fpsRange().contains(preferredFps)
             })
             
             if selectedFormat == nil {
@@ -87,10 +87,16 @@ enum VideoCapturingUtils {
         }
 
         guard let selectedFormat = selectedFormat else {
-            log.warning("Unable to resolve format with preferredDimensions:\(preferredDimensions.width)x\(preferredDimensions.height) preferredFormat:\(String(describing: preferredFormat)) preferredFPS:\(preferredFps)")
+            log
+                .warning(
+                    "Unable to resolve format with preferredDimensions:\(preferredDimensions.width)x\(preferredDimensions.height) preferredFormat:\(String(describing: preferredFormat)) preferredFPS:\(preferredFps)"
+                )
             return (format: nil, dimensions: nil, fps: 0)
         }
-        log.debug("SelectedFormat dimensions:\(selectedFormat.dimensions.width)x\(selectedFormat.dimensions.height) format:\(selectedFormat.format) diff:\(selectedFormat.diff)")
+        log
+            .debug(
+                "SelectedFormat dimensions:\(selectedFormat.dimensions.width)x\(selectedFormat.dimensions.height) format:\(selectedFormat.format) diff:\(selectedFormat.diff)"
+            )
 
         var selectedFps = preferredFps
         let fpsRange = selectedFormat.format.fpsRange()

--- a/Sources/StreamVideo/WebSockets/Client/WebSocketClient.swift
+++ b/Sources/StreamVideo/WebSockets/Client/WebSocketClient.swift
@@ -100,7 +100,7 @@ class WebSocketClient {
     /// Calling this method has no effect is the web socket is already connected, or is in the connecting phase.
     func connect() {
         switch connectionState {
-            // Calling connect in the following states has no effect
+        // Calling connect in the following states has no effect
         case .connecting, .authenticating, .connected(healthCheckInfo: _):
             return
         default: break
@@ -202,11 +202,11 @@ extension WebSocketClient: WebSocketEngineDelegate {
         }
         
         switch event {
-        case .coordinatorEvent(let event):
+        case let .coordinatorEvent(event):
             log.info("received WS \(event.type) event from coordinator \(connectURL)", subsystems: .webSocket)
-        case .internalEvent(_):
+        case .internalEvent:
             break
-        case .sfuEvent(_):
+        case .sfuEvent:
             break
         }
 
@@ -236,7 +236,11 @@ extension WebSocketClient: WebSocketEngineDelegate {
             connectionState = .disconnected(source: source)
         
         case .initialized, .disconnected:
-            log.error("Web socket can not be disconnected when in \(connectionState) state", subsystems: .webSocket, error: engineError)
+            log.error(
+                "Web socket can not be disconnected when in \(connectionState) state",
+                subsystems: .webSocket,
+                error: engineError
+            )
         }
     }
     

--- a/Sources/StreamVideo/WebSockets/Events/Event.swift
+++ b/Sources/StreamVideo/WebSockets/Events/Event.swift
@@ -27,7 +27,7 @@ extension Event {
     }
 
     func forCall(cid: String) -> Bool {
-        guard let videoEvent = self.unwrap() else {
+        guard let videoEvent = unwrap() else {
             return false
         }
         guard let wsCallEvent = videoEvent.rawValue as? WSCallEvent else {
@@ -50,17 +50,19 @@ internal enum WrappedEvent: Event {
                 return HealthCheckInfo(coordinatorHealthCheck: healthCheckEvent)
             }
             if case let .typeConnectedEvent(connectedEvent) = event {
-                return HealthCheckInfo(coordinatorHealthCheck: .init(
-                    connectionId: connectedEvent.connectionId,
-                    createdAt: connectedEvent.createdAt,
-                    type: connectedEvent.type)
+                return HealthCheckInfo(
+                    coordinatorHealthCheck: .init(
+                        connectionId: connectedEvent.connectionId,
+                        createdAt: connectedEvent.createdAt,
+                        type: connectedEvent.type
+                    )
                 )
             }
         case let .sfuEvent(event):
             if case let .healthCheckResponse(healthCheckEvent) = event {
                 return HealthCheckInfo(sfuHealthCheck: healthCheckEvent)
             }
-        case .internalEvent(_):
+        case .internalEvent:
             break
         }
         return nil
@@ -77,7 +79,7 @@ internal enum WrappedEvent: Event {
                 return errorEvent.error
             }
             return nil
-        case .internalEvent(_):
+        case .internalEvent:
             break
         }
         return nil

--- a/Sources/StreamVideo/WebSockets/Events/WSEventsMiddleware.swift
+++ b/Sources/StreamVideo/WebSockets/Events/WSEventsMiddleware.swift
@@ -38,5 +38,4 @@ final class WSEventsMiddleware: EventMiddleware {
 protocol WSEventsSubscriber: AnyObject {
     
     func onEvent(_ event: WrappedEvent)
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallContainer.swift
+++ b/Sources/StreamVideoSwiftUI/CallContainer.swift
@@ -88,7 +88,7 @@ public struct CallContainer<Factory: ViewFactory>: View {
     
     private var shouldShowCallView: Bool {
         switch viewModel.callingState {
-        case .outgoing, .incoming(_), .inCall, .joining, .lobby(_):
+        case .outgoing, .incoming(_), .inCall, .joining, .lobby:
             return true
         default:
             return false

--- a/Sources/StreamVideoSwiftUI/CallView/CallControlsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallControlsView.swift
@@ -204,5 +204,4 @@ public struct SpeakerIconView: View {
             }
         )
     }
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 /// A view that presents the call's duration and recording state.
 public struct CallDurationView: View {
@@ -20,7 +20,7 @@ public struct CallDurationView: View {
     @MainActor
     public init(_ viewModel: CallViewModel) {
         self.viewModel = viewModel
-        self.duration = viewModel.call?.state.duration ?? 0
+        duration = viewModel.call?.state.duration ?? 0
     }
 
     public var body: some View {
@@ -28,14 +28,14 @@ public struct CallDurationView: View {
             if duration > 0, let formattedDuration = formatter.format(duration) {
                 HStack(spacing: 4) {
                     iconView
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 12)
-                    .foregroundColor(
-                        viewModel.recordingState == .recording
-                        ? colors.inactiveCallControl
-                        : colors.onlineIndicatorColor
-                    )
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 12)
+                        .foregroundColor(
+                            viewModel.recordingState == .recording
+                                ? colors.inactiveCallControl
+                                : colors.onlineIndicatorColor
+                        )
 
                     TimeView(formattedDuration)
                         .layoutPriority(2)
@@ -52,7 +52,7 @@ public struct CallDurationView: View {
         .accessibility(identifier: accessibilityLabel)
     }
 
-    // MARK - Private Helpers
+    // MARK: - Private Helpers
 
     private var iconView: Image {
         viewModel.recordingState == .recording
@@ -70,7 +70,7 @@ public struct CallDurationView: View {
     }
 }
 
-fileprivate struct TimeView: View {
+private struct TimeView: View {
 
     @Injected(\.fonts) private var fonts: Fonts
     @Injected(\.colors) private var colors: Colors
@@ -80,8 +80,16 @@ fileprivate struct TimeView: View {
     fileprivate init(_ value: String) {
         let attributed = NSMutableAttributedString(string: value)
         self.value = attributed
-        self.value.addAttribute(.foregroundColor, value: colors.callDurationColor.withAlphaComponent(0.6), range: .init(location: 0, length: attributed.length - 3))
-        self.value.addAttribute(.foregroundColor, value: colors.callDurationColor, range: .init(location: attributed.length - 3, length: 3))
+        self.value.addAttribute(
+            .foregroundColor,
+            value: colors.callDurationColor.withAlphaComponent(0.6),
+            range: .init(location: 0, length: attributed.length - 3)
+        )
+        self.value.addAttribute(
+            .foregroundColor,
+            value: colors.callDurationColor,
+            range: .init(location: attributed.length - 3, length: 3)
+        )
     }
 
     fileprivate var body: some View {

--- a/Sources/StreamVideoSwiftUI/CallView/CallTopView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallTopView.swift
@@ -21,9 +21,9 @@ public struct CallTopView: View {
         Group {
             HStack(spacing: 0) {
                 HStack {
-                    if 
+                    if
                         #available(iOS 14.0, *),
-                        viewModel.callParticipants.count > 1 
+                        viewModel.callParticipants.count > 1
                     {
                         LayoutMenuView(viewModel: viewModel)
                             .opacity(hideLayoutMenu ? 0 : 1)
@@ -58,12 +58,12 @@ public struct CallTopView: View {
         }
         .overlay(
             viewModel.call?.state.isCurrentUserScreensharing == true ?
-            SharingIndicator(
-                viewModel: viewModel,
-                sharingPopupDismissed: $sharingPopupDismissed
-            )
-            .opacity(sharingPopupDismissed ? 0 : 1)
-            : nil
+                SharingIndicator(
+                    viewModel: viewModel,
+                    sharingPopupDismissed: $sharingPopupDismissed
+                )
+                .opacity(sharingPopupDismissed ? 0 : 1)
+                : nil
         )
     }
     
@@ -103,10 +103,8 @@ public struct SharingIndicator: View {
                     .frame(height: 14)
             }
             .padding(.leading, 4)
-
         }
         .padding(.all, 8)
         .modifier(ShadowViewModifier())
     }
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallView/CallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallView.swift
@@ -3,8 +3,8 @@
 //
 
 import StreamVideo
-import SwiftUI
 import StreamWebRTC
+import SwiftUI
 
 public struct CallView<Factory: ViewFactory>: View {
 
@@ -46,9 +46,9 @@ public struct CallView<Factory: ViewFactory>: View {
                         .modifier(ShadowViewModifier())
                         .padding()
                         .accessibility(identifier: "participantEventLabel")
-#if STREAM_E2E_TESTS
+                    #if STREAM_E2E_TESTS
                         .offset(y: 300)
-#endif
+                    #endif
                 }
 
                 Spacer()
@@ -73,8 +73,7 @@ public struct CallView<Factory: ViewFactory>: View {
                 .accessibility(identifier: "localVideoView")
         } else if
             let screenSharingSession = viewModel.call?.state.screenSharingSession,
-            viewModel.call?.state.isCurrentUserScreensharing == false
-        {
+            viewModel.call?.state.isCurrentUserScreensharing == false {
             viewFactory.makeScreenSharingView(
                 viewModel: viewModel,
                 screensharingSession: screenSharingSession,
@@ -109,8 +108,8 @@ public struct CallView<Factory: ViewFactory>: View {
 
     private var shouldShowDraggableView: Bool {
         (viewModel.call?.state.screenSharingSession == nil || viewModel.call?.state.isCurrentUserScreensharing == true)
-        && viewModel.participantsLayout == .grid
-        && viewModel.participants.count <= 3
+            && viewModel.participantsLayout == .grid
+            && viewModel.participants.count <= 3
     }
 
     @ViewBuilder
@@ -140,7 +139,8 @@ public struct CallView<Factory: ViewFactory>: View {
                     availableFrame: bounds,
                     ratio: bounds.width / bounds.height,
                     showAllInfo: true
-                ))
+                )
+            )
             .accessibility(identifier: "minimizedParticipantView")
         } else {
             EmptyView()

--- a/Sources/StreamVideoSwiftUI/CallView/CornerDraggableView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CornerDraggableView.swift
@@ -33,7 +33,7 @@ public struct CornerDraggableView<Content: View>: View {
         self.onTap = onTap
 
         let proxyFrame = proxy.frame(in: .local)
-        self.availableFrame = .init(
+        availableFrame = .init(
             origin: .zero,
             size: .init(
                 width: proxyFrame.width * scaleFactorX,

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/ControlBadgeView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/ControlBadgeView.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 public struct ControlBadgeView: View {
     @Injected(\.colors) private var colors

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/Controls/ModalButton.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/Controls/ModalButton.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 public struct ModalButton: View {
 

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/Controls/ParticipantsListButton.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/Controls/ParticipantsListButton.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 /// A button that can be used to present toggle the Participants List's presentation. Additionally, it will
 /// display a badge with the number of the total participants in the call.

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/HorizontalParticipantsListView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/HorizontalParticipantsListView.swift
@@ -59,8 +59,8 @@ public struct HorizontalParticipantsListView<Factory: ViewFactory>: View {
         )
         self.barFrame = barFrame
 
-        let aspectRatioWidth = min(barFrame.width, barFrame.height * 16/9)
-        self.itemFrame = .init(
+        let aspectRatioWidth = min(barFrame.width, barFrame.height * 16 / 9)
+        itemFrame = .init(
             origin: .zero,
             size: .init(
                 width: aspectRatioWidth - innerItemSpace / 2,

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutMenuView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutMenuView.swift
@@ -51,13 +51,12 @@ public struct LayoutMenuView: View {
     }
 }
 
-
 struct LayoutMenuItem: View {
     
     var title: String
     var layout: ParticipantsLayout
     var selectedLayout: ParticipantsLayout
-    var selectLayout: (ParticipantsLayout) -> ()
+    var selectLayout: (ParticipantsLayout) -> Void
     
     var body: some View {
         Button {
@@ -74,5 +73,4 @@ struct LayoutMenuItem: View {
             }
         }
     }
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 @available(iOS 14.0, *)
 public struct LocalParticipantViewModifier: ViewModifier {
@@ -26,7 +26,7 @@ public struct LocalParticipantViewModifier: ViewModifier {
         self.localParticipant = localParticipant
         self.call = call
         _microphoneChecker = .init(wrappedValue: .init())
-        self._callSettings = callSettings
+        _callSettings = callSettings
         self.showAllInfo = showAllInfo
         self.decorations = .init(decorations)
     }
@@ -74,7 +74,6 @@ public struct LocalParticipantViewModifier: ViewModifier {
     }
 }
 
-
 @available(iOS, introduced: 13, obsoleted: 14)
 public struct LocalParticipantViewModifier_iOS13: ViewModifier {
 
@@ -95,7 +94,7 @@ public struct LocalParticipantViewModifier_iOS13: ViewModifier {
         self.localParticipant = localParticipant
         self.call = call
         _microphoneChecker = .init(wrappedValue: .init())
-        self._callSettings = callSettings
+        _callSettings = callSettings
         self.showAllInfo = showAllInfo
         self.decorations = .init(decorations)
     }

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoView.swift
@@ -99,7 +99,7 @@ struct CallParticipantsViewContainer: View {
                             )
                         }
                     }
-                        .padding(.horizontal)
+                    .padding(.horizontal)
                 }
 
                 HStack(spacing: 16) {
@@ -128,7 +128,7 @@ struct CallParticipantsViewContainer: View {
                     EmptyView()
                 }
             }
-            .toolbar{
+            .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     ModalButton(image: images.xmark, action: closeTapped)
                         .accessibility(identifier: "Close")
@@ -188,7 +188,7 @@ struct ParticipantsButton: View {
 struct BlockedUsersView: View {
     
     var blockedUsers: [User]
-    var unblockActions: @MainActor (User) -> [CallParticipantMenuAction]
+    var unblockActions: @MainActor(User) -> [CallParticipantMenuAction]
     
     var body: some View {
         HStack {
@@ -238,21 +238,21 @@ struct CallParticipantView: View {
                         UserAvatar(imageURL: imageURL, size: imageSize) {
                             CircledTitleView(
                                 title: participant.name.isEmpty
-                                ? participant.id
-                                : String(participant.name.uppercased().first!),
+                                    ? participant.id
+                                    : String(participant.name.uppercased().first!),
                                 size: imageSize
                             )
                         }
                     } else {
                         CircledTitleView(
                             title: participant.name.isEmpty
-                            ? participant.id
-                            : String(participant.name.uppercased().first!),
+                                ? participant.id
+                                : String(participant.name.uppercased().first!),
                             size: imageSize
                         )
                     }
                 }
-                .overlay(TopRightView { OnlineIndicatorView(indicatorSize: imageSize * 0.3) } )
+                .overlay(TopRightView { OnlineIndicatorView(indicatorSize: imageSize * 0.3) })
 
                 Text(participant.name)
                     .font(fonts.bodyBold)

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoViewModel.swift
@@ -108,10 +108,10 @@ class CallParticipantsInfoViewModel: ObservableObject {
         }
     }
     
-    private func executeMute(userId: String,audio: Bool = true,video: Bool = true){
+    private func executeMute(userId: String, audio: Bool = true, video: Bool = true) {
         guard let call else { return }
         Task {
-            try await call.mute(userId:userId, audio:audio, video:video)
+            try await call.mute(userId: userId, audio: audio, video: video)
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsFullScreenLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsFullScreenLayout.swift
@@ -3,8 +3,8 @@
 //
 
 import StreamVideo
-import SwiftUI
 import StreamWebRTC
+import SwiftUI
 
 public struct ParticipantsFullScreenLayout<Factory: ViewFactory>: View {
     
@@ -19,7 +19,7 @@ public struct ParticipantsFullScreenLayout<Factory: ViewFactory>: View {
         participant: CallParticipant,
         call: Call?,
         frame: CGRect,
-        onChangeTrackVisibility: @escaping @MainActor (CallParticipant, Bool) -> Void
+        onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
     ) {
         self.viewFactory = viewFactory
         self.participant = participant
@@ -50,9 +50,11 @@ public struct ParticipantsFullScreenLayout<Factory: ViewFactory>: View {
             log.debug("Participant \(participant.name) is visible")
             onChangeTrackVisibility(participant, true)
         }
-        .modifier(ParticipantChangeModifier(
-            participant: participant,
-            onChangeTrackVisibility: onChangeTrackVisibility)
+        .modifier(
+            ParticipantChangeModifier(
+                participant: participant,
+                onChangeTrackVisibility: onChangeTrackVisibility
+            )
         )
     }
     
@@ -77,5 +79,4 @@ struct ParticipantChangeModifier: ViewModifier {
             content
         }
     }
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridLayout.swift
@@ -3,8 +3,8 @@
 //
 
 import StreamVideo
-import SwiftUI
 import StreamWebRTC
+import SwiftUI
 
 public struct ParticipantsGridLayout<Factory: ViewFactory>: View {
     
@@ -309,7 +309,6 @@ struct VerticalParticipantsView<Factory: ViewFactory>: View {
         )
     }
 }
-
 
 struct HorizontalParticipantsView<Factory: ViewFactory>: View {
             

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridView.swift
@@ -3,8 +3,8 @@
 //
 
 import StreamVideo
-import SwiftUI
 import StreamWebRTC
+import SwiftUI
 
 @MainActor
 struct ParticipantsGridView<Factory: ViewFactory>: View {

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsSpotlightLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsSpotlightLayout.swift
@@ -21,7 +21,7 @@ public struct ParticipantsSpotlightLayout<Factory: ViewFactory>: View {
         participants: [CallParticipant],
         frame: CGRect,
         innerItemSpace: CGFloat = 8,
-        onChangeTrackVisibility: @escaping @MainActor (CallParticipant, Bool) -> Void
+        onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
     ) {
         self.viewFactory = viewFactory
         self.participant = participant
@@ -55,7 +55,7 @@ public struct ParticipantsSpotlightLayout<Factory: ViewFactory>: View {
     }
     
     private var topParticipantFrame: CGRect {
-        /// Top 
+        /// Top
         .init(
             origin: frame.origin,
             size: CGSize(width: frame.size.width, height: frame.height - participantsStripFrame.height - innerItemSpace)

--- a/Sources/StreamVideoSwiftUI/CallView/ReconnectionView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ReconnectionView.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 public struct ReconnectionView<Factory: ViewFactory>: View {
     

--- a/Sources/StreamVideoSwiftUI/CallView/RecordingView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/RecordingView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 public struct RecordingView: View {
     
-    public init() { /* Public init. */}
+    public init() { /* Public init. */ }
     
     public var body: some View {
         HStack {

--- a/Sources/StreamVideoSwiftUI/CallView/SampleBufferVideoCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/SampleBufferVideoCallView.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import UIKit
 import AVKit
+import UIKit
 
 final class SampleBufferVideoCallView: UIView {
     override class var layerClass: AnyClass {
@@ -11,6 +11,6 @@ final class SampleBufferVideoCallView: UIView {
     }
     
     var sampleBufferDisplayLayer: AVSampleBufferDisplayLayer {
-        return layer as! AVSampleBufferDisplayLayer
+        layer as! AVSampleBufferDisplayLayer
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/ScreenSharing/BroadcastPickerView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ScreenSharing/BroadcastPickerView.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import SwiftUI
 import ReplayKit
+import SwiftUI
 
 public struct BroadcastPickerView: UIViewRepresentable {
     
@@ -23,5 +23,4 @@ public struct BroadcastPickerView: UIViewRepresentable {
     }
     
     public func updateUIView(_ uiView: UIViewType, context: Context) {}
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallView/ScreenSharing/ScreenSharingView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ScreenSharing/ScreenSharingView.swift
@@ -30,7 +30,7 @@ public struct ScreenSharingView<Factory: ViewFactory>: View {
     ) {
         self.viewModel = viewModel
         self.screenSharing = screenSharing
-        self.frame = availableFrame
+        frame = availableFrame
         self.innerItemSpace = innerItemSpace
         self.viewFactory = viewFactory
         self.isZoomEnabled = isZoomEnabled
@@ -61,7 +61,7 @@ public struct ScreenSharingView<Factory: ViewFactory>: View {
                 )
             }
         }
-        .onRotate { newOrientation in
+        .onRotate { _ in
             orientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation ?? .unknown
         }
     }
@@ -73,7 +73,10 @@ public struct ScreenSharingView<Factory: ViewFactory>: View {
             contentMode: .scaleAspectFit
         ) { view in
             if let track = screenSharing.participant.screenshareTrack {
-                log.info("Found \(track.kind) track:\(track.trackId) for \(screenSharing.participant.name) and will add on \(type(of: self)):\(identifier))", subsystems: .webRTC)
+                log.info(
+                    "Found \(track.kind) track:\(track.trackId) for \(screenSharing.participant.name) and will add on \(type(of: self)):\(identifier))",
+                    subsystems: .webRTC
+                )
                 view.add(track: track)
             }
         }
@@ -120,5 +123,4 @@ struct HorizontalContainer<Content: View>: View {
             HStack(content: content)
         }
     }
-    
 }

--- a/Sources/StreamVideoSwiftUI/CallView/ScreenSharing/ScreensharingControls.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ScreenSharing/ScreensharingControls.swift
@@ -53,7 +53,7 @@ public struct BroadcastIconView: View {
         self.viewModel = viewModel
         self.preferredExtension = preferredExtension
         self.size = size
-        self.offset = {
+        offset = {
             if #available(iOS 16.0, *) {
                 return .init(x: -5, y: -4)
             } else {

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -3,8 +3,8 @@
 //
 
 import StreamVideo
-import SwiftUI
 import StreamWebRTC
+import SwiftUI
 
 public struct VideoParticipantsView<Factory: ViewFactory>: View {
     
@@ -71,7 +71,6 @@ public struct VideoParticipantsView<Factory: ViewFactory>: View {
                 orientation = .landscapeRight
             default:
                 orientation = .unknown
-                break
             }
         }
     }
@@ -243,7 +242,8 @@ public struct VideoCallParticipantOptionsModifier: ViewModifier {
             .actionSheet(isPresented: $presentActionSheet) {
                 ActionSheet(
                     title: Text("\(participant.name)"),
-                    buttons: elements.map { ActionSheet.Button.default(Text($0.title), action: $0.action) } + [ActionSheet.Button.cancel()]
+                    buttons: elements
+                        .map { ActionSheet.Button.default(Text($0.title), action: $0.action) } + [ActionSheet.Button.cancel()]
                 )
             }
         }
@@ -454,16 +454,15 @@ public struct SoundIndicator: View {
             .accessibility(identifier: "participantMic")
             .streamAccessibility(value: participant.hasAudio ? "1" : "0")
     }
-    
 }
 
 public struct PopoverButton: View {
         
     var title: String
     @Binding var popoverShown: Bool
-    var action: () -> ()
+    var action: () -> Void
     
-    public init(title: String, popoverShown: Binding<Bool>, action: @escaping () -> ()) {
+    public init(title: String, popoverShown: Binding<Bool>, action: @escaping () -> Void) {
         self.title = title
         _popoverShown = popoverShown
         self.action = action

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRenderer.swift
@@ -2,11 +2,11 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import StreamVideo
-import SwiftUI
-import StreamWebRTC
-import MetalKit
 import Combine
+import MetalKit
+import StreamVideo
+import StreamWebRTC
+import SwiftUI
 
 public struct LocalVideoView<Factory: ViewFactory>: View {
     
@@ -54,7 +54,6 @@ public struct LocalVideoView<Factory: ViewFactory>: View {
     private var shouldRotate: Bool {
         callSettings.cameraPosition == .front && callSettings.videoOn
     }
-    
 }
 
 public struct VideoRendererView: UIViewRepresentable {
@@ -93,8 +92,8 @@ public struct VideoRendererView: UIViewRepresentable {
 
     public func makeUIView(context: Context) -> VideoRenderer {
         let view = showVideo
-        ? utils.videoRendererFactory.view(for: id, size: size)
-        : VideoRenderer()
+            ? utils.videoRendererFactory.view(for: id, size: size)
+            : VideoRenderer()
         view.videoContentMode = contentMode
         view.backgroundColor = colors.participantBackground
         if showVideo {
@@ -127,14 +126,15 @@ public class VideoRenderer: RTCMTLVideoView {
             log.debug("🔄 preferredFramesPerSecond was updated to \(preferredFramesPerSecond).")
         }
     }
+
     private lazy var metalView: MTKView? = { subviews.compactMap { $0 as? MTKView }.first }()
-    var trackId: String? { self.track?.trackId }
+    var trackId: String? { track?.trackId }
     private var viewSize: CGSize?
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         cancellable = thermalStateObserver
             .statePublisher
@@ -158,7 +158,7 @@ public class VideoRenderer: RTCMTLVideoView {
         track?.remove(self)
     }
 
-    public override var hash: Int { identifier.hashValue }
+    override public var hash: Int { identifier.hashValue }
 
     public func add(track: RTCVideoTrack) {
         queue.sync {
@@ -170,9 +170,9 @@ public class VideoRenderer: RTCMTLVideoView {
         }
     }
     
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
-        self.viewSize = bounds.size
+        viewSize = bounds.size
     }
 }
 
@@ -180,16 +180,22 @@ extension VideoRenderer {
     
     public func handleViewRendering(
         for participant: CallParticipant,
-        onTrackSizeUpdate: @escaping (CGSize, CallParticipant) -> ()
+        onTrackSizeUpdate: @escaping (CGSize, CallParticipant) -> Void
     ) {
         if let track = participant.track {
-            log.info("Found \(track.kind) track:\(track.trackId) for \(participant.name) and will add on \(type(of: self)):\(identifier))", subsystems: .webRTC)
-            self.add(track: track)
+            log.info(
+                "Found \(track.kind) track:\(track.trackId) for \(participant.name) and will add on \(type(of: self)):\(identifier))",
+                subsystems: .webRTC
+            )
+            add(track: track)
             DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 0.01) { [weak self] in
                 guard let self else { return }
                 let prev = participant.trackSize
                 if let viewSize, prev != viewSize {
-                    log.debug("Update trackSize of \(track.kind) track for \(participant.name) on \(type(of: self)):\(identifier)), \(prev) → \(viewSize)", subsystems: .webRTC)
+                    log.debug(
+                        "Update trackSize of \(track.kind) track for \(participant.name) on \(type(of: self)):\(identifier)), \(prev) → \(viewSize)",
+                        subsystems: .webRTC
+                    )
                     onTrackSizeUpdate(viewSize, participant)
                 }
             }

--- a/Sources/StreamVideoSwiftUI/CallView/ViewModifiers/ParticipantsListViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ViewModifiers/ParticipantsListViewModifier.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 extension View {
 
@@ -15,10 +15,10 @@ extension View {
         @ObservedObject viewModel: CallViewModel,
         viewFactory: Factory
     ) -> some View {
-        self.halfSheet(isPresented: $viewModel.participantsShown) {
+        halfSheet(isPresented: $viewModel.participantsShown) {
             viewFactory.makeParticipantsListView(viewModel: viewModel)
-            .opacity(viewModel.hideUIElements ? 0 : 1)
-            .accessibility(identifier: "trailingTopView")
+                .opacity(viewModel.hideUIElements ? 0 : 1)
+                .accessibility(identifier: "trailingTopView")
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/VisibilityThresholdModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VisibilityThresholdModifier.swift
@@ -30,9 +30,10 @@ struct VisibilityThresholdModifier: ViewModifier {
     /// Closure to handle visibility changes.
     var changeHandler: (Bool) -> Void
 
-    init(in bounds: CGRect,
-         threshold: CGFloat,
-         changeHandler: @escaping (Bool) -> Void
+    init(
+        in bounds: CGRect,
+        threshold: CGFloat,
+        changeHandler: @escaping (Bool) -> Void
     ) {
         self.bounds = bounds
         self.threshold = threshold
@@ -72,10 +73,10 @@ struct VisibilityThresholdModifier: ViewModifier {
 
         /// Check if the content view is vertically within the parent's bounds.
         let verticalVisible = (minY + requiredHeight <= bounds.maxY && minY >= bounds.minY) ||
-        (maxY - requiredHeight >= bounds.minY && maxY <= bounds.maxY)
+            (maxY - requiredHeight >= bounds.minY && maxY <= bounds.maxY)
         /// Check if the content view is horizontally within the parent's bounds.
         let horizontalVisible = (minX + requiredWidth <= bounds.maxX && minX >= bounds.minX) ||
-        (maxX - requiredWidth >= bounds.minX && maxX <= bounds.maxX)
+            (maxX - requiredWidth >= bounds.minX && maxX <= bounds.maxX)
 
         return (verticalVisible, horizontalVisible)
     }

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift
@@ -34,8 +34,8 @@ struct DefaultBackgroundGradient: View {
     var body: some View {
         LinearGradient(
             colors: [
-                Color(red: 60/255, green: 64/255, blue: 72/255),
-                Color(red: 30/255, green: 33/255, blue: 36/255)
+                Color(red: 60 / 255, green: 64 / 255, blue: 72 / 255),
+                Color(red: 30 / 255, green: 33 / 255, blue: 36 / 255)
             ],
             startPoint: .top,
             endPoint: .bottom

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
@@ -30,7 +30,7 @@ struct CallConnectingView<CallControls: View, CallTopView: View>: View {
                         participants: outgoingCallMembers
                     )
                     .accessibility(identifier: "callConnectingGroupView")
-                } else if outgoingCallMembers.count > 0 {
+                } else if !outgoingCallMembers.isEmpty {
                     AnimatingParticipantView(
                         participant: outgoingCallMembers.first
                     )

--- a/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallViewModel.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
 import StreamVideo
 
 @MainActor
@@ -46,5 +46,4 @@ public class IncomingViewModel: ObservableObject {
         ringingTimer?.invalidate()
         ringingTimer = nil
     }
-
 }

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneCheckView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneCheckView.swift
@@ -128,6 +128,7 @@ struct AudioLevel: Identifiable {
     var id: String {
         "\(index)-\(value)"
     }
+
     let value: Float
     let index: Int
 }

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -3,9 +3,9 @@
 //
 
 import AVFoundation
+import Combine
 import Foundation
 import StreamVideo
-import Combine
 
 /// Checks the audio capabilities of the device.
 public class MicrophoneChecker: ObservableObject {
@@ -49,7 +49,7 @@ public class MicrophoneChecker: ObservableObject {
         self.valueLimit = valueLimit
         self.audioSession = audioSession
         self.notificationCenter = notificationCenter
-        self.audioLevels = [Float](repeating: 0.0, count: valueLimit)
+        audioLevels = [Float](repeating: 0.0, count: valueLimit)
         setUpAudioCapture()
 
         subscribeToCallEnded()
@@ -76,7 +76,7 @@ public class MicrophoneChecker: ObservableObject {
         stopAudioRecorder()
     }
     
-    //MARK: - private
+    // MARK: - private
 
     private func subscribeToCallEnded() {
         callEndedCancellable = notificationCenter
@@ -120,7 +120,7 @@ public class MicrophoneChecker: ObservableObject {
 
         newAudioRecorder.record()
         newAudioRecorder.isMeteringEnabled = true
-        self.audioRecorder = newAudioRecorder
+        audioRecorder = newAudioRecorder
         timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
             newAudioRecorder.updateMeters()

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -14,16 +14,16 @@ public struct LobbyView: View {
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
-    var onJoinCallTap: () -> ()
-    var onCloseLobby: () -> ()
+    var onJoinCallTap: () -> Void
+    var onCloseLobby: () -> Void
         
     public init(
         viewModel: LobbyViewModel? = nil,
         callId: String,
         callType: String,
         callSettings: Binding<CallSettings>,
-        onJoinCallTap: @escaping () -> (),
-        onCloseLobby: @escaping () -> ()
+        onJoinCallTap: @escaping () -> Void,
+        onCloseLobby: @escaping () -> Void
     ) {
         self.callId = callId
         self.callType = callType
@@ -63,8 +63,8 @@ struct LobbyContentView: View {
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
-    var onJoinCallTap: () -> ()
-    var onCloseLobby: () -> ()
+    var onJoinCallTap: () -> Void
+    var onCloseLobby: () -> Void
     
     var body: some View {
         VStack {
@@ -189,7 +189,7 @@ struct JoinCallView: View {
     var callId: String
     var callType: String
     var callParticipants: [User]
-    var onJoinCallTap: () -> ()
+    var onJoinCallTap: () -> Void
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -201,7 +201,7 @@ struct JoinCallView: View {
                 .streamAccessibility(value: "\(otherParticipantsCount)")
             
             if #available(iOS 14, *) {
-                if callParticipants.count > 0 {
+                if !callParticipants.isEmpty {
                     ParticipantsInCallView(
                         callParticipants: callParticipants
                     )
@@ -227,7 +227,7 @@ struct JoinCallView: View {
     }
     
     private var waitingRoomDescription: String {
-        return "\(L10n.WaitingRoom.description) \(L10n.WaitingRoom.numberOfParticipants(callParticipants.count))"
+        "\(L10n.WaitingRoom.description) \(L10n.WaitingRoom.numberOfParticipants(callParticipants.count))"
     }
     
     private var otherParticipantsCount: Int {
@@ -316,13 +316,15 @@ struct ParticipantsInCallView: View {
                         if let imageURL = participant.user.imageURL {
                             UserAvatar(imageURL: imageURL, size: 40) {
                                 CircledTitleView(
-                                    title: participant.user.name.isEmpty ? participant.user.id : String(participant.user.name.uppercased().first!),
+                                    title: participant.user.name.isEmpty ? participant.user
+                                        .id : String(participant.user.name.uppercased().first!),
                                     size: 40
                                 )
                             }
                         } else {
                             CircledTitleView(
-                                title: participant.user.name.isEmpty ? participant.user.id : String(participant.user.name.uppercased().first!),
+                                title: participant.user.name.isEmpty ? participant.user
+                                    .id : String(participant.user.name.uppercased().first!),
                                 size: 40
                             )
                         }

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
@@ -19,7 +19,7 @@ public class LobbyViewModel: ObservableObject, @unchecked Sendable {
     private let call: Call
     
     public init(callType: String, callId: String) {
-        self.call = InjectedValues[\.streamVideo].call(
+        call = InjectedValues[\.streamVideo].call(
             callType: callType,
             callId: callId
         )
@@ -53,7 +53,7 @@ public class LobbyViewModel: ObservableObject, @unchecked Sendable {
     public func startCamera(front: Bool) {
         if #available(iOS 14, *) {
             Task {
-                await (camera as? Camera)?.start()
+                await(camera as? Camera)?.start()
                 if front {
                     (camera as? Camera)?.switchCaptureDevice()
                 }
@@ -82,7 +82,7 @@ public class LobbyViewModel: ObservableObject, @unchecked Sendable {
         Task {
             let response = try await call.get()
             withAnimation {
-                participants = response.session?.participants.map { $0.user.toUser } ?? []
+                participants = response.session?.participants.map(\.user.toUser) ?? []
             }
         }
     }

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -15,16 +15,16 @@ struct LobbyView_iOS13: View {
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
-    var onJoinCallTap: () -> ()
-    var onCloseLobby: () -> ()
+    var onJoinCallTap: () -> Void
+    var onCloseLobby: () -> Void
     
     public init(
         callViewModel: CallViewModel,
         callId: String,
         callType: String,
         callSettings: Binding<CallSettings>,
-        onJoinCallTap: @escaping () -> (),
-        onCloseLobby: @escaping () -> ()
+        onJoinCallTap: @escaping () -> Void,
+        onCloseLobby: @escaping () -> Void
     ) {
         _callViewModel = ObservedObject(wrappedValue: callViewModel)
         _viewModel = BackportStateObject(

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/VideoView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/VideoView_iOS13.swift
@@ -43,7 +43,7 @@ public struct CallContainer_iOS13<Factory: ViewFactory>: View {
             }
         }
         .alert(isPresented: $viewModel.errorAlertShown, content: {
-            return Alert.defaultErrorAlert
+            Alert.defaultErrorAlert
         })
         .overlay(overlayView)
         .onReceive(viewModel.$callingState) { _ in

--- a/Sources/StreamVideoSwiftUI/Colors.swift
+++ b/Sources/StreamVideoSwiftUI/Colors.swift
@@ -61,7 +61,7 @@ private extension UIColor {
     static let streamBlueAlice = mode(0xe9f2ff, 0x00193d)
     static let streamAccentBlue = mode(0x005fff, 0x005fff)
     static let streamAccentRed = mode(0xff3742, 0xff3742)
-    static let streamAccentGreen = mode(0x00E2A1, 0x00E2A1)
+    static let streamAccentGreen = mode(0x00e2a1, 0x00e2a1)
     static let streamGrayDisabledText = mode(0x72767e, 0x72767e)
     static let streamInnerBorder = mode(0xdbdde1, 0x272a30)
     static let streamHighlight = mode(0xfbf4dd, 0x333024)
@@ -71,7 +71,7 @@ private extension UIColor {
     static let streamCallControlsBackground = mode(0xffffff, 0x1c1e22)
     static let streamWaitingRoomBackground = mode(0xffffff, 0x2c2c2e)
     static let streamWaitingRoomSecondaryBackground = mode(0xf2f2f2, 0x1c1c1e)
-    static let streamParticipantBackground = mode(0x19232D, 0x19232D)
+    static let streamParticipantBackground = mode(0x19232d, 0x19232d)
 
     // Currently we are not using the correct shadow color from figma's color palette. This is to avoid
     // an issue with snapshots inconsistency between Intel vs M1. We can't use shadows with transparency.

--- a/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayer.swift
+++ b/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayer.swift
@@ -10,7 +10,7 @@ public struct LivestreamPlayer: View {
     
     @Injected(\.colors) var colors
     
-    var onFullScreenStateChange: ((Bool) -> ())?
+    var onFullScreenStateChange: ((Bool) -> Void)?
     
     @StateObject var state: CallState
     @StateObject var viewModel: LivestreamPlayerViewModel
@@ -20,7 +20,7 @@ public struct LivestreamPlayer: View {
         id: String,
         muted: Bool = false,
         showParticipantCount: Bool = true,
-        onFullScreenStateChange: ((Bool) -> ())? = nil
+        onFullScreenStateChange: ((Bool) -> Void)? = nil
     ) {
         let viewModel = LivestreamPlayerViewModel(
             type: type,
@@ -131,7 +131,6 @@ struct LiveIndicator: View {
             .background(colors.primaryButtonBackground)
             .cornerRadius(8)
     }
-    
 }
 
 struct LivestreamPlayPauseButton: View {
@@ -139,7 +138,7 @@ struct LivestreamPlayPauseButton: View {
     @Injected(\.colors) var colors
     
     @ObservedObject var viewModel: LivestreamPlayerViewModel
-    var trackUpdate: () -> ()
+    var trackUpdate: () -> Void
     
     var body: some View {
         Button {
@@ -152,7 +151,6 @@ struct LivestreamPlayPauseButton: View {
                 .frame(width: 60)
                 .foregroundColor(colors.livestreamCallControlsColor)
         }
-
     }
 }
 
@@ -199,7 +197,7 @@ struct LivestreamButton: View {
     private let buttonSize: CGFloat = 32
     
     var imageName: String
-    var action: () -> ()
+    var action: () -> Void
     
     var body: some View {
         Button {
@@ -213,6 +211,6 @@ struct LivestreamButton: View {
                 .background(colors.participantInfoBackgroundColor)
                 .cornerRadius(8)
         }
-        .padding(.horizontal, 2)        
+        .padding(.horizontal, 2)
     }
 }

--- a/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayerViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayerViewModel.swift
@@ -11,15 +11,16 @@ final class LivestreamPlayerViewModel: ObservableObject {
     @Published private(set) var controlsShown = false {
         didSet {
             if controlsShown {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
                     guard let self else { return }
                     if !self.streamPaused {
                         self.controlsShown = false
                     }
-                })
+                }
             }
         }
     }
+
     @Published private(set) var streamPaused = false
     @Published private(set) var loading = false
     @Published private(set) var muted: Bool
@@ -58,7 +59,7 @@ final class LivestreamPlayerViewModel: ObservableObject {
     }
     
     func duration(from state: CallState) -> String? {
-        guard state.duration > 0  else { return nil }
+        guard state.duration > 0 else { return nil }
         return formatter.string(from: state.duration)
     }
     

--- a/Sources/StreamVideoSwiftUI/Models/CallEventsHandler.swift
+++ b/Sources/StreamVideoSwiftUI/Models/CallEventsHandler.swift
@@ -11,35 +11,35 @@ public class CallEventsHandler {
         
     public func checkForCallEvents(from event: VideoEvent) -> CallEvent? {
         switch event {
-        case .typeBlockedUserEvent(let blockedUserEvent):
+        case let .typeBlockedUserEvent(blockedUserEvent):
             let callEventInfo = CallEventInfo(
                 callCid: blockedUserEvent.callCid,
                 user: blockedUserEvent.user.toUser,
                 action: .block
             )
             return .userBlocked(callEventInfo)
-        case .typeCallAcceptedEvent(let callAcceptedEvent):
+        case let .typeCallAcceptedEvent(callAcceptedEvent):
             let callEventInfo = CallEventInfo(
                 callCid: callAcceptedEvent.callCid,
                 user: callAcceptedEvent.user.toUser,
                 action: .accept
             )
             return .accepted(callEventInfo)
-        case .typeCallEndedEvent(let callEndedEvent):
+        case let .typeCallEndedEvent(callEndedEvent):
             let callEventInfo = CallEventInfo(
                 callCid: callEndedEvent.callCid,
                 user: callEndedEvent.user?.toUser,
                 action: .end
             )
             return .ended(callEventInfo)
-        case .typeCallRejectedEvent(let callRejectedEvent):
+        case let .typeCallRejectedEvent(callRejectedEvent):
             let callEventInfo = CallEventInfo(
                 callCid: callRejectedEvent.callCid,
                 user: callRejectedEvent.user.toUser,
                 action: .reject
             )
             return .rejected(callEventInfo)
-        case .typeCallRingEvent(let ringEvent):
+        case let .typeCallRingEvent(ringEvent):
             log.debug("Received ring event \(ringEvent)")
             let cId = ringEvent.callCid
             let id = cId.components(separatedBy: ":").last ?? cId
@@ -53,13 +53,13 @@ public class CallEventsHandler {
                 timeout: TimeInterval(ringEvent.call.settings.ring.autoCancelTimeoutMs / 1000)
             )
             return .incoming(incomingCall)
-        case .typeCallSessionStartedEvent(let callSessionStartedEvent):
+        case let .typeCallSessionStartedEvent(callSessionStartedEvent):
             if let session = callSessionStartedEvent.call.session {
                 return .sessionStarted(session)
             } else {
                 return nil
             }
-        case .typeUnblockedUserEvent(let unblockedUserEvent):
+        case let .typeUnblockedUserEvent(unblockedUserEvent):
             let callEventInfo = CallEventInfo(
                 callCid: unblockedUserEvent.callCid,
                 user: unblockedUserEvent.user.toUser,
@@ -73,14 +73,14 @@ public class CallEventsHandler {
     
     public func checkForParticipantEvents(from event: VideoEvent) -> ParticipantEvent? {
         switch event {
-        case .typeCallSessionParticipantJoinedEvent(let event):
+        case let .typeCallSessionParticipantJoinedEvent(event):
             return ParticipantEvent(
                 id: event.participant.user.id,
                 action: .join,
                 user: event.participant.user.name ?? event.participant.user.id,
                 imageURL: URL(string: event.participant.user.image ?? "")
             )
-        case .typeCallSessionParticipantLeftEvent(let event):
+        case let .typeCallSessionParticipantLeftEvent(event):
             return ParticipantEvent(
                 id: event.participant.user.id,
                 action: .leave,

--- a/Sources/StreamVideoSwiftUI/Utils/Camera.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/Camera.swift
@@ -253,7 +253,7 @@ class Camera: NSObject, @unchecked Sendable {
         }
     }
     
-    func stop() {        
+    func stop() {
         if captureSession.isRunning {
             sessionQueue.async {
                 self.captureSession.stopRunning()

--- a/Sources/StreamVideoSwiftUI/Utils/Formatters/MediaDurationFormatter.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/Formatters/MediaDurationFormatter.swift
@@ -31,9 +31,8 @@ open class StreamMediaDurationFormatter: MediaDurationFormatter {
 
     open func format(_ time: TimeInterval) -> String? {
         let dateComponentsFormatter = time < 3600
-        ? withoutHoursDateComponentsFormatter
-        : withHoursDateComponentsFormatter
+            ? withoutHoursDateComponentsFormatter
+            : withHoursDateComponentsFormatter
         return dateComponentsFormatter.string(from: time)
     }
 }
-

--- a/Sources/StreamVideoSwiftUI/Utils/HalfSheetView.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/HalfSheetView.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 struct HalfSheetView<Content: View>: View {
     @Injected(\.colors) var colors
@@ -42,7 +42,10 @@ struct DraggableSheetView<Content: View>: View {
         GeometryReader { proxy in
             VStack(spacing: 0) {
                 DragHandleView()
-                    .background(Color(colors.callBackground)) // Give the view "volume" so the DragGesture is effective from it's whole width.
+                    .background(Color(
+                        colors
+                            .callBackground
+                    )) // Give the view "volume" so the DragGesture is effective from it's whole width.
                     .padding(.vertical, 5)
                     .padding(.horizontal, 24) // Avoid collision with rounded corners.
                     .gesture(
@@ -99,8 +102,8 @@ extension View {
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content
-    ) -> some View where Content : View {
-        if #available (iOS 16.0, *) {
+    ) -> some View where Content: View {
+        if #available(iOS 16.0, *) {
             sheet(isPresented: isPresented, onDismiss: onDismiss) {
                 content()
                     .padding(.vertical)

--- a/Sources/StreamVideoSwiftUI/Utils/LazyImageExtensions.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/LazyImageExtensions.swift
@@ -44,20 +44,20 @@ public struct StreamLazyImage<Failback: View>: View {
         if failedToLoadContent, let failback {
             failback()
         } else {
-#if STREAM_SNAPSHOT_TESTS
+            #if STREAM_SNAPSHOT_TESTS
             if let imageURL = imageURL,
                imageURL.isFileURL,
-               let image = UIImage(contentsOfFile: imageURL.path)  {
+               let image = UIImage(contentsOfFile: imageURL.path) {
                 NukeImage(image)
                     .aspectRatio(contentMode: .fill)
             } else {
                 LazyImage(imageURL: imageURL)
                     .onFailure { _ in self.failedToLoadContent = true }
             }
-#else
+            #else
             LazyImage(imageURL: imageURL)
                 .onFailure { _ in self.failedToLoadContent = true }
-#endif
+            #endif
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/ModifiedContent.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/ModifiedContent.swift
@@ -8,7 +8,7 @@ extension View {
 
     public func streamAccessibility(value: String) -> some View {
         #if DEBUG
-        return self.accessibility(value: Text(value))
+        return accessibility(value: Text(value))
         #else
         return self
         #endif

--- a/Sources/StreamVideoSwiftUI/Utils/Modifiers.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/Modifiers.swift
@@ -101,6 +101,6 @@ struct DeviceRotationViewModifier: ViewModifier {
 
 extension View {
     public func onRotate(perform action: @escaping (UIDeviceOrientation) -> Void) -> some View {
-        self.modifier(DeviceRotationViewModifier(action: action))
+        modifier(DeviceRotationViewModifier(action: action))
     }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -26,7 +26,8 @@ protocol StreamAVPictureInPictureViewControlling {
 }
 
 @available(iOS 15.0, *)
-final class StreamAVPictureInPictureVideoCallViewController: AVPictureInPictureVideoCallViewController, StreamAVPictureInPictureViewControlling {
+final class StreamAVPictureInPictureVideoCallViewController: AVPictureInPictureVideoCallViewController,
+    StreamAVPictureInPictureViewControlling {
 
     private let contentView: StreamPictureInPictureVideoRenderer = .init()
 

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
@@ -43,7 +43,7 @@ struct StreamBufferTransformer {
     ) -> CMSampleBuffer? {
         var sampleBuffer: CMSampleBuffer?
 
-        var timimgInfo  = CMSampleTimingInfo()
+        var timimgInfo = CMSampleTimingInfo()
         var formatDescription: CMFormatDescription?
         CMVideoFormatDescriptionCreateForImageBuffer(
             allocator: kCFAllocatorDefault,
@@ -182,7 +182,7 @@ struct StreamBufferTransformer {
                 let vValue = Int(vPlane[vOffset]) - 128
 
                 let index = (y * bgraBytesPerRow) + (x * 4)
-                var pixel: [UInt8] = [0, 0, 0, 255]  // BGRA format, fully opaque
+                var pixel: [UInt8] = [0, 0, 0, 255] // BGRA format, fully opaque
 
                 // Perform YUV to RGB conversion with chroma upsampling
                 let c = yValue - 16
@@ -209,6 +209,6 @@ struct StreamBufferTransformer {
     }
 
     private func clamp(_ value: Int) -> UInt8 {
-        return UInt8(max(0, min(255, value)))
+        UInt8(max(0, min(255, value)))
     }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPIctureView.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPIctureView.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StreamVideo
+import SwiftUI
 
 /// A view that can be used as the sourceView for picture-in-picture. This is quite useful as PiP can become
 /// very weird if the sourceView isn't in the ViewHierarchy or doesn't have an appropriate size.
@@ -64,6 +64,6 @@ extension View {
     /// - Note:The View itself won't be used as sourceView.
     @ViewBuilder
     public func enablePictureInPicture(_ isActive: Bool) -> some View {
-        self.modifier(PictureInPictureModifier(isActive: isActive))
+        modifier(PictureInPictureModifier(isActive: isActive))
     }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureAdapter.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureAdapter.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
 import StreamVideo
 import UIKit
 
@@ -72,7 +72,8 @@ final class StreamPictureInPictureAdapter {
         let sessionId = call?.state.sessionId
         let otherParticipants = participants.filter { $0.sessionId != sessionId }
 
-        if let session = call?.state.screenSharingSession, call?.state.isCurrentUserScreensharing == false, let track = session.track {
+        if let session = call?.state.screenSharingSession, call?.state.isCurrentUserScreensharing == false,
+           let track = session.track {
             pictureInPictureController?.track = track
             activeParticipant = nil
         } else if let participant = otherParticipants.first(where: { $0.track != nil }), let track = participant.track {

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
@@ -2,11 +2,11 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import AVKit
-import StreamWebRTC
-import StreamVideo
 import Combine
+import Foundation
+import StreamVideo
+import StreamWebRTC
 
 /// A controller class for picture-in-picture whenever that is possible.
 final class StreamPictureInPictureController: NSObject, AVPictureInPictureControllerDelegate {
@@ -48,20 +48,19 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
     /// A set of `AnyCancellable` objects used to manage subscriptions.
     private var cancellableBag: Set<AnyCancellable> = []
 
-    /// A `AnyCancellable` object used to ensure that the active track is enabled while in picture-in-picture 
+    /// A `AnyCancellable` object used to ensure that the active track is enabled while in picture-in-picture
     /// mode.
     private var ensureActiveTrackIsEnabledCancellable: AnyCancellable?
 
-    /// A `StreamPictureInPictureTrackStateAdapter` object that manages the state of the 
+    /// A `StreamPictureInPictureTrackStateAdapter` object that manages the state of the
     /// active track.
     private let trackStateAdapter: StreamPictureInPictureTrackStateAdapter = .init()
-
 
     // MARK: - Lifecycle
 
     /// Initializes the controller and creates the content view
     ///
-    /// - Parameter canStartPictureInPictureAutomaticallyFromInline A boolean value 
+    /// - Parameter canStartPictureInPictureAutomaticallyFromInline A boolean value
     /// indicating whether the picture-in-picture session should start automatically when the app enters
     /// background.
     ///
@@ -146,11 +145,12 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
                 pictureInPictureController?
                     .publisher(for: \.isPictureInPictureActive)
                     .removeDuplicates()
-                    .sink { [weak self] in self?.didUpdatePictureInPictureActiveState($0)  }
+                    .sink { [weak self] in self?.didUpdatePictureInPictureActiveState($0) }
                     .store(in: &cancellableBag)
             } else {
                 // If picture-in-picture is active, simply update the sourceView.
-                if #available(iOS 15.0, *), let contentViewController = contentViewController as? StreamAVPictureInPictureVideoCallViewController {
+                if #available(iOS 15.0, *),
+                   let contentViewController = contentViewController as? StreamAVPictureInPictureVideoCallViewController {
                     pictureInPictureController?.contentSource = .init(
                         activeVideoCallSourceView: sourceView,
                         contentViewController: contentViewController
@@ -165,16 +165,19 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
     }
 
     private func makePictureInPictureController(with sourceView: UIView) {
-        if #available(iOS 15.0, *), let contentViewController = contentViewController as? StreamAVPictureInPictureVideoCallViewController {
+        if #available(iOS 15.0, *),
+           let contentViewController = contentViewController as? StreamAVPictureInPictureVideoCallViewController {
             pictureInPictureController = .init(
                 contentSource: .init(
                     activeVideoCallSourceView: sourceView,
                     contentViewController: contentViewController
-                ))
+                )
+            )
         }
 
         if #available(iOS 14.2, *) {
-            pictureInPictureController?.canStartPictureInPictureAutomaticallyFromInline = canStartPictureInPictureAutomaticallyFromInline
+            pictureInPictureController?
+                .canStartPictureInPictureAutomaticallyFromInline = canStartPictureInPictureAutomaticallyFromInline
         }
 
         pictureInPictureController?.delegate = self

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapter.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapter.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
-import StreamWebRTC
 import Combine
+import Foundation
 import StreamVideo
+import StreamWebRTC
 
 /// StreamPictureInPictureTrackStateAdapter serves as an adapter for managing the state of a video track
 /// used for picture-in-picture functionality. It can enable or disable observers based on its isEnabled property
@@ -16,7 +16,7 @@ final class StreamPictureInPictureTrackStateAdapter {
     var isEnabled: Bool = false {
         didSet {
             /// When the 'isEnabled' property changes, this didSet observer is called.
-            /// It checks if the new value is different from the old value, and if so, 
+            /// It checks if the new value is different from the old value, and if so,
             /// it calls the 'enableObserver' function.
             guard isEnabled != oldValue else { return }
             enableObserver(isEnabled)

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureVideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureVideoRenderer.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import StreamWebRTC
-import Foundation
 import Combine
+import Foundation
 import StreamVideo
+import StreamWebRTC
 
 /// A view that can be used to render an instance of `RTCVideoTrack`
 final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
@@ -52,7 +52,7 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
     /// The track's size.
     private var trackSize: CGSize = .zero {
         didSet {
-            guard trackSize != oldValue else { return  }
+            guard trackSize != oldValue else { return }
             didUpdateTrackSize()
         }
     }
@@ -129,14 +129,12 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
 
         if
             let pixelBuffer = frame.buffer as? RTCCVPixelBuffer,
-            let sampleBuffer = bufferTransformer.transform(pixelBuffer.pixelBuffer)
-        {
+            let sampleBuffer = bufferTransformer.transform(pixelBuffer.pixelBuffer) {
             bufferPublisher.send(sampleBuffer)
         } else if
             let i420buffer = frame.buffer as? RTCI420Buffer,
             let transformedBuffer = bufferTransformer.transform(i420buffer, targetSize: contentSize),
-            let sampleBuffer = bufferTransformer.transform(transformedBuffer)
-        {
+            let sampleBuffer = bufferTransformer.transform(transformedBuffer) {
             bufferPublisher.send(sampleBuffer)
         } else {
             log.warning("Failed to convert \(type(of: frame.buffer)) CMSampleBuffer.")
@@ -179,7 +177,6 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
                 contentView.sampleBufferDisplayLayer.enqueue(buffer)
             }
         }
-
     }
 
     /// A method used to start consuming frames from the track.
@@ -214,7 +211,10 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
         requiresResize = widthDiffRatio >= sizeRatioThreshold || heightDiffRatio >= sizeRatioThreshold
         framesToSkip = requiresResize ? max(Int(min(Int(widthDiffRatio), Int(heightDiffRatio)) / 2), 1) : 1
         framesSkipped = 0
-        log.debug("contentSize:\(contentSize), trackId:\(track?.trackId ?? "n/a") trackSize:\(trackSize) requiresResize:\(requiresResize) framesToSkip:\(framesToSkip) framesSkipped:\(framesSkipped)")
+        log
+            .debug(
+                "contentSize:\(contentSize), trackId:\(track?.trackId ?? "n/a") trackSize:\(trackSize) requiresResize:\(requiresResize) framesToSkip:\(framesToSkip) framesSkipped:\(framesSkipped)"
+            )
     }
 
     /// A method used to handle the frameSkipping(step) during frame consumption.

--- a/Sources/StreamVideoSwiftUI/Utils/ToastView.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/ToastView.swift
@@ -65,7 +65,7 @@ public struct ToastModifier: ViewModifier {
                 }
                 .animation(.spring(), value: toast)
             )
-            .onChange(of: toast) { value in
+            .onChange(of: toast) { _ in
                 showToast()
             }
     }
@@ -120,6 +120,6 @@ public struct ToastModifier: ViewModifier {
 @available(iOS 14.0, *)
 extension View {
     public func toastView(toast: Binding<Toast?>) -> some View {
-        self.modifier(ToastModifier(toast: toast))
+        modifier(ToastModifier(toast: toast))
     }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/ViewExtensions.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/ViewExtensions.swift
@@ -2,8 +2,8 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import SwiftUI
 import Combine
+import SwiftUI
 
 extension Alert {
     public static var defaultErrorAlert: Alert {
@@ -21,9 +21,9 @@ extension View {
     func onReceive<P>(
         _ publisher: P?,
         perform action: @escaping (P.Output) -> Void
-    ) -> some View where P : Publisher, P.Failure == Never {
+    ) -> some View where P: Publisher, P.Failure == Never {
         if let publisher = publisher {
-            self.onReceive(publisher, perform: action)
+            onReceive(publisher, perform: action)
         } else {
             self
         }

--- a/Sources/StreamVideoSwiftUI/ViewFactory.swift
+++ b/Sources/StreamVideoSwiftUI/ViewFactory.swift
@@ -274,7 +274,7 @@ extension ViewFactory {
         callSettings: Binding<CallSettings>
     ) -> some View {
         let handleJoinCall = {
-            if case .lobby(_) = viewModel.callingState {
+            if case .lobby = viewModel.callingState {
                 viewModel.startCall(
                     callType: lobbyInfo.callType,
                     callId: lobbyInfo.callId,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -585,8 +585,8 @@ end
 desc 'Run source code formatting/linting'
 lane :run_swift_format do |options|
   Dir.chdir('..') do
-    action = options[:lintOnly] ? "--lint" : ""
-    sh("mint run swiftformat #{action} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(",")} Sources")
+    action = options[:lint] ? "--lint" : ""
+    sh("mint run swiftformat #{action} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(',')} Sources")
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,7 @@ reversed_gci = gci.split('.').reverse.join('.')
 is_localhost = !is_ci
 @force_check = false
 develop_branch = 'main'
+swiftformat_excluded_paths = ["**/Generated","**/generated","**/protobuf","**/OpenApi","**/Nuke*"]
 
 before_all do |lane|
   if is_ci
@@ -584,8 +585,14 @@ end
 desc 'Run source code linting'
 lane :run_linter do
   Dir.chdir('..') do
-    UI.error('SwiftFormat lint was skipped. Check out https://github.com/GetStream/ios-issues-tracking/issues/465 for more info')
-    # sh('mint run swiftformat --lint --config .swiftformat Sources --exclude **/Generated, **/generated, **/protobuf, **/OpenApi, Sources/StreamChatSwiftUI/StreamNuke')
+    sh("mint run swiftformat --lint --config .swiftformat --exclude #{swiftformat_excluded_paths.join(",")} Sources")
+  end
+end
+
+desc 'Run source code formatting'
+lane :run_formatter do
+  Dir.chdir('..') do
+    sh("mint run swiftformat --config .swiftformat --exclude #{swiftformat_excluded_paths.join(",")} Sources")
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ reversed_gci = gci.split('.').reverse.join('.')
 is_localhost = !is_ci
 @force_check = false
 develop_branch = 'main'
-swiftformat_excluded_paths = ["**/Generated","**/generated","**/protobuf","**/OpenApi","**/Nuke*"]
+swiftformat_excluded_paths = ["**/Generated", "**/generated", "**/protobuf", "**/OpenApi", "**/Nuke*"]
 
 before_all do |lane|
   if is_ci

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -582,17 +582,11 @@ lane :rubocop do
   sh('bundle exec rubocop')
 end
 
-desc 'Run source code linting'
-lane :run_linter do
+desc 'Run source code formatting/linting'
+lane :run_swift_format do |options|
   Dir.chdir('..') do
-    sh("mint run swiftformat --lint --config .swiftformat --exclude #{swiftformat_excluded_paths.join(",")} Sources")
-  end
-end
-
-desc 'Run source code formatting'
-lane :run_formatter do
-  Dir.chdir('..') do
-    sh("mint run swiftformat --config .swiftformat --exclude #{swiftformat_excluded_paths.join(",")} Sources")
+    action = options[:lintOnly] ? "--lint" : ""
+    sh("mint run swiftformat #{action} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(",")} Sources")
   end
 end
 

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-
+mint run swiftformat --lint --config .swiftformat --exclude "**/Generated","**/generated","**/protobuf","**/OpenApi","**/Nuke*" Sources


### PR DESCRIPTION
### 🎯 Goal

Enable again swift linter and formatter in order to improve consistency in the codebase and correct common stylin issues before a PR.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)