### PR TITLE
[Fix]AsyncImage on iOS 15 and below

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/AsyncImage/StreamAsyncImage.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/AsyncImage/StreamAsyncImage.swift
@@ -29,7 +29,7 @@ struct StreamAsyncImage<Content: View>: View {
     }
 
     var body: some View {
-        if #available(iOS 15.0, *) {
+        if #available(iOS 16.0, *) {
             AsyncImage(
                 url: url,
                 scale: scale,


### PR DESCRIPTION
### 📝 Summary

It seems that AsyncImage doesn't work as expected on iOS 15 and below. This PR enables StreamAsyncImage underhood for iOS versions prior to 16.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
| ![before](https://github.com/GetStream/stream-video-swift/assets/472467/da98faed-22be-4e68-88bf-08af05095ef0) | ![after](https://github.com/GetStream/stream-video-swift/assets/472467/da7ae826-17c0-4827-97ad-7265f15ce263) |

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)