### PR TITLE
Replace wget with curl in cocoapods prepare command

### DIFF
--- a/StreamVideo-XCFramework.podspec
+++ b/StreamVideo-XCFramework.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
 
   spec.prepare_command = <<-CMD
     mkdir -p Frameworks/
-    wget https://github.com/GetStream/stream-video-swift-webrtc/releases/download/114.5735.08/StreamWebRTC.zip -O Frameworks/StreamWebRTC.zip
+    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/114.5735.08/StreamWebRTC.zip" -o Frameworks/StreamWebRTC.zip
     unzip -o Frameworks/StreamWebRTC.zip -d Frameworks/
     rm Frameworks/StreamWebRTC.zip
   CMD

--- a/StreamVideo.podspec
+++ b/StreamVideo.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |spec|
 
   spec.prepare_command = <<-CMD
     mkdir -p Frameworks/
-    wget https://github.com/GetStream/stream-video-swift-webrtc/releases/download/114.5735.08/StreamWebRTC.zip -O Frameworks/StreamWebRTC.zip
+    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/114.5735.08/StreamWebRTC.zip" -o Frameworks/StreamWebRTC.zip
     unzip -o Frameworks/StreamWebRTC.zip -d Frameworks/
     rm Frameworks/StreamWebRTC.zip
   CMD


### PR DESCRIPTION
It seems like `wget` is not pre-installed on macOS, but `curl` is.

Tested `StreamVideo.podspec` with a local path:

<img width="294" alt="Screenshot 2024-02-20 at 8 50 10 AM" src="https://github.com/GetStream/stream-video-swift/assets/20794991/bd8eea11-5118-4d08-8c07-b89396df8e7c">

