### PR TITLE
[NoiseCancellation]Integrate and cleanUp

### DIFF
--- a/DemoApp/Sources/Components/AppState.swift
+++ b/DemoApp/Sources/Components/AppState.swift
@@ -187,12 +187,7 @@ final class AppState: ObservableObject {
     }
 
     private func didUpdate(audioFilter: AudioFilter?) {
-        guard
-            let audioFilterProcessingModule = streamVideo?.videoConfig.audioProcessingModule as? StreamAudioFilterProcessingModule
-        else {
-            return
-        }
-        audioFilterProcessingModule.setAudioFilter(audioFilter)
+        activeCall?.setAudioFilter(audioFilter)
     }
 
     private func didUpdate(videoFilter: VideoFilter?) {

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -301,6 +301,12 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         callController.setVideoFilter(videoFilter)
     }
 
+    /// Sets an`audioFilter` for the current call.
+    /// - Parameter audioFilter: An `AudioFilter` instance representing the audio filter to set.
+    public func setAudioFilter(_ audioFilter: AudioFilter?) {
+        streamVideo.videoConfig.audioProcessingModule.setAudioFilter(audioFilter)
+    }
+
     /// Starts screensharing from the device.
     /// - Parameter type: The screensharing type (in-app or broadcasting).
     public func startScreensharing(type: ScreensharingType) async throws {
@@ -1089,16 +1095,16 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
             switch value.mode {
             case .available:
                 log.debug("NoiseCancellationSettings updated with mode:\(value.mode).")
-            case .disabled where audioProcessingModule.activeAudioFilterId == noiseCancellationFilter.id:
+            case .disabled where audioProcessingModule.activeAudioFilter?.id == noiseCancellationFilter.id:
                 /// Deactivate noiseCancellationFilter if mode is disabled and the noiseCancellation
                 /// audioFilter is currently active.
                 log
                     .debug(
                         "NoiseCancellationSettings updated with mode:\(value.mode). Will deactivate noiseCancellationFilter:\(noiseCancellationFilter.id)"
                     )
-                audioProcessingModule.setAudioFilter(nil)
+                setAudioFilter(nil)
             case .autoOn
-                where audioProcessingModule.activeAudioFilterId != noiseCancellationFilter.id && streamVideo
+                where audioProcessingModule.activeAudioFilter?.id != noiseCancellationFilter.id && streamVideo
                 .isHardwareAccelerationAvailable:
                 /// Activate noiseCancellationFilter if mode is autoOn,  hardwareAcceleration is
                 /// available and the noiseCancellation audioFilter isn't already enabled.
@@ -1106,7 +1112,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
                     .debug(
                         "NoiseCancellationSettings updated with mode:\(value.mode). Will activate noiseCancellationFilter:\(noiseCancellationFilter.id)"
                     )
-                audioProcessingModule.setAudioFilter(noiseCancellationFilter)
+                setAudioFilter(noiseCancellationFilter)
             default:
                 /// Log a debug message for other cases where no action is required.
                 log

--- a/Sources/StreamVideo/VideoConfig.swift
+++ b/Sources/StreamVideo/VideoConfig.swift
@@ -5,7 +5,7 @@
 import Foundation
 import StreamWebRTC
 
-public struct VideoConfig: Sendable {
+public final class VideoConfig: Sendable {
     /// An array of `VideoFilter` objects representing the filters to apply to the video.
     public let videoFilters: [VideoFilter]
 

--- a/Sources/StreamVideo/WebRTC/AudioFilter/StreamAudioFilterCapturePostProcessingModule.swift
+++ b/Sources/StreamVideo/WebRTC/AudioFilter/StreamAudioFilterCapturePostProcessingModule.swift
@@ -8,8 +8,8 @@ import StreamWebRTC
 /// A protocol defining requirements for an audio filter capture post-processing module.
 public protocol AudioFilterCapturePostProcessingModule: RTCAudioCustomProcessingDelegate {
 
-    /// The identifier of the currently active audio filter.
-    var activeAudioFilterId: String? { get }
+    /// The currently active audio filter.
+    var audioFilter: AudioFilter? { get }
 
     /// Sets the audio filter for processing captured audio.
     /// - Parameter audioFilter: The audio filter to set.
@@ -19,36 +19,14 @@ public protocol AudioFilterCapturePostProcessingModule: RTCAudioCustomProcessing
 /// A class that handles post-processing of captured audio streams using custom audio filtering.
 open class StreamAudioFilterCapturePostProcessingModule: NSObject, AudioFilterCapturePostProcessingModule, @unchecked Sendable {
 
-    /// The state actor encapsulating the module's state.
-    private actor State {
-        private(set) var audioFilter: AudioFilter?
-        private(set) var sampleRate: Int = 0
-        private(set) var channels: Int = 0
+    /// The audio filter for processing audio streams.
+    public private(set) var audioFilter: AudioFilter?
 
-        /// Sets the audio filter for processing audio streams.
-        /// - Parameter value: The audio filter to set. If not `nil`, releases the previous filter.
-        func setAudioFilter(_ value: AudioFilter?) {
-            audioFilter?.release() // Release the previous audio filter.
-            audioFilter = value // Set the new audio filter.
-        }
+    /// The sample rate for audio processing.
+    public private(set) var sampleRate: Int = 0
 
-        /// Sets the sample rate for audio processing.
-        /// - Parameter value: The sample rate value to set.
-        func setSampleRate(_ value: Int) {
-            self.sampleRate = value
-        }
-
-        /// Sets the number of audio channels for processing.
-        /// - Parameter value: The number of audio channels value to set.
-        func setChannels(_ value: Int) {
-            self.channels = value
-        }
-    }
-
-    /// The state instance containing audio processing state information.
-    private var state: State = .init()
-
-    public var activeAudioFilterId: String?
+    /// The number of audio channels for processing.
+    public private(set) var channels: Int = 0
 
     /// Initializes a new instance of `StreamCapturePostProcessingModule`.
     override public init() {
@@ -60,26 +38,22 @@ open class StreamAudioFilterCapturePostProcessingModule: NSObject, AudioFilterCa
     /// Sets the audio filter asynchronously.
     /// - Parameter audioFilter: The audio filter to set for processing.
     open func setAudioFilter(_ audioFilter: AudioFilter?) {
-        Task {
-            let oldValue = await state.audioFilter
-            let sampleRate = await state.sampleRate
-            let channels = await state.channels
+        let oldValue = self.audioFilter
+        oldValue?.release()
 
-            guard oldValue?.id != audioFilter?.id else {
-                return
-            }
+        guard oldValue?.id != audioFilter?.id else {
+            return
+        }
 
-            log.debug("AudioFilter updated \(oldValue?.id ?? "nil") → \(audioFilter?.id ?? "nil")")
+        log.debug("AudioFilter updated \(oldValue?.id ?? "nil") → \(audioFilter?.id ?? "nil")")
 
-            if let newValue = audioFilter, sampleRate > 0, channels > 0 {
-                /// If new filter is set and sample rate & channels are valid, initialize the filter.
-                newValue.initialize(sampleRate: sampleRate, channels: channels)
-                await state.setAudioFilter(newValue)
-                activeAudioFilterId = newValue.id
-            } else {
-                /// Set audio filter to `nil` if conditions not met.
-                await state.setAudioFilter(nil)
-            }
+        if let newValue = audioFilter, sampleRate > 0, channels > 0 {
+            /// If new filter is set and sample rate & channels are valid, initialize the filter.
+            newValue.initialize(sampleRate: sampleRate, channels: channels)
+            self.audioFilter = newValue
+        } else {
+            /// Set audio filter to `nil` if conditions not met.
+            self.audioFilter = nil
         }
     }
 
@@ -94,30 +68,26 @@ open class StreamAudioFilterCapturePostProcessingModule: NSObject, AudioFilterCa
         channels: Int
     ) {
         log.debug("AudioSession updated sampleRate:\(sampleRateHz) channels:\(channels)")
-        Task {
-            await state.setSampleRate(sampleRateHz)
-            await state.setChannels(channels)
-            await state.audioFilter?.initialize(
-                sampleRate: sampleRateHz,
-                channels: channels
-            )
-        }
+        sampleRate = sampleRateHz
+        self.channels = channels
+        audioFilter?.initialize(
+            sampleRate: sampleRateHz,
+            channels: channels
+        )
     }
 
     /// Handles audio processing on received audio buffers.
     /// - Parameter audioBuffer: The incoming audio buffer to process.
     open func audioProcessingProcess(audioBuffer: RTCAudioBuffer) {
-        Task {
-            guard let audioFilter = await state.audioFilter else { return }
-            var audioBuffer = audioBuffer
-            audioFilter.applyEffect(to: &audioBuffer)
+        guard let audioFilter else {
+            return
         }
+        var audioBuffer = audioBuffer
+        audioFilter.applyEffect(to: &audioBuffer)
     }
 
     /// Handles release of audio processing resources.
     open func audioProcessingRelease() {
-        Task {
-            await state.setAudioFilter(nil)
-        }
+        audioFilter = nil
     }
 }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		40AB35692B738D3D00E465CC /* EffectsLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 40AB35682B738D3D00E465CC /* EffectsLibrary */; };
 		40AB356D2B73B7A400E465CC /* DemoCallingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */; };
 		40AB356E2B73B7A400E465CC /* DemoCallingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */; };
+		40AC73B42BE0062B00C57517 /* StreamVideoNoiseCancellation in Frameworks */ = {isa = PBXBuildFile; productRef = 40AC73B32BE0062B00C57517 /* StreamVideoNoiseCancellation */; };
 		40B499CA2AC1A5E100A53B60 /* OSLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */; };
 		40B499CC2AC1A90F00A53B60 /* DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */; };
 		40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
@@ -1850,6 +1851,7 @@
 				4046DEF02A9F469100CA6D2F /* GDPerformanceView-Swift in Frameworks */,
 				401A64A52A9DF79E00534ED1 /* StreamChatSwiftUI in Frameworks */,
 				8423B7562950BB0B00012F8D /* Sentry in Frameworks */,
+				40AC73B42BE0062B00C57517 /* StreamVideoNoiseCancellation in Frameworks */,
 				401A64A82A9DF7B400534ED1 /* EffectsLibrary in Frameworks */,
 				82EB8F592B0277E70038B5A2 /* StreamWebRTC in Frameworks */,
 				4035913C2BC53D2A00B5B767 /* Accelerate.framework in Frameworks */,
@@ -4070,6 +4072,7 @@
 				4046DEEF2A9F469100CA6D2F /* GDPerformanceView-Swift */,
 				844ADA642AD3F1AB00769F6A /* GoogleSignInSwift */,
 				82EB8F582B0277E70038B5A2 /* StreamWebRTC */,
+				40AC73B32BE0062B00C57517 /* StreamVideoNoiseCancellation */,
 			);
 			productName = StreamVideoSwiftUI;
 			productReference = 842D8BC32865B31B00801910 /* StreamVideoCallApp-Debug.app */;
@@ -4321,6 +4324,7 @@
 				4046DEEC2A9F404300CA6D2F /* XCRemoteSwiftPackageReference "GDPerformanceView-Swift" */,
 				844ADA612AD3F1AB00769F6A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				82EB8F552B0277730038B5A2 /* XCRemoteSwiftPackageReference "stream-video-swift-webrtc" */,
+				40AC73B22BE0062B00C57517 /* XCRemoteSwiftPackageReference "stream-video-noise-cancellation-swift" */,
 			);
 			productRefGroup = 842D8BC42865B31B00801910 /* Products */;
 			projectDirPath = "";
