### PR TITLE
[Improvement]Allow removing videoOutputs from AVCaptureSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- New API that allows adding capturePhotoOutput, videoOutput on the local participant's AVCaptureSession. [#301](https://github.com/GetStream/stream-video-swift/pull/301)
+- New API that allows adding/removing capturePhotoOutput, videoOutput on the local participant's AVCaptureSession. [#301](https://github.com/GetStream/stream-video-swift/pull/301)
 - New API that allows zooming the local participant's camera. [#301](https://github.com/GetStream/stream-video-swift/pull/301)
 
 # [0.5.0](https://github.com/GetStream/stream-video-swift/releases/tag/0.5.0)

--- a/DemoApp/Sources/Components/Snapshot/LocalParticipantSnapshotViewModel.swift
+++ b/DemoApp/Sources/Components/Snapshot/LocalParticipantSnapshotViewModel.swift
@@ -34,6 +34,8 @@ final class LocalParticipantSnapshotViewModel: NSObject, AVCapturePhotoCaptureDe
             do {
                 if #available(iOS 16.0, *) {
                     try call?.addVideoOutput(videoOutput)
+                    /// Following Apple guidelines for videoOutputs from here:
+                    /// https://developer.apple.com/library/archive/technotes/tn2445/_index.html
                     videoOutput.alwaysDiscardsLateVideoFrames = true
                 } else {
                     try call?.addCapturePhotoOutput(photoOutput)
@@ -73,12 +75,7 @@ final class LocalParticipantSnapshotViewModel: NSObject, AVCapturePhotoCaptureDe
     // MARK: - Private Helpers
 
     private func sendImageData(_ data: Data) async {
-        defer {
-            videoOutput.setSampleBufferDelegate(
-                nil,
-                queue: videoOutput.sampleBufferCallbackQueue
-            )
-        }
+        defer { videoOutput.setSampleBufferDelegate(nil, queue: nil) }
         guard
             let snapshot = UIImage(data: data),
             let resizedImage = resize(image: snapshot, to: .init(width: 30, height: 30)),

--- a/DemoApp/Sources/ViewModifiers/MoreControls/DemoMoreControlsViewModifier.swift
+++ b/DemoApp/Sources/ViewModifiers/MoreControls/DemoMoreControlsViewModifier.swift
@@ -41,7 +41,11 @@ private struct DemoMoreControlsViewModifier: ViewModifier {
 
                             DemoMoreControlListButtonView(
                                 action: {
-                                    localParticipantSnapshotViewModel.captureVideoFrame()
+                                    if #available(iOS 16.0, *) {
+                                        localParticipantSnapshotViewModel.captureVideoFrame()
+                                    } else {
+                                        localParticipantSnapshotViewModel.capturePhoto()
+                                    }
                                 },
                                 label: "Capture Photo"
                             ) { Image(systemName: "circle.inset.filled") }

--- a/DemoApp/Sources/ViewModifiers/MoreControls/DemoMoreControlsViewModifier.swift
+++ b/DemoApp/Sources/ViewModifiers/MoreControls/DemoMoreControlsViewModifier.swift
@@ -48,6 +48,13 @@ private struct DemoMoreControlsViewModifier: ViewModifier {
                                     }
                                 },
                                 label: "Capture Photo"
+                            ) { Image(systemName: "person.crop.square.badge.camera") }
+
+                            DemoMoreControlListButtonView(
+                                action: {
+                                    snapshotTrigger.capture()
+                                },
+                                label: "Snapshot"
                             ) { Image(systemName: "circle.inset.filled") }
 
                             DemoMoreControlListButtonView(

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/16-snapshot.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/16-snapshot.swift
@@ -194,12 +194,14 @@ fileprivate func content() {
         let videoOutput: AVCaptureVideoDataOutput = .init()
 
         do {
-            try call?.addCapturePhotoOutput(photoOutput)
             if #available(iOS 16.0, *) {
                 try call?.addVideoOutput(videoOutput)
+                /// Following Apple guidelines for videoOutputs from here:
+                /// https://developer.apple.com/library/archive/technotes/tn2445/_index.html
+                videoOutput.alwaysDiscardsLateVideoFrames = true
+            } else {
+                try call?.addCapturePhotoOutput(photoOutput)
             }
-
-            videoOutput.setSampleBufferDelegate(Delegate(), queue: DispatchQueue.global(qos: .background))
         } catch {
             log.error("Failed to setup for localParticipant snapshot", error: error)
         }
@@ -271,7 +273,9 @@ fileprivate func content() {
             }
         }
 
