### PR TITLE
[Fix]Single instance AVAudioRecorder

### DIFF
--- a/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
@@ -76,6 +76,7 @@ struct DemoCallingViewModifier: ViewModifier {
                     text.wrappedValue = ""
                 }
             }
+            .toastView(toast: $viewModel.toast)
     }
 
     private func joinCallIfNeeded(with callId: String, callType: String = .default) {

--- a/DemoApp/Sources/Views/CustomCallView.swift
+++ b/DemoApp/Sources/Views/CustomCallView.swift
@@ -19,7 +19,7 @@ struct CustomCallView<Factory: ViewFactory>: View {
     var body: some View {
         StreamVideoSwiftUI.CallView(viewFactory: viewFactory, viewModel: viewModel)
             .onReceive(viewModel.$callSettings) { _ in
-                updateMicrophoneChecker()
+                Task { await updateMicrophoneChecker() }
             }
             .onReceive(microphoneChecker.$audioLevels, perform: { values in
                 guard !viewModel.callSettings.audioOn else { return }
@@ -46,19 +46,13 @@ struct CustomCallView<Factory: ViewFactory>: View {
                     }
                     : nil
             )
-            .onDisappear {
-                microphoneChecker.stopListening()
-            }
-            .onAppear {
-                updateMicrophoneChecker()
-            }
     }
     
-    private func updateMicrophoneChecker() {
+    private func updateMicrophoneChecker() async {
         if !viewModel.callSettings.audioOn {
-            microphoneChecker.startListening()
+            await microphoneChecker.startListening()
         } else {
-            microphoneChecker.stopListening()
+            await microphoneChecker.stopListening()
         }
     }
 }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/11-speaking-while-muted.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/11-speaking-while-muted.swift
@@ -19,7 +19,7 @@ fileprivate func content() {
             var body: some View {
                 CallView(viewFactory: viewFactory, viewModel: viewModel)
                     .onReceive(viewModel.$callSettings) { callSettings in
-                        updateMicrophoneChecker()
+                        Task { await updateMicrophoneChecker() }
                     }
                     .onReceive(microphoneChecker.$audioLevels, perform: { values in
                         guard !viewModel.callSettings.audioOn else { return }
@@ -46,19 +46,13 @@ fileprivate func content() {
                         }
                         : nil
                     )
-                    .onDisappear {
-                        microphoneChecker.stopListening()
-                    }
-                    .onAppear {
-                        updateMicrophoneChecker()
-                    }
             }
 
-            private func updateMicrophoneChecker() {
+            private func updateMicrophoneChecker() async {
                 if !viewModel.callSettings.audioOn {
-                    microphoneChecker.startListening()
+                    await microphoneChecker.startListening()
                 } else {
-                    microphoneChecker.stopListening()
+                    await microphoneChecker.stopListening()
                 }
             }
         }

--- a/Sources/StreamVideo/Models/CallSettings.swift
+++ b/Sources/StreamVideo/Models/CallSettings.swift
@@ -5,7 +5,7 @@
 import Combine
 
 /// Represents the settings for a call.
-public final class CallSettings: ObservableObject, Sendable {
+public final class CallSettings: ObservableObject, Sendable, Equatable {
     /// Whether the audio is on for the current user.
     public let audioOn: Bool
     /// Whether the video is on for the current user.
@@ -16,7 +16,7 @@ public final class CallSettings: ObservableObject, Sendable {
     public let audioOutputOn: Bool
     /// The camera position for the current user.
     public let cameraPosition: CameraPosition
-        
+
     public init(
         audioOn: Bool = true,
         videoOn: Bool = true,
@@ -34,24 +34,32 @@ public final class CallSettings: ObservableObject, Sendable {
         self.videoOn = videoOn
         #endif
     }
-    
+
+    public static func == (lhs: CallSettings, rhs: CallSettings) -> Bool {
+        lhs.audioOn == rhs.audioOn &&
+            lhs.videoOn == rhs.videoOn &&
+            lhs.speakerOn == rhs.speakerOn &&
+            lhs.audioOutputOn == rhs.audioOutputOn &&
+            lhs.cameraPosition == rhs.cameraPosition
+    }
+
     public var shouldPublish: Bool {
         audioOn || videoOn
     }
 }
 
 /// The camera position.
-public enum CameraPosition: Sendable {
+public enum CameraPosition: Sendable, Equatable {
     case front
     case back
-    
+
     public func next() -> CameraPosition {
         self == .front ? .back : .front
     }
 }
 
 extension CallSettingsResponse {
-    
+
     public var toCallSettings: CallSettings {
         CallSettings(
             audioOn: audio.micDefaultOn,
@@ -73,7 +81,7 @@ public extension CallSettings {
             cameraPosition: cameraPosition
         )
     }
-    
+
     func withUpdatedAudioState(_ audioOn: Bool) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
@@ -83,7 +91,7 @@ public extension CallSettings {
             cameraPosition: cameraPosition
         )
     }
-    
+
     func withUpdatedVideoState(_ videoOn: Bool) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
@@ -93,7 +101,7 @@ public extension CallSettings {
             cameraPosition: cameraPosition
         )
     }
-    
+
     func withUpdatedSpeakerState(_ speakerOn: Bool) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
@@ -103,7 +111,7 @@ public extension CallSettings {
             cameraPosition: cameraPosition
         )
     }
-    
+
     func withUpdatedAudioOutputState(_ audioOutputOn: Bool) -> CallSettings {
         CallSettings(
             audioOn: audioOn,

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -81,7 +81,7 @@ public class StreamVideo: ObservableObject {
     private let apiKey: APIKey
     private let environment: Environment
     private let pushNotificationsConfig: PushNotificationsConfig
-    
+
     /// Initializes a new instance of `StreamVideo` with the specified parameters.
     /// - Parameters:
     ///   - apiKey: The API key.

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -135,6 +135,9 @@ public class StreamVideo: ObservableObject {
             middlewares: [defaultParams]
         )
         StreamVideoProviderKey.currentValue = self
+        // This is used from the `StreamCallAudioRecorder` to observe active
+        // calls and activate/deactivate the AudioSession.
+        StreamActiveCallProviderKey.currentValue = self
         (apiTransport as? URLSessionTransport)?.setTokenUpdater { [weak self] userToken in
             self?.token = userToken
         }

--- a/Sources/StreamVideo/Utils/AudioRecorder/AVAudioRecorderBuilder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/AVAudioRecorderBuilder.swift
@@ -5,6 +5,12 @@
 import AVFoundation
 import Foundation
 
+/// The AVAudioRecorderBuilder actor simplifies the creation and management of AVAudioRecorder
+/// instances for audio recording. It offers:
+/// Caching: Stores created AVAudioRecorder objects for efficient reuse, avoiding redundant initialization.
+/// Customisable settings: Allows you to tailor recording parameters to your specific needs.
+///
+/// - Important: You need to call `.build()` before trying to access the `result` property.
 actor AVAudioRecorderBuilder {
 
     // `kAudioFormatLinearPCM` is being used to be able to support multiple
@@ -18,13 +24,14 @@ actor AVAudioRecorderBuilder {
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
     ]
 
+    /// The URL where the audio recording will be saved.
     let fileURL: URL
+
+    /// A dictionary containing audio format, sample rate, number of channels, and quality configurations.
     let settings: [String: Any]
 
+    /// A property storing the built AVAudioRecorder instance.
     private var cachedResult: AVAudioRecorder?
-    private var factory: (URL, [String: Any]) throws -> AVAudioRecorder = {
-        try .init(url: $0, settings: $1)
-    }
 
     var result: AVAudioRecorder? { cachedResult }
 
@@ -48,9 +55,10 @@ actor AVAudioRecorderBuilder {
         self.settings = cachedResult.settings
     }
 
+    /// Instructs the `AVAudioRecorderBuilder` to build and cache an instance of AVAudioRecorder.
     func build() throws {
         guard cachedResult == nil else { return }
-        let audioRecorder = try factory(fileURL, settings)
+        let audioRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
         self.cachedResult = audioRecorder
     }
 }

--- a/Sources/StreamVideo/Utils/AudioRecorder/AVAudioRecorderBuilder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/AVAudioRecorderBuilder.swift
@@ -1,0 +1,58 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Foundation
+
+actor AVAudioRecorderBuilder {
+
+    // `kAudioFormatLinearPCM` is being used to be able to support multiple
+    // instances of AVAudioRecorders. (useful when using MicrophoneChecker
+    // during a Call).
+    // https://stackoverflow.com/a/8575101
+    static let defaultRecordingSettings: [String: any Sendable] = [
+        AVFormatIDKey: Int(kAudioFormatLinearPCM),
+        AVSampleRateKey: 12000,
+        AVNumberOfChannelsKey: 1,
+        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+    ]
+
+    let fileURL: URL
+    let settings: [String: Any]
+
+    private var cachedResult: AVAudioRecorder?
+    private var factory: (URL, [String: Any]) throws -> AVAudioRecorder = {
+        try .init(url: $0, settings: $1)
+    }
+
+    var result: AVAudioRecorder? { cachedResult }
+
+    init(
+        inCacheDirectoryWithFilename filename: String,
+        settings: [String: any Sendable] = AVAudioRecorderBuilder.defaultRecordingSettings
+    ) {
+        let documentPath = FileManager.default.urls(
+            for: .cachesDirectory,
+            in: .userDomainMask
+        )[0]
+        self.fileURL = documentPath.appendingPathComponent(filename)
+        self.settings = settings
+    }
+
+    init(
+        cachedResult: AVAudioRecorder
+    ) {
+        self.cachedResult = cachedResult
+        self.fileURL = cachedResult.url
+        self.settings = cachedResult.settings
+    }
+
+    func build() throws {
+        guard cachedResult == nil else { return }
+        let audioRecorder = try factory(fileURL, settings)
+        self.cachedResult = audioRecorder
+    }
+}
+
+extension AVAudioRecorder: @unchecked Sendable {}

--- a/Sources/StreamVideo/Utils/AudioRecorder/AudioSessionProtocol.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/AudioSessionProtocol.swift
@@ -1,0 +1,30 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Foundation
+
+/// A simple protocol that abstracts the usage of AVAudioSession.
+public protocol AudioSessionProtocol: AnyObject {
+
+    func setCategory(_ category: AVAudioSession.Category) throws
+
+    func setActive(
+        _ active: Bool,
+        options: AVAudioSession.SetActiveOptions
+    ) throws
+
+    func requestRecordPermission() async -> Bool
+}
+
+extension AVAudioSession: AudioSessionProtocol {
+
+    public func requestRecordPermission() async -> Bool {
+        await withCheckedContinuation { continuation in
+            self.requestRecordPermission { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+}

--- a/Sources/StreamVideo/Utils/AudioRecorder/StreamActiveCallProvider.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/StreamActiveCallProvider.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// A protocol defining an object that can provide information regarding an active call.
+protocol StreamActiveCallProviding {
+    var hasActiveCallPublisher: AnyPublisher<Bool, Never> { get }
+}
+
+extension StreamVideo: StreamActiveCallProviding {
+    var hasActiveCallPublisher: AnyPublisher<Bool, Never> {
+        state
+            .$activeCall
+            .map { $0 != nil }
+            .eraseToAnyPublisher()
+    }
+}
+
+/// Provides the default value of the `StreamActiveCallProviding` class.
+struct StreamActiveCallProviderKey: InjectionKey {
+    static var currentValue: StreamActiveCallProviding?
+}
+
+extension InjectedValues {
+    var activeCallProvider: StreamActiveCallProviding {
+        get {
+            Self[StreamActiveCallProviderKey.self]!
+        }
+        set {
+            Self[StreamActiveCallProviderKey.self] = newValue
+        }
+    }
+}

--- a/Sources/StreamVideo/Utils/AudioRecorder/StreamAudioRecorder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/StreamAudioRecorder.swift
@@ -1,0 +1,180 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Combine
+import Foundation
+
+/// This class abstracts the usage of AVAudioRecorder, providing a convenient way to record and manage
+/// audio streams. It handles setting up the recording environment, starting and stopping recording, and
+/// publishing the average power of the audio signal. Additionally, it adjusts its behavior based on the
+/// presence of an active call, automatically stopping recording if needed.
+open class StreamAudioRecorder: @unchecked Sendable {
+
+    /// The builder used to create the AVAudioRecorder instance.
+    let audioRecorderBuilder: AVAudioRecorderBuilder
+
+    /// The audio session used for recording and playback.
+    let audioSession: AudioSessionProtocol
+
+    /// A private task responsible for setting up the recorder in the background.
+    private var setUpTask: Task<Void, Never>?
+
+    /// A cancellable used to schedule the update of audio meters.
+    private(set) var updateMetersTimerCancellable: AnyCancellable?
+
+    /// A PassthroughSubject that publishes the average power of the audio signal.
+    private var _metersPublisher: PassthroughSubject<Float, Never> = .init()
+
+    /// A public publisher that exposes the average power of the audio signal.
+    open private(set) lazy var metersPublisher: AnyPublisher<Float, Never> = _metersPublisher.eraseToAnyPublisher()
+
+    /// Indicates whether an active call is present, influencing recording behavior.
+    public var hasActiveCall: Bool = false {
+        didSet {
+            if !hasActiveCall {
+                Task {
+                    await stopRecording()
+                    try? audioSession.setActive(false, options: [])
+                }
+            }
+        }
+    }
+
+    /// Initializes the recorder with a filename.
+    ///
+    /// - Parameter filename: The name of the file to record to.
+    public init(filename: String) {
+        audioRecorderBuilder = .init(inCacheDirectoryWithFilename: filename)
+        audioSession = AVAudioSession.sharedInstance()
+
+        setUp()
+    }
+
+    /// Initializes the recorder with a custom builder and audio session.
+    ///
+    /// - Parameter audioRecorderBuilder: The builder used to create the recorder.
+    /// - Parameter audioSession: The audio session used for recording and playback.
+    init(
+        audioRecorderBuilder: AVAudioRecorderBuilder,
+        audioSession: AudioSessionProtocol
+    ) {
+        self.audioRecorderBuilder = audioRecorderBuilder
+        self.audioSession = audioSession
+
+        setUp()
+    }
+
+    deinit {
+        setUpTask?.cancel()
+        setUpTask = nil
+        do {
+            try FileManager.default.removeItem(at: audioRecorderBuilder.fileURL)
+            log.debug("Successfully deleted audio filename")
+        } catch {
+            log.error("Error deleting fileURL.", error: error)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Starts recording audio asynchronously.
+    open func startRecording() async {
+        await setUpAudioCaptureIfRequired { [weak self] audioRecorder in
+            guard let self, self.hasActiveCall, !audioRecorder.isRecording else {
+                return
+            }
+
+            audioRecorder.record()
+            audioRecorder.isMeteringEnabled = true
+
+            log.debug("️Recording started.")
+            self.updateMetersTimerCancellable = Foundation.Timer
+                .publish(every: 0.1, on: .main, in: .default)
+                .autoconnect()
+                .sink { [weak self, audioRecorder] _ in
+                    Task { [weak self, audioRecorder] in
+                        guard let self else { return }
+                        audioRecorder.updateMeters()
+                        self._metersPublisher.send(audioRecorder.averagePower(forChannel: 0))
+                        log.debug("️Recording meters updated")
+                    }
+                }
+        }
+    }
+
+    /// Stops recording audio asynchronously.
+    open func stopRecording() async {
+        guard let audioRecorder = await audioRecorderBuilder.result, audioRecorder.isRecording else {
+            return
+        }
+
+        updateMetersTimerCancellable?.cancel()
+        updateMetersTimerCancellable = nil
+        audioRecorder.stop()
+        do {
+            try audioSession.setCategory(.playback)
+        } catch {
+            log.error("Failed to set AudiSession category to playback.", error: error)
+        }
+        log.debug("️Recording stopped.")
+    }
+
+    // MARK: - Private helpers
+
+    private func setUp() {
+        setUpTask = Task {
+            do {
+                #if DEBUG
+                let startedOn = Date()
+                try await audioRecorderBuilder.build()
+                let diff = Date().timeIntervalSince1970 - startedOn.timeIntervalSince1970
+                try Task.checkCancellation() // This required to ensure that tests aren't crashing.
+                log.debug("🎙️AVAudioRecorder creation took: \(diff) seconds.")
+                #else
+                try await audioRecorderBuilder.build()
+                #endif
+            } catch {
+                if type(of: error) != CancellationError.self {
+                    log.error("Failed to create AVAudioRecorder.", error: error)
+                }
+            }
+        }
+    }
+
+    private func setUpAudioCaptureIfRequired(
+        _ completionHandler: @escaping (AVAudioRecorder) async -> Void
+    ) async {
+        do {
+            try audioSession.setCategory(.playAndRecord)
+            try audioSession.setActive(true, options: [])
+            if
+                await audioSession.requestRecordPermission(),
+                let audioRecorder = await audioRecorderBuilder.result {
+                await completionHandler(audioRecorder)
+            }
+        } catch {
+            log.error("Failed to set up recording session", error: error)
+        }
+    }
+}
+
+/// Provides the default value of the `StreamAudioRecorder` class.
+public struct StreamAudioRecorderKey: InjectionKey {
+    public static var currentValue: StreamAudioRecorder = StreamAudioRecorder(
+        filename: "recording.wav"
+    )
+}
+
+extension InjectedValues {
+
+    public var audioRecorder: StreamAudioRecorder {
+        get {
+            Self[StreamAudioRecorderKey.self]
+        }
+        set {
+            Self[StreamAudioRecorderKey.self] = newValue
+        }
+    }
+}

--- a/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
@@ -86,10 +86,13 @@ open class StreamCallAudioRecorder: @unchecked Sendable {
     // MARK: - Public API
 
     /// Starts recording audio asynchronously.
-    open func startRecording() async {
+    /// - Parameters:
+    /// - ignoreActiveCall: Instructs the internal AudioRecorder to ignore the existence of an activeCall
+    /// and start recording anyway.
+    open func startRecording(ignoreActiveCall: Bool = false) async {
         do {
             let audioRecorder = try await setUpAudioCaptureIfRequired()
-            guard hasActiveCall, !audioRecorder.isRecording else {
+            guard hasActiveCall || ignoreActiveCall, !audioRecorder.isRecording else {
                 log
                     .info(
                         "🎙️Attempted to start recording but failed. hasActiveCall:\(hasActiveCall) isRecording:\(audioRecorder.isRecording)"

--- a/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
@@ -132,13 +132,6 @@ open class StreamCallAudioRecorder: @unchecked Sendable {
         updateMetersTimerCancellable = nil
         audioRecorder.stop()
         removeRecodingFile()
-        do {
-            /// - Warning: It's on purpose that we don't deactivate the AudioSession here as a
-            /// call is in progress.
-            try audioSession.setCategory(.playback)
-        } catch {
-            log.error("🎙️Failed to set AudiSession category to playback.", error: error)
-        }
         log.debug("️🎙️Recording stopped.")
     }
 

--- a/Sources/StreamVideoSwiftUI/CallContainer.swift
+++ b/Sources/StreamVideoSwiftUI/CallContainer.swift
@@ -42,7 +42,7 @@ public struct CallContainer<Factory: ViewFactory>: View {
     }
     
     public var body: some View {
-        ZStack {
+        Group {
             if shouldShowCallView {
                 if viewModel.callParticipants.count > 1 {
                     if viewModel.isMinimized {

--- a/Sources/StreamVideoSwiftUI/CallView/CallTopView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallTopView.swift
@@ -37,11 +37,7 @@ public struct CallTopView: View {
                 .frame(maxWidth: .infinity)
 
                 HStack(alignment: .center) {
-                    if #available(iOS 14.0, *) {
-                        CallDurationView(viewModel)
-                    } else {
-                        EmptyView()
-                    }
+                    CallDurationView(viewModel)
                 }
                 .frame(height: 44)
                 .frame(maxWidth: .infinity)

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRendererFactory.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRendererFactory.swift
@@ -56,11 +56,19 @@ class VideoRendererFactory {
         }
         log.debug("Removing view for participant \(participantId)")
         queue.sync {
+            if let participantView = views[participantId] {
+                participantView.track = nil
+                participantView.removeFromSuperview()
+            }
             views[participantId] = nil
         }
     }
     
     @objc func clearViews() {
+        views.forEach {
+            $0.value.track = nil
+            $0.value.removeFromSuperview()
+        }
         views = [String: VideoRenderer]()
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -13,7 +13,7 @@ open class CallViewModel: ObservableObject {
     
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.pictureInPictureAdapter) var pictureInPictureAdapter
-    @Injected(\.audioRecorder) var audioRecorder
+    @Injected(\.callAudioRecorder) var audioRecorder
 
     /// Provides access to the current call.
     @Published public private(set) var call: Call? {
@@ -72,7 +72,6 @@ open class CallViewModel: ObservableObject {
     @Published public var callingState: CallingState = .idle {
         didSet {
             handleRingingEvents()
-            audioRecorder.hasActiveCall = callingState != .idle
         }
     }
     

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -13,6 +13,7 @@ open class CallViewModel: ObservableObject {
     
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.pictureInPictureAdapter) var pictureInPictureAdapter
+    @Injected(\.audioRecorder) var audioRecorder
 
     /// Provides access to the current call.
     @Published public private(set) var call: Call? {
@@ -71,6 +72,7 @@ open class CallViewModel: ObservableObject {
     @Published public var callingState: CallingState = .idle {
         didSet {
             handleRingingEvents()
+            audioRecorder.hasActiveCall = callingState != .idle
         }
     }
     
@@ -292,7 +294,12 @@ open class CallViewModel: ObservableObject {
     ///  - callId: the id of the call.
     ///  - members: list of members that are part of the call.
     ///  - ring: whether the call should ring.
-    public func startCall(callType: String, callId: String, members: [MemberRequest], ring: Bool = false) {
+    public func startCall(
+        callType: String,
+        callId: String,
+        members: [MemberRequest],
+        ring: Bool = false
+    ) {
         outgoingCallMembers = members
         callingState = ring ? .outgoing : .joining
         if !ring {
@@ -330,7 +337,11 @@ open class CallViewModel: ObservableObject {
     ///  - callType: the type of the call.
     ///  - callId: the id of the call.
     ///  - members: list of members that are part of the call.
-    public func enterLobby(callType: String, callId: String, members: [MemberRequest]) {
+    public func enterLobby(
+        callType: String,
+        callId: String,
+        members: [MemberRequest]
+    ) {
         let lobbyInfo = LobbyInfo(callId: callId, callType: callType, participants: members)
         callingState = .lobby(lobbyInfo)
         if !localCallSettingsChange {

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -15,7 +15,7 @@ public final class MicrophoneChecker: ObservableObject {
 
     private let valueLimit: Int
     private let audioNormaliser = AudioValuePercentageNormaliser()
-    private let audioRecorder = InjectedValues[\.audioRecorder]
+    private let audioRecorder = InjectedValues[\.callAudioRecorder]
 
     private var updateMetersCancellable: AnyCancellable?
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -8,51 +8,26 @@ import Foundation
 import StreamVideo
 
 /// Checks the audio capabilities of the device.
-public class MicrophoneChecker: ObservableObject {
-    
+public final class MicrophoneChecker: ObservableObject {
+
     /// Returns the last three decibel values.
-    @Published public var audioLevels: [Float]
-    
-    private var timer: Timer?
-    
+    @Published public private(set) var audioLevels: [Float]
+
     private let valueLimit: Int
-    private let audioSession: AudioSessionProtocol
-    private let notificationCenter: NotificationCenter
+    private let audioNormaliser = AudioValuePercentageNormaliser()
+    private let audioRecorder = InjectedValues[\.audioRecorder]
 
-    private var audioRecorder: AVAudioRecorder?
+    private var updateMetersCancellable: AnyCancellable?
 
-    private var callEndedCancellable: AnyCancellable?
-
-    private let audioFilename: URL = {
-        let documentPath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-        let audioFilename = documentPath.appendingPathComponent("recording.wav")
-        return audioFilename
-    }()
-
-    private lazy var audioNormaliser: AudioValuePercentageNormaliser = .init()
-
-    public convenience init(
+    public init(
         valueLimit: Int = 3
     ) {
-        self.init(
-            valueLimit: valueLimit,
-            audioSession: AVAudioSession.sharedInstance(),
-            notificationCenter: .default
-        )
+        self.valueLimit = valueLimit
+        audioLevels = [Float](repeating: 0.0, count: valueLimit)
     }
 
-    init(
-        valueLimit: Int,
-        audioSession: AudioSessionProtocol,
-        notificationCenter: NotificationCenter = .default
-    ) {
-        self.valueLimit = valueLimit
-        self.audioSession = audioSession
-        self.notificationCenter = notificationCenter
-        audioLevels = [Float](repeating: 0.0, count: valueLimit)
-        setUpAudioCapture()
-
-        subscribeToCallEnded()
+    deinit {
+        updateMetersCancellable?.cancel()
     }
 
     /// Checks if there are audible values available.
@@ -66,110 +41,37 @@ public class MicrophoneChecker: ObservableObject {
     }
     
     /// Starts listening to audio updates.
-    public func startListening() {
-        captureAudio()
+    public func startListening() async {
+        await audioRecorder.startRecording()
+        if updateMetersCancellable == nil {
+            updateMetersCancellable = audioRecorder
+                .metersPublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] in self?.didReceiveUpdatedMeters($0) }
+        }
     }
     
     /// Stops listening to audio updates.
-    public func stopListening() {
-        stopTimer()
-        stopAudioRecorder()
+    public func stopListening() async {
+        await audioRecorder.stopRecording()
+        updateMetersCancellable?.cancel()
+        updateMetersCancellable = nil
+        Task { @MainActor in
+            audioLevels = [Float](repeating: 0.0, count: valueLimit)
+        }
     }
     
     // MARK: - private
 
-    private func subscribeToCallEnded() {
-        callEndedCancellable = notificationCenter
-            .publisher(for: Notification.Name(CallNotification.callEnded))
-            .sink { [audioSession] _ in try? audioSession.setActive(false, options: []) }
-    }
-
-    private func setUpAudioCapture() {
-        do {
-            try audioSession.setCategory(.playAndRecord)
-            try audioSession.setActive(true, options: [])
-            audioSession.requestRecordPermission { result in
-                guard result else { return }
-            }
-            captureAudio()
-        } catch {
-            log.error("Failed to set up recording session", error: error)
+    private func didReceiveUpdatedMeters(_ decibel: Float) {
+        let normalisedAudioLevel = audioNormaliser.normalise(decibel)
+        var temp = audioLevels
+        temp.append(normalisedAudioLevel)
+        if temp.count > valueLimit {
+            temp = Array(temp.dropFirst())
         }
-    }
-    
-    private func captureAudio() {
-        guard audioRecorder == nil else { return }
-        // `kAudioFormatLinearPCM` is being used to be able to support multiple
-        // instances of AVAudioRecorders. (useful when using MicrophoneChecker
-        // during a Call).
-        // https://stackoverflow.com/a/8575101
-        let settings = [
-            AVFormatIDKey: Int(kAudioFormatLinearPCM),
-            AVSampleRateKey: 12000,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
-        ]
-
-        let newAudioRecorder: AVAudioRecorder
-        do {
-            newAudioRecorder = try AVAudioRecorder(url: audioFilename, settings: settings)
-        } catch {
-            log.error("Failed to start recording process", error: error)
-            return
-        }
-
-        newAudioRecorder.record()
-        newAudioRecorder.isMeteringEnabled = true
-        audioRecorder = newAudioRecorder
-        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            newAudioRecorder.updateMeters()
-            let decibel = newAudioRecorder.averagePower(forChannel: 0)
-            let normalisedAudioLevel = self.audioNormaliser.normalise(decibel)
-            var temp = self.audioLevels
-            temp.append(normalisedAudioLevel)
-            if temp.count > self.valueLimit {
-                temp = Array(temp.dropFirst())
-            }
-            self.audioLevels = temp
-        }
-    }
-    
-    private func stopTimer() {
-        guard timer != nil else { return }
-        timer?.invalidate()
-        timer = nil
-    }
-    
-    private func stopAudioRecorder() {
-        guard audioRecorder != nil else { return }
-        audioRecorder?.stop()
-        audioRecorder = nil
-    }
-
-    deinit {
-        stopTimer()
-        stopAudioRecorder()
-        do {
-            try FileManager.default.removeItem(at: audioFilename)
-            log.debug("Successfully deleted audio filename")
-        } catch {
-            log.error("Error deleting audio filename: \(error.localizedDescription)", error: error)
-        }
+        audioLevels = temp
     }
 }
 
-/// A simple protocol that abstracts the usage of AVAudioSession.
-protocol AudioSessionProtocol {
-
-    func setCategory(_ category: AVAudioSession.Category) throws
-
-    func setActive(
-        _ active: Bool,
-        options: AVAudioSession.SetActiveOptions
-    ) throws
-
-    func requestRecordPermission(_ response: @escaping (Bool) -> Void)
-}
-
-extension AVAudioSession: AudioSessionProtocol {}
+extension MicrophoneChecker: @unchecked Sendable {}

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -41,8 +41,11 @@ public final class MicrophoneChecker: ObservableObject {
     }
     
     /// Starts listening to audio updates.
-    public func startListening() async {
-        await audioRecorder.startRecording()
+    /// - Parameters:
+    /// - ignoreActiveCall: Instructs the internal AudioRecorder to ignore the existence of an activeCall
+    /// and start recording anyway.
+    public func startListening(ignoreActiveCall: Bool = false) async {
+        await audioRecorder.startRecording(ignoreActiveCall: ignoreActiveCall)
         if updateMetersCancellable == nil {
             updateMetersCancellable = audioRecorder
                 .metersPublisher

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -41,7 +41,7 @@ public struct LobbyView: View {
 
         Task {
             callSettings.wrappedValue.audioOn
-                ? await microphoneCheckerInstance.startListening()
+                ? await microphoneCheckerInstance.startListening(ignoreActiveCall: true)
                 : await microphoneCheckerInstance.stopListening()
         }
     }
@@ -59,7 +59,7 @@ public struct LobbyView: View {
         .onChange(of: callSettings) { newValue in
             Task {
                 newValue.audioOn
-                    ? await microphoneChecker.startListening()
+                    ? await microphoneChecker.startListening(ignoreActiveCall: true)
                     : await microphoneChecker.stopListening()
             }
         }

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -36,6 +36,14 @@ public struct LobbyView: View {
                 callId: callId
             )
         )
+        let microphoneCheckerInstance = MicrophoneChecker()
+        _microphoneChecker = .init(wrappedValue: microphoneCheckerInstance)
+
+        Task {
+            callSettings.wrappedValue.audioOn
+                ? await microphoneCheckerInstance.startListening()
+                : await microphoneCheckerInstance.stopListening()
+        }
     }
     
     public var body: some View {
@@ -48,6 +56,13 @@ public struct LobbyView: View {
             onJoinCallTap: onJoinCallTap,
             onCloseLobby: onCloseLobby
         )
+        .onChange(of: callSettings) { newValue in
+            Task {
+                newValue.audioOn
+                    ? await microphoneChecker.startListening()
+                    : await microphoneChecker.stopListening()
+            }
+        }
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
@@ -52,11 +52,11 @@ public class LobbyViewModel: ObservableObject, @unchecked Sendable {
     
     public func startCamera(front: Bool) {
         if #available(iOS 14, *) {
+            if front {
+                (camera as? Camera)?.switchCaptureDevice()
+            }
             Task {
                 await(camera as? Camera)?.start()
-                if front {
-                    (camera as? Camera)?.switchCaptureDevice()
-                }
             }
         }
     }

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -50,5 +50,12 @@ struct LobbyView_iOS13: View {
             onJoinCallTap: onJoinCallTap,
             onCloseLobby: onCloseLobby
         )
+        .onReceive(callViewModel.$callSettings) { newValue in
+            Task {
+                newValue.audioOn
+                    ? await microphoneChecker.startListening()
+                    : await microphoneChecker.stopListening()
+            }
+        }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -10,8 +10,8 @@ struct LobbyView_iOS13: View {
     
     @ObservedObject var callViewModel: CallViewModel
     @BackportStateObject var viewModel: LobbyViewModel
-    @BackportStateObject var microphoneChecker = MicrophoneChecker()
-    
+    @BackportStateObject var microphoneChecker: MicrophoneChecker
+
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
@@ -33,11 +33,19 @@ struct LobbyView_iOS13: View {
                 callId: callId
             )
         )
+        let microphoneCheckerInstance = MicrophoneChecker()
+        _microphoneChecker = BackportStateObject(wrappedValue: microphoneCheckerInstance)
         _callSettings = callSettings
         self.callId = callId
         self.callType = callType
         self.onJoinCallTap = onJoinCallTap
         self.onCloseLobby = onCloseLobby
+
+        Task {
+            callSettings.wrappedValue.audioOn
+                ? await microphoneCheckerInstance.startListening(ignoreActiveCall: true)
+                : await microphoneCheckerInstance.stopListening()
+        }
     }
     
     public var body: some View {
@@ -53,7 +61,7 @@ struct LobbyView_iOS13: View {
         .onReceive(callViewModel.$callSettings) { newValue in
             Task {
                 newValue.audioOn
-                    ? await microphoneChecker.startListening()
+                    ? await microphoneChecker.startListening(ignoreActiveCall: true)
                     : await microphoneChecker.stopListening()
             }
         }

--- a/Sources/StreamVideoSwiftUI/Utils/Camera.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/Camera.swift
@@ -15,7 +15,11 @@ class Camera: NSObject, @unchecked Sendable {
     private var photoOutput: AVCapturePhotoOutput?
     private var videoOutput: AVCaptureVideoDataOutput?
     private var sessionQueue: DispatchQueue!
-    
+    private lazy var frameProcessingQueue: DispatchQueue = DispatchQueue(
+        label: "io.getstream.\(String(describing: type(of: self))).videoDataOutputQueue",
+        target: .global(qos: .userInteractive)
+    )
+
     private var allCaptureDevices: [AVCaptureDevice] {
         AVCaptureDevice.DiscoverySession(
             deviceTypes: [
@@ -133,7 +137,7 @@ class Camera: NSObject, @unchecked Sendable {
         captureSession.sessionPreset = AVCaptureSession.Preset.high
 
         let videoOutput = AVCaptureVideoDataOutput()
-        videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue.global(qos: .userInteractive))
+        videoOutput.setSampleBufferDelegate(self, queue: frameProcessingQueue)
 
         guard captureSession.canAddInput(deviceInput) else {
             logger.error("Unable to add device input to capture session.")

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		4030E5A02A9DF5BD003E8CBA /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		4030E5A22A9DF6B6003E8CBA /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E5A12A9DF6B6003E8CBA /* Router.swift */; };
 		4031D7F62B801D8A002EC6E4 /* LocalParticipantSnapshotViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CB9FA62B7FB1C9006BED93 /* LocalParticipantSnapshotViewModel.swift */; };
-		4031D7F82B83C087002EC6E4 /* StreamAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */; };
+		4031D7F82B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031D7F72B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift */; };
 		4031D7FA2B84B077002EC6E4 /* StreamActiveCallProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031D7F92B84B077002EC6E4 /* StreamActiveCallProvider.swift */; };
 		403812F62A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403812F52A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift */; };
 		403BE0FE2A24C07300988F65 /* DeeplinkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */; };
@@ -1096,7 +1096,7 @@
 		402F04B02B724EE500CA1986 /* CallViewModel+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallViewModel+Snapshot.swift"; sourceTree = "<group>"; };
 		4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		4030E5A12A9DF6B6003E8CBA /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
-		4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioRecorderTests.swift; sourceTree = "<group>"; };
+		4031D7F72B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCallAudioRecorderTests.swift; sourceTree = "<group>"; };
 		4031D7F92B84B077002EC6E4 /* StreamActiveCallProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamActiveCallProvider.swift; sourceTree = "<group>"; };
 		403812F52A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneChecker_Tests.swift; sourceTree = "<group>"; };
 		403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkAdapter.swift; sourceTree = "<group>"; };
@@ -3009,7 +3009,7 @@
 				845E31072A712389004DC470 /* BroadcastUtils_Tests.swift */,
 				400D63F62AC3273F0000BB30 /* ThermalStateObserverTests.swift */,
 				84D6E5392B3AD10000D0056C /* RepeatingTimer_Tests.swift */,
-				4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */,
+				4031D7F72B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5036,7 +5036,7 @@
 				846D162B2A52F62B0036CE4C /* CameraManager_Tests.swift in Sources */,
 				4063033F2AD847EC0091AE77 /* CallState_Tests.swift in Sources */,
 				843DAB9C29E6FFCD00E0EB63 /* StreamVideo_Tests.swift in Sources */,
-				4031D7F82B83C087002EC6E4 /* StreamAudioRecorderTests.swift in Sources */,
+				4031D7F82B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		401480362A5447C50029166A /* LocalParticipantViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480352A5447C50029166A /* LocalParticipantViewModifier.swift */; };
 		40149DC32B7E202600473176 /* ParticipantEventViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DC22B7E202600473176 /* ParticipantEventViewModifier.swift */; };
 		40149DCC2B7E814300473176 /* AVAudioRecorderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCB2B7E814300473176 /* AVAudioRecorderBuilder.swift */; };
-		40149DCE2B7E837A00473176 /* StreamAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCD2B7E837A00473176 /* StreamAudioRecorder.swift */; };
+		40149DCE2B7E837A00473176 /* StreamCallAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCD2B7E837A00473176 /* StreamCallAudioRecorder.swift */; };
 		40149DD02B7E839500473176 /* AudioSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCF2B7E839500473176 /* AudioSessionProtocol.swift */; };
 		401A0F032AB1C1B600BE2DBD /* ThermalStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401A0F022AB1C1B600BE2DBD /* ThermalStateObserver.swift */; };
 		401A64A52A9DF79E00534ED1 /* StreamChatSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 401A64A42A9DF79E00534ED1 /* StreamChatSwiftUI */; };
@@ -45,6 +45,7 @@
 		4030E5A22A9DF6B6003E8CBA /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E5A12A9DF6B6003E8CBA /* Router.swift */; };
 		4031D7F62B801D8A002EC6E4 /* LocalParticipantSnapshotViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CB9FA62B7FB1C9006BED93 /* LocalParticipantSnapshotViewModel.swift */; };
 		4031D7F82B83C087002EC6E4 /* StreamAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */; };
+		4031D7FA2B84B077002EC6E4 /* StreamActiveCallProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031D7F92B84B077002EC6E4 /* StreamActiveCallProvider.swift */; };
 		403812F62A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403812F52A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift */; };
 		403BE0FE2A24C07300988F65 /* DeeplinkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */; };
 		403BE1012A24C70000988F65 /* DemoApp+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE1002A24C70000988F65 /* DemoApp+Sentry.swift */; };
@@ -1072,7 +1073,7 @@
 		401480352A5447C50029166A /* LocalParticipantViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalParticipantViewModifier.swift; sourceTree = "<group>"; };
 		40149DC22B7E202600473176 /* ParticipantEventViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantEventViewModifier.swift; sourceTree = "<group>"; };
 		40149DCB2B7E814300473176 /* AVAudioRecorderBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAudioRecorderBuilder.swift; sourceTree = "<group>"; };
-		40149DCD2B7E837A00473176 /* StreamAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioRecorder.swift; sourceTree = "<group>"; };
+		40149DCD2B7E837A00473176 /* StreamCallAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCallAudioRecorder.swift; sourceTree = "<group>"; };
 		40149DCF2B7E839500473176 /* AudioSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionProtocol.swift; sourceTree = "<group>"; };
 		401A0F022AB1C1B600BE2DBD /* ThermalStateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateObserver.swift; sourceTree = "<group>"; };
 		401A64AA2A9DF7EC00534ED1 /* DemoChatAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatAdapter.swift; sourceTree = "<group>"; };
@@ -1096,6 +1097,7 @@
 		4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		4030E5A12A9DF6B6003E8CBA /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioRecorderTests.swift; sourceTree = "<group>"; };
+		4031D7F92B84B077002EC6E4 /* StreamActiveCallProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamActiveCallProvider.swift; sourceTree = "<group>"; };
 		403812F52A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneChecker_Tests.swift; sourceTree = "<group>"; };
 		403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkAdapter.swift; sourceTree = "<group>"; };
 		403BE1002A24C70000988F65 /* DemoApp+Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoApp+Sentry.swift"; sourceTree = "<group>"; };
@@ -1951,8 +1953,9 @@
 			isa = PBXGroup;
 			children = (
 				40149DCB2B7E814300473176 /* AVAudioRecorderBuilder.swift */,
-				40149DCD2B7E837A00473176 /* StreamAudioRecorder.swift */,
+				40149DCD2B7E837A00473176 /* StreamCallAudioRecorder.swift */,
 				40149DCF2B7E839500473176 /* AudioSessionProtocol.swift */,
+				4031D7F92B84B077002EC6E4 /* StreamActiveCallProvider.swift */,
 			);
 			path = AudioRecorder;
 			sourceTree = "<group>";
@@ -4767,6 +4770,7 @@
 				84DC38AB29ADFCFD00946713 /* RecordSettingsRequest.swift in Sources */,
 				84EA5D3F28C09AAC004D3531 /* CallController.swift in Sources */,
 				84DC38CA29ADFCFD00946713 /* UpdateCallRequest.swift in Sources */,
+				4031D7FA2B84B077002EC6E4 /* StreamActiveCallProvider.swift in Sources */,
 				84AF64D9287C79F60012A503 /* Errors.swift in Sources */,
 				84DC389429ADFCFD00946713 /* UpdateUserPermissionsRequest.swift in Sources */,
 				8456E6D3287EC343004E180E /* BaseLogDestination.swift in Sources */,
@@ -4880,7 +4884,7 @@
 				840F59932A77FDCB00EF3EB2 /* PinResponse.swift in Sources */,
 				840042C52A6FED2900917B30 /* IntExtensions.swift in Sources */,
 				84FC2C2428AD1B5E00181490 /* WebRTCEventDecoder.swift in Sources */,
-				40149DCE2B7E837A00473176 /* StreamAudioRecorder.swift in Sources */,
+				40149DCE2B7E837A00473176 /* StreamCallAudioRecorder.swift in Sources */,
 				84DC389B29ADFCFD00946713 /* PermissionRequestEvent.swift in Sources */,
 				84BAD77A2A6BFEF900733156 /* BroadcastBufferUploader.swift in Sources */,
 				84DC38A429ADFCFD00946713 /* BackstageSettings.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		401480342A5423D60029166A /* AudioValuePercentageNormaliser_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */; };
 		401480362A5447C50029166A /* LocalParticipantViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480352A5447C50029166A /* LocalParticipantViewModifier.swift */; };
 		40149DC32B7E202600473176 /* ParticipantEventViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DC22B7E202600473176 /* ParticipantEventViewModifier.swift */; };
+		40149DCC2B7E814300473176 /* AVAudioRecorderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCB2B7E814300473176 /* AVAudioRecorderBuilder.swift */; };
+		40149DCE2B7E837A00473176 /* StreamAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCD2B7E837A00473176 /* StreamAudioRecorder.swift */; };
+		40149DD02B7E839500473176 /* AudioSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40149DCF2B7E839500473176 /* AudioSessionProtocol.swift */; };
 		401A0F032AB1C1B600BE2DBD /* ThermalStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401A0F022AB1C1B600BE2DBD /* ThermalStateObserver.swift */; };
 		401A64A52A9DF79E00534ED1 /* StreamChatSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 401A64A42A9DF79E00534ED1 /* StreamChatSwiftUI */; };
 		401A64A82A9DF7B400534ED1 /* EffectsLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 401A64A72A9DF7B400534ED1 /* EffectsLibrary */; };
@@ -41,6 +44,7 @@
 		4030E5A02A9DF5BD003E8CBA /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		4030E5A22A9DF6B6003E8CBA /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E5A12A9DF6B6003E8CBA /* Router.swift */; };
 		4031D7F62B801D8A002EC6E4 /* LocalParticipantSnapshotViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CB9FA62B7FB1C9006BED93 /* LocalParticipantSnapshotViewModel.swift */; };
+		4031D7F82B83C087002EC6E4 /* StreamAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */; };
 		403812F62A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403812F52A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift */; };
 		403BE0FE2A24C07300988F65 /* DeeplinkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */; };
 		403BE1012A24C70000988F65 /* DemoApp+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE1002A24C70000988F65 /* DemoApp+Sentry.swift */; };
@@ -1067,6 +1071,9 @@
 		401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioValuePercentageNormaliser_Tests.swift; sourceTree = "<group>"; };
 		401480352A5447C50029166A /* LocalParticipantViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalParticipantViewModifier.swift; sourceTree = "<group>"; };
 		40149DC22B7E202600473176 /* ParticipantEventViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantEventViewModifier.swift; sourceTree = "<group>"; };
+		40149DCB2B7E814300473176 /* AVAudioRecorderBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAudioRecorderBuilder.swift; sourceTree = "<group>"; };
+		40149DCD2B7E837A00473176 /* StreamAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioRecorder.swift; sourceTree = "<group>"; };
+		40149DCF2B7E839500473176 /* AudioSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionProtocol.swift; sourceTree = "<group>"; };
 		401A0F022AB1C1B600BE2DBD /* ThermalStateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateObserver.swift; sourceTree = "<group>"; };
 		401A64AA2A9DF7EC00534ED1 /* DemoChatAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatAdapter.swift; sourceTree = "<group>"; };
 		401A64B02A9DF83200534ED1 /* TokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenResponse.swift; sourceTree = "<group>"; };
@@ -1088,6 +1095,7 @@
 		402F04B02B724EE500CA1986 /* CallViewModel+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallViewModel+Snapshot.swift"; sourceTree = "<group>"; };
 		4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		4030E5A12A9DF6B6003E8CBA /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioRecorderTests.swift; sourceTree = "<group>"; };
 		403812F52A6EA2A7009BB2F7 /* MicrophoneChecker_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneChecker_Tests.swift; sourceTree = "<group>"; };
 		403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkAdapter.swift; sourceTree = "<group>"; };
 		403BE1002A24C70000988F65 /* DemoApp+Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoApp+Sentry.swift"; sourceTree = "<group>"; };
@@ -1937,6 +1945,16 @@
 				407AF7192B6163DD00E9E3E7 /* StreamMediaDurationFormatter_Tests.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		40149DCA2B7E813500473176 /* AudioRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				40149DCB2B7E814300473176 /* AVAudioRecorderBuilder.swift */,
+				40149DCD2B7E837A00473176 /* StreamAudioRecorder.swift */,
+				40149DCF2B7E839500473176 /* AudioSessionProtocol.swift */,
+			);
+			path = AudioRecorder;
 			sourceTree = "<group>";
 		};
 		401A64A92A9DF7E600534ED1 /* Chat */ = {
@@ -2988,6 +3006,7 @@
 				845E31072A712389004DC470 /* BroadcastUtils_Tests.swift */,
 				400D63F62AC3273F0000BB30 /* ThermalStateObserverTests.swift */,
 				84D6E5392B3AD10000D0056C /* RepeatingTimer_Tests.swift */,
+				4031D7F72B83C087002EC6E4 /* StreamAudioRecorderTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3419,6 +3438,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40149DCA2B7E813500473176 /* AudioRecorder */,
 				8456E6C7287EC343004E180E /* Logger */,
 				84C2997C28784BB30034B735 /* Utils.swift */,
 				84AF64D4287C79320012A503 /* RawJSON.swift */,
@@ -4676,6 +4696,7 @@
 				84E5C51C2A013C440003A27A /* PushNotificationsConfig.swift in Sources */,
 				84A7E184288362DF00526C98 /* Atomic.swift in Sources */,
 				84D2E37729DC856D001D2118 /* CallMemberUpdatedEvent.swift in Sources */,
+				40149DD02B7E839500473176 /* AudioSessionProtocol.swift in Sources */,
 				8409465B29AF4EEC007AF5BF /* ListRecordingsResponse.swift in Sources */,
 				8490DD21298D4ADF007E53D2 /* StreamJsonDecoder.swift in Sources */,
 				84C4004229E3F446007B69C2 /* ConnectedEvent.swift in Sources */,
@@ -4845,6 +4866,7 @@
 				84FC2C1E28ACF2AE00181490 /* WebRTCClient.swift in Sources */,
 				84DC389E29ADFCFD00946713 /* CallCreatedEvent.swift in Sources */,
 				842B8E202A2DFED900863A87 /* CallSessionParticipantLeftEvent.swift in Sources */,
+				40149DCC2B7E814300473176 /* AVAudioRecorderBuilder.swift in Sources */,
 				84DC38AE29ADFCFD00946713 /* BlockedUserEvent.swift in Sources */,
 				842B8E1A2A2DFED900863A87 /* CallLiveStartedEvent.swift in Sources */,
 				843DAB9E29E757B600E0EB63 /* CallsController.swift in Sources */,
@@ -4858,6 +4880,7 @@
 				840F59932A77FDCB00EF3EB2 /* PinResponse.swift in Sources */,
 				840042C52A6FED2900917B30 /* IntExtensions.swift in Sources */,
 				84FC2C2428AD1B5E00181490 /* WebRTCEventDecoder.swift in Sources */,
+				40149DCE2B7E837A00473176 /* StreamAudioRecorder.swift in Sources */,
 				84DC389B29ADFCFD00946713 /* PermissionRequestEvent.swift in Sources */,
 				84BAD77A2A6BFEF900733156 /* BroadcastBufferUploader.swift in Sources */,
 				84DC38A429ADFCFD00946713 /* BackstageSettings.swift in Sources */,
@@ -5009,6 +5032,7 @@
 				846D162B2A52F62B0036CE4C /* CameraManager_Tests.swift in Sources */,
 				4063033F2AD847EC0091AE77 /* CallState_Tests.swift in Sources */,
 				843DAB9C29E6FFCD00E0EB63 /* StreamVideo_Tests.swift in Sources */,
+				4031D7F82B83C087002EC6E4 /* StreamAudioRecorderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -12,11 +12,11 @@ import Combine
 final class MicrophoneChecker_Tests: XCTestCase {
 
     private lazy var subject: MicrophoneChecker! = .init(valueLimit: 3)
-    private lazy var mockAudioRecorder: MockStreamAudioRecorder! = MockStreamAudioRecorder(filename: "test.wav")
+    private lazy var mockAudioRecorder: MockStreamCallAudioRecorder! = MockStreamCallAudioRecorder(filename: "test.wav")
 
     override func setUp() {
         super.setUp()
-        InjectedValues[\.audioRecorder] = mockAudioRecorder
+        InjectedValues[\.callAudioRecorder] = mockAudioRecorder
     }
 
     override func tearDown() {
@@ -59,7 +59,7 @@ final class MicrophoneChecker_Tests: XCTestCase {
     }
 }
 
-private final class MockStreamAudioRecorder: StreamAudioRecorder {
+private final class MockStreamCallAudioRecorder: StreamCallAudioRecorder {
 
     private(set) var startRecordingWasCalled = false
     private(set) var stopRecordingWasCalled = false

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -67,7 +67,7 @@ private final class MockStreamCallAudioRecorder: StreamCallAudioRecorder {
     private(set) var mockMetersPublisher: PassthroughSubject<Float, Never> = .init()
     override var metersPublisher: AnyPublisher<Float, Never> { mockMetersPublisher.eraseToAnyPublisher() }
 
-    override func startRecording() async {
+    override func startRecording(ignoreActiveCall: Bool) async {
         startRecordingWasCalled = true
     }
 

--- a/StreamVideoTests/Utils/StreamAudioRecorderTests.swift
+++ b/StreamVideoTests/Utils/StreamAudioRecorderTests.swift
@@ -1,0 +1,159 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+@testable import StreamVideo
+import XCTest
+
+final class StreamAudioRecorderTests: XCTestCase {
+
+    private lazy var builder: AVAudioRecorderBuilder! = .init(cachedResult: mockAudioRecorder)
+    private lazy var mockAudioSession: MockAudioSession! = .init()
+    private var mockAudioRecorder: MockAudioRecorder!
+    private lazy var subject: StreamAudioRecorder! = .init(
+        audioRecorderBuilder: builder,
+        audioSession: mockAudioSession
+    )
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockAudioRecorder = try .init(
+            url: URL(string: "test.wav")!,
+            settings: AVAudioRecorderBuilder.defaultRecordingSettings
+        )
+    }
+
+    override func tearDown() {
+        builder = nil
+        mockAudioSession = nil
+        mockAudioRecorder = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: Initialization
+
+    func testInitWithFilename_givenValidFilename_whenInitialized_thenSetsUpCorrectly() async throws {
+        let filename = "test_recording.m4a"
+        let recorder = StreamAudioRecorder(filename: filename)
+
+        let actualFileURL = await recorder.audioRecorderBuilder.fileURL.lastPathComponent
+        XCTAssertTrue(actualFileURL == filename)
+        XCTAssertTrue(recorder.audioSession === AVAudioSession.sharedInstance())
+    }
+
+    func testInitWithBuilderAndSession_givenCustomBuilderAndSession_whenInitialized_thenUsesProvidedObjects() {
+        XCTAssertTrue(subject.audioRecorderBuilder === builder)
+        XCTAssertTrue(subject.audioSession === mockAudioSession)
+    }
+
+    // MARK: Deinitialization
+
+    func testFileDeletion_givenRecordingExists_whenDeinitialized_thenDeletesFile() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+
+        let filename = tempDirectory.appendingPathComponent("test_recording.m4a")
+        let mockBuilder = AVAudioRecorderBuilder(cachedResult: try .init(url: filename, settings: [:]))
+        var recorder: StreamAudioRecorder! = StreamAudioRecorder(
+            audioRecorderBuilder: mockBuilder,
+            audioSession: MockAudioSession()
+        )
+
+        await recorder.startRecording() // Simulate recording
+        recorder = nil
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: filename.standardizedFileURL.absoluteString))
+    }
+
+    // MARK: Public API
+
+    func testStartRecording_givenPermissionNotGranted_whenStarted_thenRecordsAndMetersAreNotUpdated() async throws {
+        mockAudioSession.recordPermission = false
+        subject.hasActiveCall = true
+
+        await subject.startRecording()
+
+        let audioRecorder = try await XCTAsyncUnwrap(await builder.result)
+        XCTAssertFalse(audioRecorder.isRecording)
+        XCTAssertFalse(audioRecorder.isMeteringEnabled)
+        XCTAssertNil(subject.updateMetersTimerCancellable)
+    }
+
+    func testStartRecording_givenPermissionGranted_whenStarted_thenRecordsAndMetersUpdates() async throws {
+        mockAudioSession.recordPermission = true
+        subject.hasActiveCall = true
+
+        await subject.startRecording()
+
+        let audioRecorder = try await XCTAsyncUnwrap(await builder.result)
+        XCTAssertTrue(audioRecorder.isRecording)
+        XCTAssertTrue(audioRecorder.isMeteringEnabled)
+        XCTAssertNotNil(subject.updateMetersTimerCancellable)
+    }
+
+    func testStopRecording_givenRecording_whenStopped_thenStopsRecording() async throws {
+        mockAudioSession.recordPermission = true
+        subject.hasActiveCall = true
+
+        await subject.startRecording()
+        await subject.stopRecording()
+
+        let audioRecorder = try await XCTAsyncUnwrap(await builder.result)
+        XCTAssertFalse(audioRecorder.isRecording)
+        XCTAssertTrue(mockAudioSession.active)
+        XCTAssertNil(subject.updateMetersTimerCancellable)
+    }
+}
+
+// Mocks for unit testing
+
+private class MockAudioRecorder: AVAudioRecorder {
+    private var _isRecoding = false
+    override var isRecording: Bool { _isRecoding }
+
+    override func record() -> Bool {
+        _isRecoding = true
+        return _isRecoding
+    }
+
+    override func stop() {
+        _isRecoding = false
+    }
+
+    override func updateMeters() {
+        // Simulate meter update
+    }
+}
+
+private class MockAudioSession: AudioSessionProtocol {
+
+    var category: AVAudioSession.Category = .playback
+    var active = false
+    var recordPermission = false
+
+    func setCategory(_ category: AVAudioSession.Category) throws {
+        self.category = category
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions = []) throws {
+        self.active = active
+    }
+
+    func requestRecordPermission() async -> Bool {
+        recordPermission
+    }
+}
+
+extension XCTestCase {
+
+    func XCTAsyncUnwrap<T>(
+        _ expression: @autoclosure () async throws -> T?,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> T {
+        let expressionResult = try await expression()
+        return try XCTUnwrap(expressionResult, message(), file: file, line: line)
+    }
+}

--- a/StreamVideoTests/Utils/StreamCallAudioRecorderTests.swift
+++ b/StreamVideoTests/Utils/StreamCallAudioRecorderTests.swift
@@ -90,6 +90,23 @@ final class StreamAudioRecorderTests: XCTestCase {
         try await assertRecording(true)
     }
 
+    func testStartRecording_givenPermissionGrantedButNoActiveCall_whenStarted_thenRecordsAndMetersWontStart() async throws {
+        mockAudioSession.recordPermission = true
+
+        await subject.startRecording()
+
+        try await assertRecording(false, isMeteringEnabled: false)
+    }
+
+    func testStartRecording_givenPermissionGrantedButNoActiveCall_whenIgnoreActiveCallAndStarted_thenRecordsAndMetersUpdates(
+    ) async throws {
+        mockAudioSession.recordPermission = true
+
+        await subject.startRecording(ignoreActiveCall: true)
+
+        try await assertRecording(true)
+    }
+
     // MARK: - stopRecording
 
     func testStopRecording_givenRecording_whenStopped_thenStopsRecording() async throws {

--- a/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
@@ -238,7 +238,7 @@ extension UserRobot {
         if isVisible {
             XCTAssertTrue(CallPage.reconnectingMessage.wait().exists, "reconnectingMessage should appear")
         } else {
-            XCTAssertFalse(CallPage.reconnectingMessage.waitForDisappearance(timeout: UserRobot.defaultTimeout).exists, "reconnectingMessage should disappear")
+            XCTAssertFalse(CallPage.reconnectingMessage.waitForDisappearance(timeout: UserRobot.defaultTimeout * 2).exists, "reconnectingMessage should disappear")
         }
         return self
     }

--- a/docusaurus/docs/iOS/05-ui-cookbook/11-speaking-while-muted.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/11-speaking-while-muted.mdx
@@ -23,7 +23,7 @@ struct CustomCallView<Factory: ViewFactory>: View {
     var body: some View {
         CallView(viewFactory: viewFactory, viewModel: viewModel)
             .onReceive(viewModel.$callSettings) { callSettings in
-                updateMicrophoneChecker()
+                Task { await updateMicrophoneChecker() }
             }
             .onReceive(microphoneChecker.$$audioLevels, perform: { values in
                 guard !viewModel.callSettings.audioOn else { return }
@@ -50,19 +50,13 @@ struct CustomCallView<Factory: ViewFactory>: View {
                 }
                 : nil
             )
-            .onDisappear {
-                microphoneChecker.stopListening()
-            }
-            .onAppear {
-                updateMicrophoneChecker()
-            }
     }
     
-    private func updateMicrophoneChecker() {
+    private func updateMicrophoneChecker() async {
         if !viewModel.callSettings.audioOn {
-            microphoneChecker.startListening()
+            await microphoneChecker.startListening()
         } else {
-            microphoneChecker.stopListening()
+            await microphoneChecker.stopListening()
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

AVAudioRecorder is an expensive resource. This PR aims to centralise its usage and maintain a single instance during runtime, that will be initialized once and early to avoid delays during the call.

### 📝 Summary

- Abstract the AVAudioRecorder behind a specialized, thread safe object.
- Inject it into the UI components and update paths accordingly.
- Minor UI updates to make the interface smoother.
- Extensive unit testing for the recording layer.

### 🧪 Manual Testing Notes

|  Lobby  |  Join Call  | Leave Call|
| ------- | ----------- | --------- |
|  true   |  true       | false     |
|  false  |  false      | false     |
|  false  |  true       | true      |
|  true   |  false      | false     |

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)