### PR TITLE
[Fix]Crop & Scale RTCCVPixelBuffer frames

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/Extensions/CVPixelBuffer+Convenience.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/Extensions/CVPixelBuffer+Convenience.swift
@@ -1,0 +1,28 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreVideo
+import Foundation
+
+extension CVPixelBuffer {
+    public static func make(
+        with size: CGSize,
+        pixelFormat: OSType
+    ) -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+
+        let attributes: [CFString: Any] = [:]
+
+        _ = CVPixelBufferCreate(
+            nil,
+            Int(size.width),
+            Int(size.height),
+            pixelFormat,
+            attributes as CFDictionary,
+            &pixelBuffer
+        )
+
+        return pixelBuffer
+    }
+}

--- a/Sources/StreamVideoSwiftUI/Utils/Extensions/RTCCVPixelBuffer+Convenience.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/Extensions/RTCCVPixelBuffer+Convenience.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamWebRTC
+
+extension RTCCVPixelBuffer {
+
+    public func bufferSizeForCroppingAndScaling(to size: CGSize) -> Int {
+        Int(
+            bufferSizeForCroppingAndScaling(
+                toWidth: Int32(size.width),
+                height: Int32(
+                    size.height
+                )
+            )
+        )
+    }
+}

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
@@ -12,14 +12,14 @@ struct StreamBufferTransformer {
 
     var requiresResize = false
 
-    /// Transforms an RTCI420Buffer to a CVPixelBuffer with optional resizing.
+    /// Transforms an RTCVideoFrameBuffer to a CVPixelBuffer with optional resizing.
     ///
     /// - Parameters:
-    ///   - source: The source RTCI420Buffer to be transformed.
+    ///   - source: The source RTCVideoFrameBuffer to be transformed.
     ///   - targetSize: The target size for the resulting CVPixelBuffer.
     /// - Returns: A transformed CVPixelBuffer or nil if transformation fails.
     func transform(
-        _ source: RTCI420Buffer,
+        _ source: RTCVideoFrameBuffer,
         targetSize: CGSize
     ) -> CVPixelBuffer? {
         let sourceSize = CGSize(width: Int(source.width), height: Int(source.height))
@@ -79,21 +79,36 @@ struct StreamBufferTransformer {
         return buffer
     }
 
-    /// Resizes an RTCI420Buffer to the specified size.
+    /// Resizes an RTCVideoFrameBuffer to the specified size.
     ///
     /// - Parameters:
-    ///   - source: The source RTCI420Buffer to be resized.
+    ///   - source: The source RTCVideoFrameBuffer to be resized.
     ///   - size: The target size for resizing.
-    /// - Returns: A resized RTCI420Buffer or nil if resizing fails.
-    private func resize(_ source: RTCI420Buffer, to size: CGSize) -> RTCI420Buffer? {
-        source.cropAndScale(
-            with: 0,
-            offsetY: 0,
-            cropWidth: Int32(source.width),
-            cropHeight: Int32(source.height),
-            scaleWidth: Int32(size.width),
-            scaleHeight: Int32(size.height)
-        ) as? RTCI420Buffer
+    /// - Returns: A resized RTCVideoFrameBuffer or nil if resizing fails.
+    private func resize<TargetBuffer: RTCVideoFrameBuffer>(
+        _ source: TargetBuffer,
+        to size: CGSize
+    ) -> TargetBuffer? {
+        if
+            let rtcCVPixelBuffer = source as? RTCCVPixelBuffer,
+            let newPixelBuffer = CVPixelBuffer.make(
+                with: size,
+                // Use the same pixelFormat as the source pixelBuffer to match the color profile
+                pixelFormat: CVPixelBufferGetPixelFormatType(rtcCVPixelBuffer.pixelBuffer)
+            ) {
+            let count = rtcCVPixelBuffer.bufferSizeForCroppingAndScaling(to: size)
+            rtcCVPixelBuffer.cropAndScale(to: newPixelBuffer, withTempBuffer: malloc(count))
+            return RTCCVPixelBuffer(pixelBuffer: newPixelBuffer) as? TargetBuffer
+        } else {
+            return source.cropAndScale?(
+                with: 0,
+                offsetY: 0,
+                cropWidth: Int32(source.width),
+                cropHeight: Int32(source.height),
+                scaleWidth: Int32(size.width),
+                scaleHeight: Int32(size.height)
+            ) as? TargetBuffer
+        }
     }
 
     /// Calculates the new size to fit within a container size while maintaining the aspect ratio.
@@ -122,90 +137,97 @@ struct StreamBufferTransformer {
         return newSize
     }
 
-    /// Converts an RTCI420Buffer to a CVPixelBuffer.
+    /// Converts an RTCVideoFrameBuffer to a CVPixelBuffer.
     ///
-    /// - Parameter source: The source RTCI420Buffer to be converted.
+    /// - Parameter source: The source RTCVideoFrameBuffer to be converted.
     /// - Returns: A converted CVPixelBuffer or nil if conversion fails.
-    private func convert(_ source: RTCI420Buffer) -> CVPixelBuffer? {
-        let width = Int(source.width)
-        let height = Int(source.height)
+    /// - Note: It can only convert RTCCVPixelBuffer and RTCI420Buffer. Any other type will return `nil`.
+    private func convert(_ source: RTCVideoFrameBuffer) -> CVPixelBuffer? {
+        if let rtcCVPixelBuffer = source as? RTCCVPixelBuffer {
+            return rtcCVPixelBuffer.pixelBuffer
+        } else if let source = source as? RTCI420Buffer {
+            let width = Int(source.width)
+            let height = Int(source.height)
 
-        // Create a BGRA pixel buffer
-        var pixelBuffer: CVPixelBuffer?
-        let pixelFormat = kCVPixelFormatType_32BGRA
-        let pixelBufferAttrs: [String: Any] = [
-            kCVPixelBufferMetalCompatibilityKey as String: kCFBooleanTrue as Any,
-            kCVPixelBufferCGImageCompatibilityKey as String: kCFBooleanTrue as Any,
-            kCVPixelBufferCGBitmapContextCompatibilityKey as String: kCFBooleanTrue as Any
-        ]
+            // Create a BGRA pixel buffer
+            var pixelBuffer: CVPixelBuffer?
+            let pixelFormat = kCVPixelFormatType_32BGRA
+            let pixelBufferAttrs: [String: Any] = [
+                kCVPixelBufferMetalCompatibilityKey as String: kCFBooleanTrue as Any,
+                kCVPixelBufferCGImageCompatibilityKey as String: kCFBooleanTrue as Any,
+                kCVPixelBufferCGBitmapContextCompatibilityKey as String: kCFBooleanTrue as Any
+            ]
 
-        let status = CVPixelBufferCreate(
-            kCFAllocatorDefault,
-            width,
-            height,
-            pixelFormat,
-            pixelBufferAttrs as CFDictionary,
-            &pixelBuffer
-        )
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                width,
+                height,
+                pixelFormat,
+                pixelBufferAttrs as CFDictionary,
+                &pixelBuffer
+            )
 
-        guard status == kCVReturnSuccess, let outputPixelBuffer = pixelBuffer else {
-            return nil
-        }
-
-        CVPixelBufferLockBaseAddress(outputPixelBuffer, .readOnly)
-
-        // Get the destination BGRA plane base address
-        guard let bgraBaseAddress = CVPixelBufferGetBaseAddress(outputPixelBuffer) else {
-            CVPixelBufferUnlockBaseAddress(outputPixelBuffer, .readOnly)
-            return nil
-        }
-
-        // Perform YUV to RGB conversion with proper chroma upsampling
-        let yPlane = source.dataY
-        let uPlane = source.dataU
-        let vPlane = source.dataV
-
-        let yBytesPerRow = Int(source.strideY)
-        let uBytesPerRow = Int(source.strideU)
-        let vBytesPerRow = Int(source.strideV)
-
-        let bgraBytesPerRow = CVPixelBufferGetBytesPerRow(outputPixelBuffer)
-
-        for y in stride(from: 0, to: height, by: 1) {
-            for x in stride(from: 0, to: width, by: 1) {
-                let yOffset = y * yBytesPerRow + x
-                let uOffset = (y / 2) * uBytesPerRow + (x / 2)
-                let vOffset = (y / 2) * vBytesPerRow + (x / 2)
-
-                let yValue = Int(yPlane[yOffset])
-                let uValue = Int(uPlane[uOffset]) - 128
-                let vValue = Int(vPlane[vOffset]) - 128
-
-                let index = (y * bgraBytesPerRow) + (x * 4)
-                var pixel: [UInt8] = [0, 0, 0, 255] // BGRA format, fully opaque
-
-                // Perform YUV to RGB conversion with chroma upsampling
-                let c = yValue - 16
-                let d = uValue
-                let e = vValue
-
-                let r = clamp((298 * c + 409 * e + 128) >> 8)
-                let g = clamp((298 * c - 100 * d - 208 * e + 128) >> 8)
-                let b = clamp((298 * c + 516 * d + 128) >> 8)
-
-                pixel[0] = UInt8(b)
-                pixel[1] = UInt8(g)
-                pixel[2] = UInt8(r)
-
-                // Copy the pixel data to the BGRA plane
-                memcpy(bgraBaseAddress.advanced(by: index), &pixel, 4)
+            guard status == kCVReturnSuccess, let outputPixelBuffer = pixelBuffer else {
+                return nil
             }
+
+            CVPixelBufferLockBaseAddress(outputPixelBuffer, .readOnly)
+
+            // Get the destination BGRA plane base address
+            guard let bgraBaseAddress = CVPixelBufferGetBaseAddress(outputPixelBuffer) else {
+                CVPixelBufferUnlockBaseAddress(outputPixelBuffer, .readOnly)
+                return nil
+            }
+
+            // Perform YUV to RGB conversion with proper chroma upsampling
+            let yPlane = source.dataY
+            let uPlane = source.dataU
+            let vPlane = source.dataV
+
+            let yBytesPerRow = Int(source.strideY)
+            let uBytesPerRow = Int(source.strideU)
+            let vBytesPerRow = Int(source.strideV)
+
+            let bgraBytesPerRow = CVPixelBufferGetBytesPerRow(outputPixelBuffer)
+
+            for y in stride(from: 0, to: height, by: 1) {
+                for x in stride(from: 0, to: width, by: 1) {
+                    let yOffset = y * yBytesPerRow + x
+                    let uOffset = (y / 2) * uBytesPerRow + (x / 2)
+                    let vOffset = (y / 2) * vBytesPerRow + (x / 2)
+
+                    let yValue = Int(yPlane[yOffset])
+                    let uValue = Int(uPlane[uOffset]) - 128
+                    let vValue = Int(vPlane[vOffset]) - 128
+
+                    let index = (y * bgraBytesPerRow) + (x * 4)
+                    var pixel: [UInt8] = [0, 0, 0, 255] // BGRA format, fully opaque
+
+                    // Perform YUV to RGB conversion with chroma upsampling
+                    let c = yValue - 16
+                    let d = uValue
+                    let e = vValue
+
+                    let r = clamp((298 * c + 409 * e + 128) >> 8)
+                    let g = clamp((298 * c - 100 * d - 208 * e + 128) >> 8)
+                    let b = clamp((298 * c + 516 * d + 128) >> 8)
+
+                    pixel[0] = UInt8(b)
+                    pixel[1] = UInt8(g)
+                    pixel[2] = UInt8(r)
+
+                    // Copy the pixel data to the BGRA plane
+                    memcpy(bgraBaseAddress.advanced(by: index), &pixel, 4)
+                }
+            }
+
+            // Unlock the BGRA pixel buffer
+            CVPixelBufferUnlockBaseAddress(outputPixelBuffer, .readOnly)
+
+            return outputPixelBuffer
+        } else {
+            return nil
         }
-
-        // Unlock the BGRA pixel buffer
-        CVPixelBufferUnlockBaseAddress(outputPixelBuffer, .readOnly)
-
-        return outputPixelBuffer
     }
 
     private func clamp(_ value: Int) -> UInt8 {

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -223,6 +223,8 @@
 		40F446022A9E2C23004BE3DA /* DemoCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446012A9E2C23004BE3DA /* DemoCallView.swift */; };
 		40F446042A9E2C78004BE3DA /* MicrophoneChecker+MicrophoneChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446032A9E2C78004BE3DA /* MicrophoneChecker+MicrophoneChecking.swift */; };
 		40F446062A9E2CB8004BE3DA /* CallViewModel+CallSettingsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446052A9E2CB8004BE3DA /* CallViewModel+CallSettingsPublisher.swift */; };
+		40FA12F02B76AC5900CE3EC9 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FA12EF2B76AC5900CE3EC9 /* CVPixelBuffer+Convenience.swift */; };
+		40FA12F22B76AC8300CE3EC9 /* RTCCVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FA12F12B76AC8300CE3EC9 /* RTCCVPixelBuffer+Convenience.swift */; };
 		40FAF3D32B10F611003F8029 /* UIDevice+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FAF3D22B10F611003F8029 /* UIDevice+Convenience.swift */; };
 		40FBEF492AC30343007CFF17 /* Safari.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF482AC30343007CFF17 /* Safari.swift */; };
 		40FBEF4B2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */; };