-        func sendImageData(_ data: Data) async {}
+        func sendImageData(_ data: Data) async {
+            defer { videoOutput.setSampleBufferDelegate(nil, queue: nil) }
+        }
     }
 
     container {

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -758,6 +758,32 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         try callController.addCapturePhotoOutput(capturePhotoOutput)
     }
 
+    /// Removes the `AVCapturePhotoOutput` from the `CameraVideoCapturer` to disable photo
+    /// capturing capabilities.
+    ///
+    /// This method configures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCapturePhotoOutput` previously added for capturing photos. This action is necessary when
+    /// the application needs to stop capturing still images or when adjusting the capturing setup. It ensures
+    /// that the video capturing process can continue without the overhead or interference of photo
+    /// capturing capabilities.
+    ///
+    /// - Parameter capturePhotoOutput: The `AVCapturePhotoOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output disables the capture of photos alongside
+    /// video capturing.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCapturePhotoOutput`.
+    /// This method is specifically designed for `RTCCameraVideoCapturer` instances. If the
+    /// `CameraVideoCapturer` in use does not support the removal of photo output functionality, an
+    /// appropriate error will be thrown to indicate that the operation is not supported.
+    ///
+    /// - Note: Ensure that the `AVCapturePhotoOutput` being removed was previously added to the
+    /// `CameraVideoCapturer`. Attempting to remove an output that is not currently added will not
+    /// affect the capture session but may result in unnecessary processing.
+    public func removeCapturePhotoOutput(_ capturePhotoOutput: AVCapturePhotoOutput) throws {
+        try callController.removeCapturePhotoOutput(capturePhotoOutput)
+    }
+
     /// Adds an `AVCaptureVideoDataOutput` to the `CameraVideoCapturer` for video frame
     /// processing capabilities.
     ///
@@ -777,12 +803,40 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     ///
     /// - Warning: A maximum of one output of each type may be added. For applications linked on or
     /// after iOS 16.0, this restriction no longer applies to AVCaptureVideoDataOutputs. When adding more
-    /// than one AVCaptureVideoDataOutput, AVCaptureSession.hardwareCost must be taken into account.
-    /// Given that WebRTC adds a videoOutput for frame processing, we cannot accept videoOutputs
-    /// on versions prior to iOS 16.0.
+    /// than one AVCaptureVideoDataOutput, AVCaptureSession **hardwareCost must be taken into
+    /// account as it can result in delayed fames delivery**. Given that WebRTC adds a videoOutput
+    /// for frame processing, we cannot accept videoOutputs on versions prior to iOS 16.0.
     @available(iOS 16.0, *)
     public func addVideoOutput(_ videoOutput: AVCaptureVideoDataOutput) throws {
         try callController.addVideoOutput(videoOutput)
+    }
+
+    /// Removes an `AVCaptureVideoDataOutput` from the `CameraVideoCapturer` to disable
+    /// video frame processing capabilities.
+    ///
+    /// This method reconfigures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCaptureVideoDataOutput` that was previously added. This change is essential when the
+    /// application no longer requires access to raw video data for analysis, filtering, or other processing
+    /// tasks, or when adjusting the video capturing setup for different operational requirements. It ensures t
+    /// hat video capturing can proceed without the additional processing overhead associated with
+    /// handling video frame outputs.
+    ///
+    /// - Parameter videoOutput: The `AVCaptureVideoDataOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output stops the capture and processing of live video
+    /// frames through the specified output, simplifying the capture session.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCaptureVideoDataOutput`. This functionality is tailored for `RTCCameraVideoCapturer`
+    /// instances. If the `CameraVideoCapturer` being used does not permit the removal of video outputs,
+    /// an error will be thrown to indicate the unsupported operation.
+    ///
+    /// - Note: It is crucial to ensure that the `AVCaptureVideoDataOutput` intended for removal
+    /// has been previously added to the `CameraVideoCapturer`. Trying to remove an output that is
+    /// not part of the capture session will have no negative impact but could lead to unnecessary processing
+    /// and confusion.
+    @available(iOS 16.0, *)
+    public func removeVideoOutput(_ videoOutput: AVCaptureVideoDataOutput) throws {
+        try callController.removeVideoOutput(videoOutput)
     }
 
     /// Zooms the camera video by the specified factor.

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -228,6 +228,32 @@ class CallController {
         try webRTCClient?.addCapturePhotoOutput(capturePhotoOutput)
     }
 
