### PR TITLE
Remove unnecessary usage of RTCCameraVideoCapturer

### DIFF
--- a/Sources/StreamVideo/WebRTC/Screensharing/BroadcastScreenCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/BroadcastScreenCapturer.swift
@@ -28,7 +28,7 @@ class BroadcastScreenCapturer: VideoCapturing {
         #else
         let handler = StreamVideoCaptureHandler(source: videoSource, filters: videoFilters, handleRotation: false)
         videoCaptureHandler = handler
-        videoCapturer = RTCCameraVideoCapturer(delegate: handler)
+        videoCapturer = RTCVideoCapturer(delegate: handler)
         #endif
     }
     

--- a/Sources/StreamVideo/WebRTC/Screensharing/ScreenshareCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/Screensharing/ScreenshareCapturer.swift
@@ -24,7 +24,7 @@ class ScreenshareCapturer: VideoCapturing {
         #else
         let handler = StreamVideoCaptureHandler(source: videoSource, filters: videoFilters, handleRotation: false)
         videoCaptureHandler = handler
-        videoCapturer = RTCCameraVideoCapturer(delegate: handler)
+        videoCapturer = RTCVideoCapturer(delegate: handler)
         #endif
     }
     


### PR DESCRIPTION
### 📝 Summary

The RTCCameraVideoCapturer does much more than sending data to the server. As this functionality isn't required when screensharing or broadcasting, we switch back to plain RTCVideoCapturer which is the best intermediate between us getting frames and the WebRTC stack.

### 🧪 Manual Testing Notes

- Join a call
- Screenshare you screen

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)