@@ -1183,6 +1185,8 @@
 		40F446012A9E2C23004BE3DA /* DemoCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCallView.swift; sourceTree = "<group>"; };
 		40F446032A9E2C78004BE3DA /* MicrophoneChecker+MicrophoneChecking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MicrophoneChecker+MicrophoneChecking.swift"; sourceTree = "<group>"; };
 		40F446052A9E2CB8004BE3DA /* CallViewModel+CallSettingsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallViewModel+CallSettingsPublisher.swift"; sourceTree = "<group>"; };
+		40FA12EF2B76AC5900CE3EC9 /* CVPixelBuffer+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+Convenience.swift"; sourceTree = "<group>"; };
+		40FA12F12B76AC8300CE3EC9 /* RTCCVPixelBuffer+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RTCCVPixelBuffer+Convenience.swift"; sourceTree = "<group>"; };
 		40FAF3D22B10F611003F8029 /* UIDevice+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Convenience.swift"; sourceTree = "<group>"; };
 		40FBEF482AC30343007CFF17 /* Safari.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Safari.swift; sourceTree = "<group>"; };
 		40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+KeyboardIntroduction.swift"; sourceTree = "<group>"; };
@@ -2501,6 +2505,15 @@
 			path = WaitingLocalUserView;
 			sourceTree = "<group>";
 		};
+		40FA12EE2B76AC4B00CE3EC9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				40FA12EF2B76AC5900CE3EC9 /* CVPixelBuffer+Convenience.swift */,
+				40FA12F12B76AC8300CE3EC9 /* RTCCVPixelBuffer+Convenience.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		40FBEF472AC3030C007CFF17 /* UITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -3665,6 +3678,7 @@
 		84EBAA91288C135700BE3176 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40FA12EE2B76AC4B00CE3EC9 /* Extensions */,
 				402F04AC2B714E9B00CA1986 /* DeviceOrientation */,
 				40E1104A2B5A9F5B007DF492 /* Formatters */,
 				40A9416C2B4D958A006D6965 /* PictureInPicture */,
