### PR TITLE
Handle `call_display_name` on VoIP notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - The SDK now provides a CallKit integration out of the box. [#334](https://github.com/GetStream/stream-video-swift/pull/334)
 - Infrastructure required for NoiseCancellation support [#353](https://github.com/GetStream/stream-video-swift/pull/353)
+- User `call_display_name` property from VoIP push notifications, whenever is available [#361](https://github.com/GetStream/stream-video-swift/pull/361)
 
 ### 🐞 Fixed
 - An issue where VoIP push notifications for ended calls, were received when the user connects [#336](https://github.com/GetStream/stream-video-swift/pull/336)

--- a/docusaurus/docs/iOS/06-advanced/03-callkit-integration.mdx
+++ b/docusaurus/docs/iOS/06-advanced/03-callkit-integration.mdx
@@ -130,6 +130,19 @@ struct MyCustomView: View {
 
 By doing that, the `CallKitAdapter` will make sure to unregister the `VoIP` token from receiving notifications._createMdxContent
 
+#### Call display name
+
+The Stream backend fills 2 properties in the VoIP push notification payload that can be used as the display name of the call.
+- **call_display_name**
+The `call_display_name` is a calculated property that evaluates the following properties on the Call object, in the order they are being presented: 
+    - `display_name` 
+    - `name` 
+    - `title`
+If none of the fields above are being set, the property will be empty.
+
+- **created_by_display_name**
+The property is always set and contains the name of the user who created the call.
+
 ### VoIP Token Observation
 
 Even though by using the `CallKitAdapter` abstracts most of the `CallKit` & `PushKit` complexity from you, there are still cases where you may want to acces the device's `VoIP` token (e.g. to persist it ).


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://getstream.zendesk.com/agent/tickets/49108

### 📝 Summary

VoIP push notification contain a calculated `call_display_name` property that can be used to present a more informative name for the call (useful in group call cases).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (Docusaurus, tutorial, CMS)