### PR TITLE
[Fix]Reconnection attempt after call.ended

### DIFF
--- a/Sources/StreamVideo/WebSockets/Events/Event.swift
+++ b/Sources/StreamVideo/WebSockets/Events/Event.swift
@@ -90,9 +90,13 @@ internal enum WrappedEvent: Event {
         case let .coordinatorEvent(event):
             return "Coordinator:\(event.name)"
         case let .sfuEvent(event):
-            return "SFU:\(type(of: event))"
+            return "SFU:\(event.name)"
         case let .internalEvent(event):
             return "Internal:\(event.name)"
         }
     }
+}
+
+extension Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload {
+    var name: String { String(describing: self) }
 }

--- a/Sources/StreamVideo/WebSockets/Events/JsonEventDecoder.swift
+++ b/Sources/StreamVideo/WebSockets/Events/JsonEventDecoder.swift
@@ -11,7 +11,9 @@ struct JsonEventDecoder: AnyEventDecoder {
     }
 }
 
-extension VideoEvent: @unchecked Sendable, Event {}
+extension VideoEvent: @unchecked Sendable, Event {
+    var name: String { type }
+}
 
 extension UserResponse {
     public var toUser: User {

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -555,14 +555,14 @@ open class CallViewModel: ObservableObject {
         Task {
             for await event in streamVideo.subscribe() {
                 if let callEvent = callEventsHandler.checkForCallEvents(from: event) {
-                    if case let .incoming(incomingCall) = callEvent,
-                       incomingCall.caller.id != streamVideo.user.id {
+                    switch callEvent {
+                    case let .incoming(incomingCall) where incomingCall.caller.id != streamVideo.user.id:
                         let isAppActive = UIApplication.shared.applicationState == .active
                         // TODO: implement holding a call.
                         if callingState == .idle && isAppActive {
                             callingState = .incoming(incomingCall)
                         }
-                    } else if case let .accepted(callEventInfo) = callEvent {
+                    case let .accepted(callEventInfo):
                         if callingState == .outgoing {
                             enterCall(call: call, callType: callEventInfo.type, callId: callEventInfo.callId, members: [])
                         } else if case .incoming = callingState,
@@ -570,14 +570,22 @@ open class CallViewModel: ObservableObject {
                             // Accepted on another device.
                             callingState = .idle
                         }
-                    } else if case .rejected = callEvent {
+                    case let .rejected(callEventInfo):
+                        log.debug("Call rejected with info:\(callEventInfo)")
                         handleRejectedEvent(callEvent)
-                    } else if case .ended = callEvent {
+                    case let .ended(callEventInfo):
+                        log.debug("Call ended with info:\(callEventInfo)")
                         leaveCall()
-                    } else if case let .userBlocked(callEventInfo) = callEvent {
+                    case let .userBlocked(callEventInfo):
                         if callEventInfo.user?.id == streamVideo.user.id {
                             leaveCall()
                         }
+                    case let .userUnblocked(callEventInfo):
+                        log.debug("User unblocked with event:\(callEventInfo)")
+                    case let .sessionStarted(callSessionResponse):
+                        log.debug("Session started with response:\(callSessionResponse)")
+                    default:
+                        log.debug("Unhandled callEvent:\(callEvent).")
                     }
                 } else if let participantEvent = callEventsHandler.checkForParticipantEvents(from: event) {
                     guard participants.count < 25 else {


### PR DESCRIPTION
### 📝 Summary

Avoid unnecessary actions when call.ended event is being received.

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🧪 Manual Testing Notes

- Join a call from iOS and Web
- End the call for all from web
- Filtering the logs on iOS should present the following after the `call.ended` has been received
```
2024-04-23 13:02:27.962 [DEBUG] [io.getstream.Batch.WrappedEvent] [EventNotificationCenter.swift:26] [process(_:postNotifications:completion:)] > Processing Events: ["Coordinator:call.ended"]
2024-04-23 13:02:27.964 [DEBUG] [io.getstream.Batch.WrappedEvent] [EventNotificationCenter.swift:26] [process(_:postNotifications:completion:)] > Processing Events: ["Coordinator:call.session_participant_left"]
2024-04-23 13:02:28.049 [DEBUG] [io.getstream.Batch.WrappedEvent] [EventNotificationCenter.swift:26] [process(_:postNotifications:completion:)] > Processing Events: ["Coordinator:call.session_participant_left"]
2024-04-23 13:02:33.245 [DEBUG] [io.getStream.video.core.web_socket_engine_queue] [EventNotificationCenter.swift:26] [process(_:postNotifications:completion:)] > Processing Events: ["Coordinator:health.check"]
```
After the `health.check` you should not see other events coming in (note that `health.check` will keep coming in as is part of StreamVideo client).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)