+    /// Removes the `AVCapturePhotoOutput` from the `CameraVideoCapturer` to disable photo
+    /// capturing capabilities.
+    ///
+    /// This method configures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCapturePhotoOutput` previously added for capturing photos. This action is necessary when
+    /// the application needs to stop capturing still images or when adjusting the capturing setup. It ensures
+    /// that the video capturing process can continue without the overhead or interference of photo
+    /// capturing capabilities.
+    ///
+    /// - Parameter capturePhotoOutput: The `AVCapturePhotoOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output disables the capture of photos alongside
+    /// video capturing.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCapturePhotoOutput`.
+    /// This method is specifically designed for `RTCCameraVideoCapturer` instances. If the
+    /// `CameraVideoCapturer` in use does not support the removal of photo output functionality, an
+    /// appropriate error will be thrown to indicate that the operation is not supported.
+    ///
+    /// - Note: Ensure that the `AVCapturePhotoOutput` being removed was previously added to the
+    /// `CameraVideoCapturer`. Attempting to remove an output that is not currently added will not
+    /// affect the capture session but may result in unnecessary processing.
+    func removeCapturePhotoOutput(_ capturePhotoOutput: AVCapturePhotoOutput) throws {
+        try webRTCClient?.removeCapturePhotoOutput(capturePhotoOutput)
+    }
+
     /// Adds an `AVCaptureVideoDataOutput` to the `CameraVideoCapturer` for video frame
     /// processing capabilities.
     ///
