### PR TITLE
[Fix]Failing tests due to AudioProcessingModule lifecycle

### DIFF
--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapterTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapterTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @MainActor
 final class StreamPictureInPictureTrackStateAdapterTests: XCTestCase {
 
-    private var factory: PeerConnectionFactory! = .init(audioProcessingModule: StreamAudioFilterProcessingModule())
+    private var factory: PeerConnectionFactory! = .init(audioProcessingModule: MockAudioProcessingModule())
     private var adapter: StreamPictureInPictureTrackStateAdapter! = .init()
 
     // MARK: - Lifecycle

--- a/StreamVideoTests/WebRTC/WebRTCClient_Tests.swift
+++ b/StreamVideoTests/WebRTC/WebRTCClient_Tests.swift
@@ -762,7 +762,7 @@ final class WebRTCClient_Tests: StreamVideoTestCase {
     }
     
     private func makeVideoTrack() async -> RTCVideoTrack {
-        let factory = PeerConnectionFactory(audioProcessingModule: StreamAudioFilterProcessingModule())
+        let factory = PeerConnectionFactory(audioProcessingModule: MockAudioProcessingModule())
         let videoSource = await factory.makeVideoSource(forScreenShare: false)
         let track = await factory.makeVideoTrack(source: videoSource)
         return track


### PR DESCRIPTION
### 📝 Summary

Tests were failing due to the lifecycle of the StreamAudioProcessingModule (which is being attached on WebRTC and that is holding a reference on it). Replacing the StreamAudioProcessingModule to MockAudioProcessingModule, tests fixes the issue.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)