### PR TITLE
[Fix]Stop recording when error occurs on join

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -511,6 +511,7 @@ open class CallViewModel: ObservableObject {
                 log.error("Error starting a call", error: error)
                 self.error = error
                 callingState = .idle
+                Task { await audioRecorder.stopRecording() }
                 enteringCallTask = nil
             }
         }


### PR DESCRIPTION
### 📝 Summary

When a call fails to join from the LobbyView the audioRecorder isn't being stopped from recording. This PR fixes that.

### 🧪 Manual Testing Notes

- Run the app on debugger
- Choose to login with a guest account (not one of the predefined ones)
- Enter any callId and click join
- In the lobbyView don't turn off the mic
- Press join
- After the error there should be no audioRecording.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)