### PR TITLE
[Fix]Stop recording when closing the Lobby

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -87,6 +87,7 @@ struct LobbyContentView: View {
                 HStack {
                     Spacer()
                     Button {
+                        Task { await microphoneChecker.stopListening() }
                         onCloseLobby()
                     } label: {
                         Image(systemName: "xmark")


### PR DESCRIPTION
### 📝 Summary

When we close the lobby (by tapping the x(close button) on the top right corner) I noticed that we don't stop recording. This PR addresses this issue, by explicitly calling `stopRecording` on the microphoneCheker.

### 🧪 Manual Testing Notes

- Run the app on a device or simulator
- Type in any callId and tap Join Call
- You will notice some logs like this one `🎙️Recording meters updated`
- Tap the close button, on the top right corner
- You should not see any further messages about recording

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)