### PR TITLE
[Fix]Long usernames on various places

### DIFF
--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -487,7 +487,18 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         let token = UserToken(rawValue: guestUserResponse.accessToken)
         
         // Update the user and token provider.
-        let updatedUser = guestUserResponse.user.toUser
+        var updatedUser = guestUserResponse.user.toUser
+        let lastNameComponent = updatedUser.name.split(separator: "-").last.map { String($0) }
+        if lastNameComponent == user.name {
+            updatedUser = .init(
+                id: updatedUser.id,
+                name: user.name,
+                imageURL: updatedUser.imageURL,
+                role: updatedUser.role,
+                type: updatedUser.type,
+                customData: updatedUser.customData
+            )
+        }
         let tokenProvider = { [environment = self.environment] result in
             Self.loadGuestToken(
                 userId: user.id,


### PR DESCRIPTION
### 🎯 Goal

Make sure that long user ids won't be presented on UI.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
| ![before](https://github.com/GetStream/stream-video-swift/assets/472467/161c8fb3-cf22-4320-ab1c-92f72de440f0) | ![after](https://github.com/GetStream/stream-video-swift/assets/472467/81dcc40f-49e8-4dba-abc2-74fdd390ffbd) |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)