### PR TITLE
[DemoApp & Docs]CallService unregister

### DIFF
--- a/DemoApp/Sources/Components/Services/VoIPPushService.swift
+++ b/DemoApp/Sources/Components/Services/VoIPPushService.swift
@@ -29,7 +29,12 @@ final class VoIPPushService: NSObject, PKPushRegistryDelegate {
         registry.delegate = self
         registry.desiredPushTypes = [.voIP]
     }
-    
+
+    func unregisterForVoIPPushes() {
+        registry.delegate = nil
+        registry.desiredPushTypes = []
+    }
+
     func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
         print(credentials.token)
         let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/02-push-notifications.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/02-push-notifications.swift
@@ -32,6 +32,11 @@ fileprivate func content() {
                 self.registry.desiredPushTypes = [.voIP]
             }
 
+            func unregisterForVoIPPushes() {
+                self.registry.delegate = nil
+                self.registry.desiredPushTypes = []
+            }
+
             func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
                 print(credentials.token)
                 let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()
@@ -77,6 +82,14 @@ fileprivate func content() {
                 log.info("CallKit notifications not working on a simulator")
             #else
                 voIPPushService.registerForVoIPPushes()
+            #endif
+            }
+
+            private func unregisterForIncomingCalls() {
+            #if targetEnvironment(simulator)
+                log.info("CallKit notifications not working on a simulator")
+            #else
+                voIPPushService.unregisterForVoIPPushes()
             #endif
             }
 

--- a/docusaurus/docs/iOS/06-advanced/03-callkit-integration.mdx
+++ b/docusaurus/docs/iOS/06-advanced/03-callkit-integration.mdx
@@ -129,6 +129,17 @@ func pushRegistry(
 }
 ```
 
+When the user sign out , we need to unregister from VoIP push notifications, by adding the following method to the `VoipPushService`:
+
+```swift
+func unregisterForVoIPPushes() {
+    self.registry.delegate = nil
+    self.registry.desiredPushTypes = []
+}
+```
+
+You will need to call this method once the signout flow has been completed.
+
 #### Saving the PN credentials
 
 We're implementing three methods here. The `pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType)` method is called when new push notifications credentials are provided. You should use this method to save the device token to our backend. In our sample app, we are storing it in our `AppState` object. Whenever the `StreamVideo` SDK is initalized, we are saving the token to our backend, by calling the `setVoipDevice` method.
@@ -176,6 +187,14 @@ final class CallService {
         log.info("CallKit notifications not working on a simulator")
     #else
         voIPPushService.registerForVoIPPushes()
+    #endif
+    }
+
+    private func unregisterForIncomingCalls() {
+    #if targetEnvironment(simulator)
+        log.info("CallKit notifications not working on a simulator")
+    #else
+        voIPPushService.unregisterForVoIPPushes()
     #endif
     }
 


### PR DESCRIPTION
### 📝 Summary

In the DemoApp (debug builds only) there is a rare issue that can happen, if someone rings a user who just signed out from the app. The signed out user will still receive the notification and join the call because we are not unregistering from the CallService notifications.

### 🧪 Manual Testing Notes

- Get 2 users signed in on different devices.
- Logout one of them and at the same time call the logged out user from the other device.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (Docusaurus, tutorial, CMS)