@@ -6905,6 +6909,14 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		40AC73B22BE0062B00C57517 /* XCRemoteSwiftPackageReference "stream-video-noise-cancellation-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/GetStream/stream-video-noise-cancellation-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.1;
+			};
+		};
 		40F445C32A9E1D91004BE3DA /* XCRemoteSwiftPackageReference "stream-chat-swift-test-helpers" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift-test-helpers";
@@ -6977,6 +6989,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 401A64A62A9DF7B400534ED1 /* XCRemoteSwiftPackageReference "effects-library" */;
 			productName = EffectsLibrary;
+		};
+		40AC73B32BE0062B00C57517 /* StreamVideoNoiseCancellation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40AC73B22BE0062B00C57517 /* XCRemoteSwiftPackageReference "stream-video-noise-cancellation-swift" */;
+			productName = StreamVideoNoiseCancellation;
 		};
 		40F017892BC014EC00E89FD1 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/StreamVideoTests/Mock/VideoConfig+Dummy.swift
+++ b/StreamVideoTests/Mock/VideoConfig+Dummy.swift
@@ -15,7 +15,7 @@ extension VideoConfig {
 }
 
 final class MockAudioProcessingModule: NSObject, AudioProcessingModule {
-    var activeAudioFilterId: String? { nil }
+    var activeAudioFilter: AudioFilter? { nil }
     func setAudioFilter(_ filter: AudioFilter?) {}
     func apply(_ config: RTCAudioProcessingConfig) {}
 }


### PR DESCRIPTION
### 🎯 Goal

Integrate with `StreamVideoNoiseCancellation` and cleanUp the API for noiseCancellation.

### 🛠 Implementation

The biggest change in the PR is the removal of Concurrency in the NoiseCancellationFilter and the ProcessingModule. WebRTC provides the [thread-safety](https://chromium.googlesource.com/external/webrtc/stable/webrtc/+/b8a655ac3c71977abf0e8d657dbe9d0aec633ff9/modules/audio_processing/include/audio_processing.h#79) that we need. Additionally, swift concurrency doesn't work great with multiple thread processing buffers that are coming in, in a serial way.

The other big change is the change of type for VideoConfig, from `struct` to `class`. That seems to be necessary otherwise i noticed crashes on startup where the videoConfig was copied in different places and trying to access the processing module.

### 🧪 Manual Testing Notes

- Enter a call, activate the noise cancellation make sure it works

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)