@@ -250,6 +276,33 @@ class CallController {
     /// than one AVCaptureVideoDataOutput, AVCaptureSession.hardwareCost must be taken into account.
     func addVideoOutput(_ videoOutput: AVCaptureVideoDataOutput) throws {
         try webRTCClient?.addVideoOutput(videoOutput)
+    }
+
+    /// Removes an `AVCaptureVideoDataOutput` from the `CameraVideoCapturer` to disable
+    /// video frame processing capabilities.
+    ///
+    /// This method reconfigures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCaptureVideoDataOutput` that was previously added. This change is essential when the
+    /// application no longer requires access to raw video data for analysis, filtering, or other processing
+    /// tasks, or when adjusting the video capturing setup for different operational requirements. It ensures t
+    /// hat video capturing can proceed without the additional processing overhead associated with
+    /// handling video frame outputs.
+    ///
+    /// - Parameter videoOutput: The `AVCaptureVideoDataOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output stops the capture and processing of live video
+    /// frames through the specified output, simplifying the capture session.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCaptureVideoDataOutput`. This functionality is tailored for `RTCCameraVideoCapturer`
+    /// instances. If the `CameraVideoCapturer` being used does not permit the removal of video outputs,
+    /// an error will be thrown to indicate the unsupported operation.
+    ///
+    /// - Note: It is crucial to ensure that the `AVCaptureVideoDataOutput` intended for removal
+    /// has been previously added to the `CameraVideoCapturer`. Trying to remove an output that is
+    /// not part of the capture session will have no negative impact but could lead to unnecessary processing
+    /// and confusion.
+    func removeVideoOutput(_ videoOutput: AVCaptureVideoDataOutput) throws {
+        try webRTCClient?.removeVideoOutput(videoOutput)
     }
 
     /// Zooms the camera video by the specified factor.

--- a/Sources/StreamVideo/WebRTC/VideoCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturer.swift
@@ -184,7 +184,41 @@ class VideoCapturer: CameraVideoCapturing {
         cameraVideoCapturer.captureSession.addOutput(capturePhotoOutput)
         cameraVideoCapturer.captureSession.commitConfiguration()
     }
-    
+
+    /// Removes the `AVCapturePhotoOutput` from the `CameraVideoCapturer` to disable photo
+    /// capturing capabilities.
+    ///
+    /// This method configures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCapturePhotoOutput` previously added for capturing photos. This action is necessary when
+    /// the application needs to stop capturing still images or when adjusting the capturing setup. It ensures
+    /// that the video capturing process can continue without the overhead or interference of photo
+    /// capturing capabilities.
+    ///
+    /// - Parameter capturePhotoOutput: The `AVCapturePhotoOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output disables the capture of photos alongside
+    /// video capturing.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCapturePhotoOutput`.
+    /// This method is specifically designed for `RTCCameraVideoCapturer` instances. If the
+    /// `CameraVideoCapturer` in use does not support the removal of photo output functionality, an
+    /// appropriate error will be thrown to indicate that the operation is not supported.
+    ///
+    /// - Note: Ensure that the `AVCapturePhotoOutput` being removed was previously added to the
+    /// `CameraVideoCapturer`. Attempting to remove an output that is not currently added will not
+    /// affect the capture session but may result in unnecessary processing.
+    func removeCapturePhotoOutput(_ capturePhotoOutput: AVCapturePhotoOutput) throws {
+        guard
+            let cameraVideoCapturer = videoCapturer as? RTCCameraVideoCapturer
+        else {
+            throw ClientError.Unexpected("Cannot remove capturePhotoOutput for videoCapturer of type:\(type(of: videoCapturer)).")
+        }
+
+        cameraVideoCapturer.captureSession.beginConfiguration()
+        cameraVideoCapturer.captureSession.removeOutput(capturePhotoOutput)
+        cameraVideoCapturer.captureSession.commitConfiguration()
+    }
+
     /// Adds an `AVCaptureVideoDataOutput` to the `CameraVideoCapturer` for video frame
     /// processing capabilities.
     ///
@@ -216,7 +250,41 @@ class VideoCapturer: CameraVideoCapturing {
         cameraVideoCapturer.captureSession.addOutput(videoOutput)
         cameraVideoCapturer.captureSession.commitConfiguration()
     }
-    
+
+    /// Removes an `AVCaptureVideoDataOutput` from the `CameraVideoCapturer` to disable
+    /// video frame processing capabilities.
+    ///
+    /// This method reconfigures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCaptureVideoDataOutput` that was previously added. This change is essential when the
+    /// application no longer requires access to raw video data for analysis, filtering, or other processing
+    /// tasks, or when adjusting the video capturing setup for different operational requirements. It ensures t
+    /// hat video capturing can proceed without the additional processing overhead associated with
+    /// handling video frame outputs.
+    ///
+    /// - Parameter videoOutput: The `AVCaptureVideoDataOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output stops the capture and processing of live video
+    /// frames through the specified output, simplifying the capture session.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCaptureVideoDataOutput`. This functionality is tailored for `RTCCameraVideoCapturer`
+    /// instances. If the `CameraVideoCapturer` being used does not permit the removal of video outputs,
+    /// an error will be thrown to indicate the unsupported operation.
+    ///
+    /// - Note: It is crucial to ensure that the `AVCaptureVideoDataOutput` intended for removal
+    /// has been previously added to the `CameraVideoCapturer`. Trying to remove an output that is
+    /// not part of the capture session will have no negative impact but could lead to unnecessary processing
+    /// and confusion.
+    func removeVideoOutput(_ videoOutput: AVCaptureVideoDataOutput) throws {
+        guard
+            let cameraVideoCapturer = videoCapturer as? RTCCameraVideoCapturer
+        else {
+            throw ClientError.Unexpected("Cannot remove videoOutput for videoCapturer of type:\(type(of: videoCapturer)).")
+        }
+        cameraVideoCapturer.captureSession.beginConfiguration()
+        cameraVideoCapturer.captureSession.removeOutput(videoOutput)
+        cameraVideoCapturer.captureSession.commitConfiguration()
+    }
+
     /// Zooms the camera video by the specified factor.
     ///
     /// This method attempts to zoom the camera's video feed by adjusting the `videoZoomFactor` of

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -611,6 +611,36 @@ class WebRTCClient: NSObject, @unchecked Sendable {
         try videoCapturer.addCapturePhotoOutput(capturePhotoOutput)
     }
 
+    /// Removes the `AVCapturePhotoOutput` from the `CameraVideoCapturer` to disable photo
+    /// capturing capabilities.
+    ///
+    /// This method configures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCapturePhotoOutput` previously added for capturing photos. This action is necessary when
+    /// the application needs to stop capturing still images or when adjusting the capturing setup. It ensures
+    /// that the video capturing process can continue without the overhead or interference of photo
+    /// capturing capabilities.
+    ///
+    /// - Parameter capturePhotoOutput: The `AVCapturePhotoOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output disables the capture of photos alongside
+    /// video capturing.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCapturePhotoOutput`.
+    /// This method is specifically designed for `RTCCameraVideoCapturer` instances. If the
+    /// `CameraVideoCapturer` in use does not support the removal of photo output functionality, an
+    /// appropriate error will be thrown to indicate that the operation is not supported.
+    ///
+    /// - Note: Ensure that the `AVCapturePhotoOutput` being removed was previously added to the
+    /// `CameraVideoCapturer`. Attempting to remove an output that is not currently added will not
+    /// affect the capture session but may result in unnecessary processing.
+    func removeCapturePhotoOutput(_ capturePhotoOutput: AVCapturePhotoOutput) throws {
+        guard let videoCapturer = videoCapturer as? VideoCapturer else {
+            throw ClientError.Unexpected()
+        }
+
+        try videoCapturer.removeCapturePhotoOutput(capturePhotoOutput)
+    }
+
     /// Adds an `AVCaptureVideoDataOutput` to the `CameraVideoCapturer` for video frame
     /// processing capabilities.
     ///
@@ -637,6 +667,37 @@ class WebRTCClient: NSObject, @unchecked Sendable {
         }
 
         try videoCapturer.addVideoOutput(videoOutput)
+    }
+
+    /// Removes an `AVCaptureVideoDataOutput` from the `CameraVideoCapturer` to disable
+    /// video frame processing capabilities.
+    ///
+    /// This method reconfigures the local user's `CameraVideoCapturer` by removing an
+    /// `AVCaptureVideoDataOutput` that was previously added. This change is essential when the
+    /// application no longer requires access to raw video data for analysis, filtering, or other processing
+    /// tasks, or when adjusting the video capturing setup for different operational requirements. It ensures t
+    /// hat video capturing can proceed without the additional processing overhead associated with
+    /// handling video frame outputs.
+    ///
+    /// - Parameter videoOutput: The `AVCaptureVideoDataOutput` instance to be removed
+    /// from the `CameraVideoCapturer`. Removing this output stops the capture and processing of live video
+    /// frames through the specified output, simplifying the capture session.
+    ///
+    /// - Throws: An error if the `CameraVideoCapturer` does not support removing an
+    /// `AVCaptureVideoDataOutput`. This functionality is tailored for `RTCCameraVideoCapturer`
+    /// instances. If the `CameraVideoCapturer` being used does not permit the removal of video outputs,
+    /// an error will be thrown to indicate the unsupported operation.
+    ///
+    /// - Note: It is crucial to ensure that the `AVCaptureVideoDataOutput` intended for removal
+    /// has been previously added to the `CameraVideoCapturer`. Trying to remove an output that is
+    /// not part of the capture session will have no negative impact but could lead to unnecessary processing
+    /// and confusion.
+    func removeVideoOutput(_ videoOutput: AVCaptureVideoDataOutput) throws {
+        guard let videoCapturer = videoCapturer as? VideoCapturer else {
+            throw ClientError.Unexpected()
+        }
+
+        try videoCapturer.removeVideoOutput(videoOutput)
     }
 
     /// Zooms the camera video by the specified factor.

