### PR TITLE
[Fix]Change method's return type

### DIFF
--- a/DemoApp/Sources/Components/Services/CallKitService.swift
+++ b/DemoApp/Sources/Components/Services/CallKitService.swift
@@ -76,7 +76,7 @@ final class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     private func checkIfCallWasHandled(callId: String, type: String) {
         Task {
             let call = streamVideo.call(callType: type, callId: callId)
-            let callState = try await call.get()
+            let callState = try await call.get().call
             let acceptedBy = callState.session?.acceptedBy ?? [:]
             let rejectedBy = callState.session?.rejectedBy ?? [:]
             let currentUserId = streamVideo.user.id

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -128,7 +128,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         membersLimit: Int? = nil,
         ring: Bool = false,
         notify: Bool = false
-    ) async throws -> CallResponse {
+    ) async throws -> GetCallResponse {
         let response = try await coordinatorClient.getCall(
             type: callType,
             id: callId,
@@ -140,7 +140,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         if ring {
             streamVideo.state.ringingCall = self
         }
-        return response.call
+        return response
     }
     
     /// Rings the call (sends call notification to members).
@@ -149,7 +149,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     public func ring() async throws -> CallResponse {
         let response = try await get(ring: true)
         await state.update(from: response)
-        return response
+        return response.call
     }
     
     /// Notifies the users of the call, by sending push notification.
@@ -158,7 +158,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     public func notify() async throws -> CallResponse {
         let response = try await get(notify: true)
         await state.update(from: response)
-        return response
+        return response.call
     }
 
     @discardableResult

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -347,7 +347,7 @@ open class CallViewModel: ObservableObject {
             Task {
                 let call = streamVideo.call(callType: callType, callId: callId)
                 let info = try await call.get()
-                self.callSettings = info.settings.toCallSettings
+                self.callSettings = info.call.settings.toCallSettings
             }
         }
     }

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
@@ -82,7 +82,7 @@ public class LobbyViewModel: ObservableObject, @unchecked Sendable {
         Task {
             let response = try await call.get()
             withAnimation {
-                participants = response.session?.participants.map(\.user.toUser) ?? []
+                participants = response.call.session?.participants.map(\.user.toUser) ?? []
             }
         }
     }

--- a/StreamVideoTests/IntegrationTests/CallCRUDTests.swift
+++ b/StreamVideoTests/IntegrationTests/CallCRUDTests.swift
@@ -457,7 +457,7 @@ final class CallCRUDTest: IntegrationTest {
         var membersResponse = try await call.queryMembers()
         XCTAssertEqual(2, membersResponse.members.count)
         
-        var blockedUsers = try await call.get().blockedUserIds
+        var blockedUsers = try await call.get().call.blockedUserIds
         XCTAssertEqual(blockedUsers, [user2])
         
         try await call.unblockUser(with: user2)
@@ -465,7 +465,7 @@ final class CallCRUDTest: IntegrationTest {
         membersResponse = try await call.queryMembers()
         XCTAssertEqual(2, membersResponse.members.count)
         
-        blockedUsers = try await call.get().blockedUserIds
+        blockedUsers = try await call.get().call.blockedUserIds
         XCTAssertEqual(blockedUsers, [])
     }
     
@@ -546,13 +546,13 @@ final class CallCRUDTest: IntegrationTest {
         try await call.ring()
         try await customWait()
         
-        var session = try await call.get().session
+        var session = try await call.get().call.session
         XCTAssertEqual(session?.acceptedBy.isEmpty, true, "Call should not be accepted yet")
         
         try await call.accept()
         try await customWait()
         
-        session = try await call.get().session
+        session = try await call.get().call.session
         XCTAssertNotNil(session?.acceptedBy[client.user.id], "Call should be accepted by \(user1)")
     }
     


### PR DESCRIPTION
### 🎯 Goal

Return the correct object type as it being returned from API. That will help being consistent with other SDKs and also supporting some features.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (Docusaurus, tutorial, CMS)