### PR TITLE
[Fix]Picture-in-Picture memory consumption

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
@@ -12,25 +12,30 @@ struct StreamBufferTransformer {
 
     var requiresResize = false
 
-    /// Transforms an RTCVideoFrameBuffer to a CVPixelBuffer with optional resizing.
+    /// Transforms an RTCVideoFrameBuffer to a CMSampleBuffer with optional resizing.
     ///
     /// - Parameters:
     ///   - source: The source RTCVideoFrameBuffer to be transformed.
-    ///   - targetSize: The target size for the resulting CVPixelBuffer.
-    /// - Returns: A transformed CVPixelBuffer or nil if transformation fails.
-    func transform(
+    ///   - targetSize: The target size for the resulting CMSampleBuffer.
+    /// - Returns: A transformed CMSampleBuffer or nil if transformation fails.
+    func transformAndResizeIfRequired(
         _ source: RTCVideoFrameBuffer,
         targetSize: CGSize
-    ) -> CVPixelBuffer? {
+    ) -> CMSampleBuffer? {
         let sourceSize = CGSize(width: Int(source.width), height: Int(source.height))
 
         guard
             requiresResize,
-            let resizedSource = resize(source, to: resizeSize(sourceSize, toFitWithin: targetSize))
+            let resizedSource = resize(source, to: resizeSize(sourceSize, toFitWithin: targetSize)),
+            let pixelBuffer = convert(resizedSource)
         else {
-            return convert(source)
+            if let pixelBuffer = convert(source) {
+                return transform(pixelBuffer)
+            } else {
+                return nil
+            }
         }
-        return convert(resizedSource)
+        return transform(pixelBuffer)
     }
 
     /// Transforms an CVPixelBuffer to a CMSampleBuffer.

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamBufferTransformer.swift
@@ -28,9 +28,9 @@ struct StreamBufferTransformer {
         guard
             requiresResize,
             let resizedSource = resize(source, to: resizeSize(sourceSize, toFitWithin: targetSize)),
-                let pixelBuffer = convert(resizedSource.toI420())
+            let pixelBuffer = convert(resizedSource.toI420())
         else {
-                if let pixelBuffer = convert(source.toI420()) {
+            if let pixelBuffer = convert(source.toI420()) {
                 return transform(pixelBuffer)
             } else {
                 return nil
@@ -103,9 +103,9 @@ struct StreamBufferTransformer {
                 pixelFormat: CVPixelBufferGetPixelFormatType(rtcCVPixelBuffer.pixelBuffer)
             ) {
             let count = rtcCVPixelBuffer.bufferSizeForCroppingAndScaling(to: size)
-                let tempBuffer: UnsafeMutableRawPointer? = malloc(count)
-                rtcCVPixelBuffer.cropAndScale(to: newPixelBuffer, withTempBuffer: tempBuffer)
-                tempBuffer?.deallocate()
+            let tempBuffer: UnsafeMutableRawPointer? = malloc(count)
+            rtcCVPixelBuffer.cropAndScale(to: newPixelBuffer, withTempBuffer: tempBuffer)
+            tempBuffer?.deallocate()
             return RTCCVPixelBuffer(pixelBuffer: newPixelBuffer) as? TargetBuffer
         } else {
             return source.cropAndScale?(

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
@@ -149,13 +149,7 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
                     .store(in: &cancellableBag)
             } else {
                 // If picture-in-picture is active, simply update the sourceView.
-                if #available(iOS 15.0, *),
-                   let contentViewController = contentViewController as? StreamAVPictureInPictureVideoCallViewController {
-                    pictureInPictureController?.contentSource = .init(
-                        activeVideoCallSourceView: sourceView,
-                        contentViewController: contentViewController
-                    )
-                }
+                makePictureInPictureController(with: sourceView)
             }
         } else {
             if #available(iOS 15.0, *) {

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureVideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureVideoRenderer.swift
@@ -122,6 +122,10 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
             return
         }
 
+        if bufferUpdatesCancellable == nil, let track, let window {
+            startFrameStreaming(for: track, on: window)
+        }
+
         // Update the trackSize and re-calculate rendering properties if the size
         // has changed.
         trackSize = .init(width: Int(frame.width), height: Int(frame.height))

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureVideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureVideoRenderer.swift
@@ -77,7 +77,12 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
     private var shouldRenderFrame: Bool { skippedFrames == 0 && trackSize != .zero }
 
     /// A size ratio threshold used to determine if resizing is required.
-    let sizeRatioThreshold: CGFloat = 2
+    /// - Note: It seems that Picture-in-Picture doesn't like rendering frames that are bigger than its
+    /// window size. For this reason, we are setting the resizeThreshold to `1`.
+    private let resizeRequiredSizeRatioThreshold: CGFloat = 1
+
+    /// A size ratio threshold used to determine if skipping frames is required.
+    private let sizeRatioThreshold: CGFloat = 2
 
     // MARK: - Lifecycle
 
@@ -121,7 +126,7 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
         // has changed.
         trackSize = .init(width: Int(frame.width), height: Int(frame.height))
 
-        log.debug("Received frame with trackSize:\(trackSize)")
+        log.debug("→ Received frame with trackSize:\(trackSize)")
 
         defer {
             handleFrameSkippingIfRequired()
@@ -132,21 +137,17 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
         }
 
         let pixelBuffer: RTCVideoFrameBuffer? = {
-            if
-                let i420buffer = frame.buffer as? RTCI420Buffer,
-                let transformed = bufferTransformer.transform(i420buffer, targetSize: trackSize) {
-                return RTCCVPixelBuffer(pixelBuffer: transformed)
+            if let i420buffer = frame.buffer as? RTCI420Buffer {
+                return i420buffer
             } else {
                 return frame.buffer
             }
         }()
 
         if
-            let transformedBuffer = bufferTransformer.transform(
-                pixelBuffer ?? frame.buffer,
-                targetSize: contentSize
-            ),
-            let sampleBuffer = bufferTransformer.transform(transformedBuffer) {
+            let pixelBuffer = pixelBuffer,
+            let sampleBuffer = bufferTransformer.transformAndResizeIfRequired(pixelBuffer, targetSize: contentSize) {
+            log.debug("➕ Buffer for trackId:\(track?.trackId ?? "n/a") added.")
             bufferPublisher.send(sampleBuffer)
         } else {
             log.warning("Failed to convert \(type(of: frame.buffer)) CMSampleBuffer.")
@@ -168,20 +169,37 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
 
     /// A method used to process the frame's buffer and enqueue on the rendering view.
     private func process(_ buffer: CMSampleBuffer) {
-        guard let trackId = track?.trackId else {
+        guard
+            bufferUpdatesCancellable != nil,
+            let trackId = track?.trackId,
+            buffer.isValid
+        else {
             contentView.sampleBufferDisplayLayer.flush()
             return
         }
 
+        log.debug("⚙️ Processing buffer for trackId:\(trackId).")
         if #available(iOS 14.0, *) {
             if contentView.sampleBufferDisplayLayer.requiresFlushToResumeDecoding == true {
                 contentView.sampleBufferDisplayLayer.flush()
-                log.debug("Display layer for track:\(trackId) flushed ✅")
+                log.debug("🔥 Display layer for track:\(trackId) flushed.")
             }
         }
 
-        if contentView.sampleBufferDisplayLayer.isReadyForMoreMediaData {
-            contentView.sampleBufferDisplayLayer.enqueue(buffer)
+        let isReadyForMoreMediaData: Bool = {
+            if #available(iOS 17.0, *) {
+                return contentView.sampleBufferDisplayLayer.sampleBufferRenderer.isReadyForMoreMediaData
+            } else {
+                return contentView.sampleBufferDisplayLayer.isReadyForMoreMediaData
+            }
+        }()
+        if isReadyForMoreMediaData {
+            if #available(iOS 17.0, *) {
+                contentView.sampleBufferDisplayLayer.sampleBufferRenderer.enqueue(buffer)
+            } else {
+                contentView.sampleBufferDisplayLayer.enqueue(buffer)
+            }
+            log.debug("✅ Buffer for trackId:\(trackId) enqueued.")
         }
     }
 
@@ -199,13 +217,17 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
             .sink { [weak self] in self?.process($0) }
 
         track.add(self)
+        log.debug("⏳ Frame streaming for Picture-in-Picture started.")
     }
 
     /// A method that stops the frame consumption from the track. Used automatically when the rendering
     /// view move's away from the window or when the track changes.
     private func stopFrameStreaming(for track: RTCVideoTrack?) {
+        guard bufferUpdatesCancellable != nil else { return }
         bufferUpdatesCancellable?.cancel()
+        bufferUpdatesCancellable = nil
         track?.remove(self)
+        log.debug("Frame streaming for Picture-in-Picture stopped.")
     }
 
     /// A method used to calculate rendering required properties, every time the trackSize changes.
@@ -214,13 +236,14 @@ final class StreamPictureInPictureVideoRenderer: UIView, RTCVideoRenderer {
 
         let widthDiffRatio = trackSize.width / contentSize.width
         let heightDiffRatio = trackSize.height / contentSize.height
-        requiresResize = widthDiffRatio >= sizeRatioThreshold || heightDiffRatio >= sizeRatioThreshold
-        noOfFramesToSkipAfterRendering = requiresResize ? max(Int(max(Int(widthDiffRatio), Int(heightDiffRatio)) / 2), 1) : 1
+        requiresResize = widthDiffRatio >= resizeRequiredSizeRatioThreshold || heightDiffRatio >= resizeRequiredSizeRatioThreshold
+        let requiresFramesSkipping = widthDiffRatio >= sizeRatioThreshold || heightDiffRatio >= sizeRatioThreshold
+        noOfFramesToSkipAfterRendering = requiresFramesSkipping ? max(Int(max(Int(widthDiffRatio), Int(heightDiffRatio)) / 2), 1) :
+            0
         skippedFrames = 0
-        log
-            .debug(
-                "contentSize:\(contentSize), trackId:\(track?.trackId ?? "n/a") trackSize:\(trackSize) requiresResize:\(requiresResize) noOfFramesToSkipAfterRendering:\(noOfFramesToSkipAfterRendering) skippedFrames:\(skippedFrames) widthDiffRatio:\(widthDiffRatio) heightDiffRatio:\(heightDiffRatio)"
-            )
+        log.debug(
+            "contentSize:\(contentSize), trackId:\(track?.trackId ?? "n/a") trackSize:\(trackSize) requiresResize:\(requiresResize) noOfFramesToSkipAfterRendering:\(noOfFramesToSkipAfterRendering) skippedFrames:\(skippedFrames) widthDiffRatio:\(widthDiffRatio) heightDiffRatio:\(heightDiffRatio)"
+        )
     }
 
     /// A method used to handle the frameSkipping(step) during frame consumption.

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
@@ -25,7 +25,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 100, height: 100)
 
-        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -44,7 +44,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 50, height: 50)
 
-        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -63,7 +63,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 150, height: 75)
 
-        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -85,7 +85,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 100, height: 100)
 
-        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -105,7 +105,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 50, height: 50)
 
-        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -125,7 +125,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 150, height: 75)
 
-        let resultBuffer = try XCTUnwrap(transformer.transform(sourceBuffer, targetSize: targetSize))
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/731 & https://github.com/GetStream/ios-issues-tracking/issues/732

### 🎯 Goal

Stabilise memory consumption while on Picture-in-Picture.

### 📝 Summary

Due to wrong implementation we were doing unnecessary buffer conversions prior to resizing to the required size (which costs a lot as we process more data than we need).

### 🧪 Manual Testing Notes

- Join a call with other participants
- Move to background
- Let the participants take rounds talking (to validate that the active track is changing)
- Stay in Picture-in-Picture fora few minutes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)