--- a/docusaurus/docs/iOS/05-ui-cookbook/16-snapshot.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/16-snapshot.mdx
@@ -252,12 +252,19 @@ let photoOutput: AVCapturePhotoOutput = .init()
 let videoOutput: AVCaptureVideoDataOutput = .init()
 
 do {
-    try call?.addCapturePhotoOutput(photoOutput)
-    if #available(iOS 16.0, *) {
-        try call?.addVideoOutput(videoOutput)
+    guard call?.cId != oldValue?.cId else { return }
+    do {
+        if #available(iOS 16.0, *) {
+            try call?.addVideoOutput(videoOutput)
+            /// Following Apple guidelines for videoOutputs from here:
+            /// https://developer.apple.com/library/archive/technotes/tn2445/_index.html
+            videoOutput.alwaysDiscardsLateVideoFrames = true
+        } else {
+            try call?.addCapturePhotoOutput(photoOutput)
+        }
+    } catch {
+        log.error("Failed to setup for localParticipant snapshot", error: error)
     }
-
-    videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue.global(qos: .background))
 } catch {
     log.error("Failed to setup for localParticipant snapshot", error: error)
 }
@@ -340,6 +347,7 @@ Both examples are using the same method to send the Image data:
 
 ```swift
 func sendImageData(_ data: Data) async {
+    defer { videoOutput.setSampleBufferDelegate(nil, queue: nil) }
     guard
         let snapshot = UIImage(data: data),
         let resizedImage = resize(image: snapshot, to: .init(width: 30, height: 30)),
@@ -357,6 +365,8 @@ func sendImageData(_ data: Data) async {
     }
 }
 ```
+
+We are removing the videoOutput's delegate so we stop receiving frames and avoid video delays due to unnecessary processing.
 
 ## Conclusion
 

--- a/docusaurus/docs/iOS/05-ui-cookbook/17-camera-zoom.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/17-camera-zoom.mdx
@@ -5,7 +5,7 @@ description: Documentation on implementing cammera zooming.
 
 # Camera zoom
 
-Zooming the local participant's camera is a feature that users will look into when using your app. Fotunately the StreamVideo SDK makes that easy for you by taking care of all interactions with the `AVCaptureSession` and the `AVCaptureDevice`. 
+Zooming the local participant's camera is a feature that users will look into when using your app. Fortunately the StreamVideo SDK makes that easy for you by taking care of all interactions with the `AVCaptureSession` and the `AVCaptureDevice`. 
 
 Zoom factors are limited with the following: `1 < zoomFactor < activeCaptureDevice.activeFormat.videoMaxZoomFactor`.
 


### PR DESCRIPTION
### 🎯 Goal

Allow removing custom videoOutputs in order to avoid performance hiccups when not necessary.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (Docusaurus, tutorial, CMS)