@@ -4728,6 +4742,7 @@
 				84DC38A829ADFCFD00946713 /* QueryCallsResponse.swift in Sources */,
 				840F59912A77FDCB00EF3EB2 /* HLSSettingsRequest.swift in Sources */,
 				842B8E1B2A2DFED900863A87 /* CallSessionStartedEvent.swift in Sources */,
+				40FA12F22B76AC8300CE3EC9 /* RTCCVPixelBuffer+Convenience.swift in Sources */,
 				8490032629D308A000AD9BB4 /* TranscriptionSettings.swift in Sources */,
 				848CCCEB2AB8ED8F002E83A2 /* CallHLSBroadcastingStoppedEvent.swift in Sources */,
 				8409465829AF4EEC007AF5BF /* SendReactionRequest.swift in Sources */,
@@ -4765,6 +4780,7 @@
 				84CC058B2A531B0B00EE9815 /* CallSettingsManager.swift in Sources */,
 				84DC38B929ADFCFD00946713 /* MemberRequest.swift in Sources */,
 				84DC38BE29ADFCFD00946713 /* CallSettingsRequest.swift in Sources */,
+				40FA12F02B76AC5900CE3EC9 /* CVPixelBuffer+Convenience.swift in Sources */,
 				402F04AB2B70ED8600CA1986 /* StreamCallStatisticsFormatter.swift in Sources */,
 				8487D8B02A697E9A00536ED4 /* VideoCapturing.swift in Sources */,
 				842B8E242A2DFED900863A87 /* CallSessionParticipantJoinedEvent.swift in Sources */,

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
@@ -13,7 +13,7 @@ final class StreamBufferTransformerTests: XCTestCase {
 
     // MARK: - transform(_: RTCI420Buffer, targetSize: CGSize)
 
-    func testTransformWithNoResizeRequired() throws {
+    func test_RTCI420Buffer_TransformWithNoResizeRequired() throws {
         var transformer = StreamBufferTransformer()
         transformer.requiresResize = false
         let sourceBuffer = RTCI420Buffer(
@@ -32,7 +32,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         XCTAssertEqual(CVPixelBufferGetHeight(resultBuffer), Int(targetSize.height))
     }
 
-    func testTransformWithResizeRequired() throws {
+    func test_RTCI420Buffer_TransformWithResizeRequired() throws {
         var transformer = StreamBufferTransformer()
         transformer.requiresResize = true
         let sourceBuffer = RTCI420Buffer(
@@ -51,7 +51,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         XCTAssertEqual(CVPixelBufferGetHeight(resultBuffer), Int(targetSize.height))
     }
 
-    func testResizeSizeToFitWithinContainer() throws {
+    func test_RTCI420Buffer_ResizeSizeToFitWithinContainer() throws {
         var transformer = StreamBufferTransformer()
         transformer.requiresResize = true
         let sourceBuffer = RTCI420Buffer(
@@ -60,6 +60,68 @@ final class StreamBufferTransformerTests: XCTestCase {
             strideY: 450,
             strideU: 225,
             strideV: 225
+        )
+        let targetSize = CGSize(width: 150, height: 75)
+
+        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+
+        // Assert that no resize occurred, and the output size matches the target size.
+        XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
+        XCTAssertEqual(CVPixelBufferGetHeight(resultBuffer), Int(targetSize.height))
+    }
+
+    // MARK: - transform(_: RTCCVPixelBuffer, targetSize: CGSize)
+
+    func test_RTCCVPixelBuffer_TransformWithNoResizeRequired() throws {
+        var transformer = StreamBufferTransformer()
+        transformer.requiresResize = false
+        let sourceBuffer = RTCCVPixelBuffer(
+            pixelBuffer: try XCTUnwrap(
+                CVPixelBuffer.make(
+                    with: .init(width: 100,height: 100),
+                    pixelFormat: kCVPixelFormatType_32ARGB
+                )
+            )
+        )
+        let targetSize = CGSize(width: 100, height: 100)
+
+        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+
+        // Assert that no resize occurred, and the output size matches the target size.
+        XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
+        XCTAssertEqual(CVPixelBufferGetHeight(resultBuffer), Int(targetSize.height))
+    }
+
+    func test_RTCCVPixelBuffer_TransformWithResizeRequired() throws {
+        var transformer = StreamBufferTransformer()
+        transformer.requiresResize = true
+        let sourceBuffer = RTCCVPixelBuffer(
+            pixelBuffer: try XCTUnwrap(
+                CVPixelBuffer.make(
+                    with: .init(width: 200, height: 200),
+                    pixelFormat: kCVPixelFormatType_32ARGB
+                )
+            )
+        )
+        let targetSize = CGSize(width: 50, height: 50)
+
+        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+
+        // Assert that no resize occurred, and the output size matches the target size.
+        XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
+        XCTAssertEqual(CVPixelBufferGetHeight(resultBuffer), Int(targetSize.height))
+    }
+
+    func test_RTCCVPixelBuffer_ResizeSizeToFitWithinContainer() throws {
+        var transformer = StreamBufferTransformer()
+        transformer.requiresResize = true
+        let sourceBuffer = RTCCVPixelBuffer(
+            pixelBuffer: try XCTUnwrap(
+                CVPixelBuffer.make(
+                    with: .init(width: 450, height: 225),
+                    pixelFormat: kCVPixelFormatType_32ARGB
+                )
+            )
         )
         let targetSize = CGSize(width: 150, height: 75)
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/706

### 📝 Summary

In the latest improvement work that we did to Picture in Picture we introduced cropAndScale to frames that use an RTCI420Buffer underline buffer. That improved memory consumption for most devices. However, some newer devices (e.g. iPad Pro models) are receiving frames that are using RTCCVPixelBuffer underneath. Those frames weren't optimised which resulted in CPU and memory spiking when rendering tracks with sizes much bigger than the PiP window, leading to crashes.

### 🛠 Implementation

The PR makes the existing StreamBufferTransformer's API generic so we can reuse the logic that we have in place to cropAndScale RTCCVPixelBuffer.

### 🧪 Manual Testing Notes

- Testing requires iPad [devices](https://support.apple.com/en-sg/guide/ipad/aside/ipad7a0645dd/17.0/ipados/17.0) that support Stage Manager

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)