### PR TITLE
[Fix]Handle VoIP notifications for ended calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
-- The return type of `call.get()` is now the API type `GetCallResponse` which encapsulates the previous `CallResponse` under the `call` property. [#335](https://github.com/GetStream/stream-video-swift/pull/335) 
+- The return type of `call.get()` is now the API type `GetCallResponse` which encapsulates the previous `CallResponse` under the `call` property. [#335](https://github.com/GetStream/stream-video-swift/pull/335)
+
+### 🐞 Fixed
+- An issue where VoIP push notifications for ended calls, were received when the user connects [#336](https://github.com/GetStream/stream-video-swift/pull/336)
 
 # [0.5.3](https://github.com/GetStream/stream-video-swift/releases/tag/0.5.3)
 _March 19, 2024_

--- a/DemoApp/Sources/Components/Services/CallService.swift
+++ b/DemoApp/Sources/Components/Services/CallService.swift
@@ -65,7 +65,10 @@ final class CallService {
                 callCid: callCid,
                 displayName: createdByName,
                 callerId: createdById
-            ) { _ in
+            ) { error in
+                if let error {
+                    log.error(error)
+                }
                 completion()
             }
         }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/747

### 📝 Summary

When a user is logged out but is being involved in a ringing call the VoIP push notifications will be sent to their device once they get back online (and register their device token). This PR addresses an issue where VoIP push notifications for ended/rejected calls were displayed to the user.

### 🧪 Manual Testing Notes

The easiest way is by changing the code for the DemoApp. Spefically:
- Comment out `Router.swift:50` to disable auto login
- Delete the DemoApp from the device
- Build and run
- From another device use the Detailed LoggedIn view and call one of the predefined users a few times. Make sure to select the ring events and always generate a new callId
- On the device that you built and run choose the user you called from the list
- You shouldn't receive any of the previously made calls

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)