### PR TITLE
[CleanUp]Remove AVAudioRecorder creation timing

### DIFF
--- a/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
@@ -140,15 +140,7 @@ open class StreamCallAudioRecorder: @unchecked Sendable {
     private func setUp() {
         setUpTask = Task {
             do {
-                #if DEBUG
-                let startedOn = Date()
                 try await audioRecorderBuilder.build()
-                let diff = Date().timeIntervalSince1970 - startedOn.timeIntervalSince1970
-                try Task.checkCancellation() // This required to ensure that tests aren't crashing.
-                log.debug("🎙️AVAudioRecorder creation took: \(diff) seconds.")
-                #else
-                try await audioRecorderBuilder.build()
-                #endif
             } catch {
                 if type(of: error) != CancellationError.self {
                     log.error("🎙️Failed to create AVAudioRecorder.", error: error)


### PR DESCRIPTION
### 🎯 Goal

Since we are using a single AVAudioRecorder instance, measuring the time that takes to create it isn't useful any more.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)