### PR TITLE
[Enhancement]Allow CallKitService to handle multiple calls

### DIFF
--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -144,7 +144,7 @@ extension AppEnvironment {
             return .detailed
         case .debug:
             #if targetEnvironment(simulator)
-            return .simple
+            return .detailed
             #else
             return .simple
             #endif

--- a/Sources/StreamVideo/Utils/Stack.swift
+++ b/Sources/StreamVideo/Utils/Stack.swift
@@ -45,6 +45,13 @@ struct Stack<Element>: Sequence {
         elements.count
     }
 
+    mutating func remove(_ element: Element) where Element: Equatable {
+        guard let indexOf = elements.firstIndex(where: { $0 == element }) else {
+            return
+        }
+        elements.remove(at: indexOf)
+    }
+
     /// An iterator for the stack.
     struct Iterator: IteratorProtocol {
         /// The elements to iterate over.

--- a/Sources/StreamVideo/Utils/Stack.swift
+++ b/Sources/StreamVideo/Utils/Stack.swift
@@ -1,0 +1,72 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A stack is a collection that supports push and pop operations, following the last-in, first-out (LIFO) principle.
+struct Stack<Element>: Sequence {
+    /// The underlying storage for the stack's elements.
+    private var elements: [Element] = []
+
+    /// Adds an element to the top of the stack.
+    ///
+    /// - Parameter element: The element to be pushed onto the stack.
+    mutating func push(_ element: Element) {
+        elements.append(element)
+    }
+
+    /// Removes and returns the element at the top of the stack.
+    ///
+    /// - Returns: The element at the top of the stack, or `nil` if the stack is empty.
+    @discardableResult
+    mutating func pop() -> Element? {
+        elements.popLast()
+    }
+
+    /// Returns the element at the top of the stack without removing it.
+    ///
+    /// - Returns: The element at the top of the stack, or `nil` if the stack is empty.
+    func peek() -> Element? {
+        elements.last
+    }
+
+    /// Checks if the stack is empty.
+    ///
+    /// - Returns: `true` if the stack is empty; otherwise, `false`.
+    func isEmpty() -> Bool {
+        elements.isEmpty
+    }
+
+    /// Returns the number of elements in the stack.
+    ///
+    /// - Returns: The number of elements in the stack.
+    func count() -> Int {
+        elements.count
+    }
+
+    /// An iterator for the stack.
+    struct Iterator: IteratorProtocol {
+        /// The elements to iterate over.
+        private var currentElements: [Element]
+
+        /// Creates an iterator for the given elements.
+        ///
+        /// - Parameter elements: The elements to iterate over.
+        init(_ elements: [Element]) {
+            currentElements = elements
+        }
+
+        /// Advances to the next element and returns it.
+        ///
+        /// - Returns: The next element in the iteration, or `nil` if no more elements are available.
+        mutating func next() -> Element? {
+            currentElements.popLast()
+        }
+    }
+
+    /// Creates an iterator that iterates over the elements of the stack.
+    ///
+    /// - Returns: An iterator that iterates over the elements of the stack.
+    func makeIterator() -> Iterator { .init(elements) }
+}

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -194,6 +194,10 @@
 		4093861C2AA0A11500FF5AF4 /* LogQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4093861B2AA0A11500FF5AF4 /* LogQueue.swift */; };
 		4093861F2AA0A21800FF5AF4 /* MemoryLogViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4093861E2AA0A21800FF5AF4 /* MemoryLogViewer.swift */; };
 		4097B3832BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */; };
+		4097B37A2BF4A9190057992D /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B3792BF4A9190057992D /* Stack.swift */; };
+		4097B37C2BF4A9AF0057992D /* Stack_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B37B2BF4A9AF0057992D /* Stack_Tests.swift */; };
+		4097B37E2BF4B06A0057992D /* GetCallResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B37D2BF4B06A0057992D /* GetCallResponse+Dummy.swift */; };
+		4097B3802BF4B0850057992D /* MockCXProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B37F2BF4B0850057992D /* MockCXProvider.swift */; };
 		409CA7992BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		40A0E9602B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */; };
 		40A0E9622B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */; };
@@ -1235,6 +1239,10 @@
 		4093861B2AA0A11500FF5AF4 /* LogQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogQueue.swift; sourceTree = "<group>"; };
 		4093861E2AA0A21800FF5AF4 /* MemoryLogViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryLogViewer.swift; sourceTree = "<group>"; };
 		4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeViewModifier_iOS13.swift; sourceTree = "<group>"; };
+		4097B3792BF4A9190057992D /* Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
+		4097B37B2BF4A9AF0057992D /* Stack_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack_Tests.swift; sourceTree = "<group>"; };
+		4097B37D2BF4B06A0057992D /* GetCallResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GetCallResponse+Dummy.swift"; sourceTree = "<group>"; };
+		4097B37F2BF4B0850057992D /* MockCXProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCXProvider.swift; sourceTree = "<group>"; };
 		409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+PredicateFulfillment.swift"; sourceTree = "<group>"; };
 		40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoBackgroundEffectSelector.swift; sourceTree = "<group>"; };
 		40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIInterfaceOrientation+CGOrientation.swift"; sourceTree = "<group>"; };
@@ -2717,6 +2725,7 @@
 			children = (
 				40F017382BBEAF6400E89FD1 /* MockCallKitService.swift */,
 				40F0173F2BBEBC6500E89FD1 /* MockCallKitPushNotificationAdapter.swift */,
+				4097B37F2BF4B0850057992D /* MockCXProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2774,6 +2783,7 @@
 				40F0174A2BBEEFB200E89FD1 /* VideoSettings+Dummy.swift */,
 				40F017742BBEF3E700E89FD1 /* CallRejectedEvent+Dummy.swift */,
 				40F017762BBEF43B00E89FD1 /* CallSessionParticipantLeftEvent+Dummy.swift */,
+				4097B37D2BF4B06A0057992D /* GetCallResponse+Dummy.swift */,
 			);
 			path = Dummy;
 			sourceTree = "<group>";
@@ -3184,6 +3194,7 @@
 				84D6E5392B3AD10000D0056C /* RepeatingTimer_Tests.swift */,
 				4031D7F72B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift */,
 				40A0E9632B88DE830089E8D3 /* SerialActor_Tests.swift */,
+				4097B37B2BF4A9AF0057992D /* Stack_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3635,6 +3646,7 @@
 				40013DDB2B87AA2300915453 /* SerialActor.swift */,
 				40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */,
 				408CE0F22BD905920052EC3A /* Models+Sendable.swift */,
+				4097B3792BF4A9190057992D /* Stack.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5112,6 +5124,7 @@
 				843DAB9E29E757B600E0EB63 /* CallsController.swift in Sources */,
 				84DC38CC29ADFCFD00946713 /* RequestPermissionResponse.swift in Sources */,
 				848CCCEC2AB8ED8F002E83A2 /* HLSSettingsResponse.swift in Sources */,
+				4097B37A2BF4A9190057992D /* Stack.swift in Sources */,
 				842B8E312A2DFED900863A87 /* TargetResolution.swift in Sources */,
 				842B8E172A2DFED900863A87 /* EgressRTMPResponse.swift in Sources */,
 				841BAA312BD15CDE000C73E4 /* VideoQuality.swift in Sources */,
@@ -5227,6 +5240,7 @@
 				8490031929D2E0DF00AD9BB4 /* Sorting_Tests.swift in Sources */,
 				40F0174D2BBEEFD500E89FD1 /* TranscriptionSettings+Dummy.swift in Sources */,
 				84F58B7629EE92BF00010C4C /* UniqueValues.swift in Sources */,
+				4097B37C2BF4A9AF0057992D /* Stack_Tests.swift in Sources */,
 				84F58B9529EEBA3900010C4C /* EquatableEvent.swift in Sources */,
 				40A0E9682B88E04D0089E8D3 /* CIImage_Resize_Tests.swift in Sources */,
 				40F017612BBEF15E00E89FD1 /* CallParticipantResponse+Dummy.swift in Sources */,
@@ -5258,6 +5272,7 @@
 				841FF5172A5EA7F600809BBB /* CallParticipants_Tests.swift in Sources */,
 				40F017452BBEEE6D00E89FD1 /* UserResponse+Dummy.swift in Sources */,
 				40F017422BBEC81C00E89FD1 /* CallKitServiceTests.swift in Sources */,
+				4097B3802BF4B0850057992D /* MockCXProvider.swift in Sources */,
 				40F0175D2BBEF0E200E89FD1 /* BackstageSettings+Dummy.swift in Sources */,
 				8490032F29D6D00C00AD9BB4 /* CallController_Mock.swift in Sources */,
 				842747F829EEEB8200E063AD /* EventNotificationCenter_Tests.swift in Sources */,
@@ -5290,6 +5305,7 @@
 				4351AEAF2A40591800D32D0D /* CallCRUDTests.swift in Sources */,
 				84F58B8529EEABC100010C4C /* EventDecoder_Mock.swift in Sources */,
 				8414081129F284A800FF2D7C /* AssertJSONEqual.swift in Sources */,
+				4097B37E2BF4B06A0057992D /* GetCallResponse+Dummy.swift in Sources */,
 				846D16292A52F3A10036CE4C /* MicrophoneManager_Tests.swift in Sources */,
 				40F017492BBEEF8100E89FD1 /* TargetResolution+Dummy.swift in Sources */,
 				8492B87A29081E6600006649 /* StreamVideo_Mock.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -193,11 +193,11 @@
 		4093861A2AA09E4A00FF5AF4 /* MemoryLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409386192AA09E4A00FF5AF4 /* MemoryLogDestination.swift */; };
 		4093861C2AA0A11500FF5AF4 /* LogQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4093861B2AA0A11500FF5AF4 /* LogQueue.swift */; };
 		4093861F2AA0A21800FF5AF4 /* MemoryLogViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4093861E2AA0A21800FF5AF4 /* MemoryLogViewer.swift */; };
-		4097B3832BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */; };
 		4097B37A2BF4A9190057992D /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B3792BF4A9190057992D /* Stack.swift */; };
 		4097B37C2BF4A9AF0057992D /* Stack_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B37B2BF4A9AF0057992D /* Stack_Tests.swift */; };
 		4097B37E2BF4B06A0057992D /* GetCallResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B37D2BF4B06A0057992D /* GetCallResponse+Dummy.swift */; };
 		4097B3802BF4B0850057992D /* MockCXProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B37F2BF4B0850057992D /* MockCXProvider.swift */; };
+		4097B3832BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */; };
 		409CA7992BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		40A0E9602B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */; };
 		40A0E9622B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */; };
@@ -1238,11 +1238,11 @@
 		409386192AA09E4A00FF5AF4 /* MemoryLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryLogDestination.swift; sourceTree = "<group>"; };
 		4093861B2AA0A11500FF5AF4 /* LogQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogQueue.swift; sourceTree = "<group>"; };
 		4093861E2AA0A21800FF5AF4 /* MemoryLogViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryLogViewer.swift; sourceTree = "<group>"; };
-		4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeViewModifier_iOS13.swift; sourceTree = "<group>"; };
 		4097B3792BF4A9190057992D /* Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 		4097B37B2BF4A9AF0057992D /* Stack_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack_Tests.swift; sourceTree = "<group>"; };
 		4097B37D2BF4B06A0057992D /* GetCallResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GetCallResponse+Dummy.swift"; sourceTree = "<group>"; };
 		4097B37F2BF4B0850057992D /* MockCXProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCXProvider.swift; sourceTree = "<group>"; };
+		4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeViewModifier_iOS13.swift; sourceTree = "<group>"; };
 		409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+PredicateFulfillment.swift"; sourceTree = "<group>"; };
 		40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoBackgroundEffectSelector.swift; sourceTree = "<group>"; };
 		40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIInterfaceOrientation+CGOrientation.swift"; sourceTree = "<group>"; };

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -12,26 +12,34 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     private lazy var subject: CallKitService! = .init()
     private lazy var callController: MockCXCallController! = .init()
     private lazy var callProvider: MockCXProvider! = .init()
-    private lazy var cid: String = "default:\(callId)"
+    private lazy var user: User! = .init(id: "test")
+    private lazy var cid: String! = "default:\(callId)"
+    private var callId: String = String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(10))
+    private var localizedCallerName: String! = "Test Caller"
+    private var callerId: String! = "test@example.com"
     private lazy var mockedStreamVideo: MockStreamVideo! = MockStreamVideo(
         stubbedProperty: [
-            MockStreamVideo.propertyKey(for: \.state): MockStreamVideo.State(user: .dummy(id: "test"))
+            MockStreamVideo.propertyKey(for: \.state): MockStreamVideo.State(user: user)
         ],
-        user: .init(id: "test")
+        user: user
     )
-
-    private var callId: String = String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(10))
-    private var localizedCallerName: String = "Test Caller"
-    private var callerId: String = "test@example.com"
 
     override func setUp() {
         super.setUp()
         subject.callController = callController
         subject.callProvider = callProvider
+        callProvider.setDelegate(subject, queue: nil)
     }
 
     override func tearDown() {
         subject = nil
+        callController = nil
+        callProvider = nil
+        user = nil
+        cid = nil
+        mockedStreamVideo = nil
+        localizedCallerName = nil
+        callerId = nil
         super.tearDown()
     }
 
@@ -60,8 +68,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(callProvider.reportNewIncomingCallUpdate?.remoteHandle?.value, callerId)
     }
 
-    func test_reportIncomingCall_streamVideoIsNil_callWasEnded() async throws {
-        try await assertRequestTransaction(CXEndCallAction.self) {
+    func test_reportIncomingCall_streamVideoIsNil_noCallWasCreatedAndNoActionIsBeingPerformed() async throws {
+        try await assertWithoutRequestTransaction {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
@@ -70,10 +78,12 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func test_reportIncomingCall_streamVideoDisconnectedAndThrowsError_callWasEnded() async throws {
         struct ConnectionError: Error {}
         stubConnectionState(to: .disconnected(error: nil))
         mockedStreamVideo.stub(for: .connect, with: ConnectionError())
+        _ = stubCall()
         subject.streamVideo = mockedStreamVideo
 
         try await assertRequestTransaction(CXEndCallAction.self) {
@@ -124,16 +134,11 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     @MainActor
     func test_reportIncomingCall_ringingTimeElapsed_callWasEnded() async throws {
         let ringingTimeoutSeconds = 1
-        let call = MockCall(.dummy())
-        let response = GetCallResponse(
-            call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: ringingTimeoutSeconds * 1000))),
-            duration: "100",
-            members: [],
-            ownCapabilities: []
+        stubCall(
+            response: .dummy(
+                call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: ringingTimeoutSeconds * 1000)))
+            )
         )
-        call.stub(for: .get, with: response)
-        call.stub(for: \.state, with: .init())
-        mockedStreamVideo.stub(for: .call, with: call)
         subject.streamVideo = mockedStreamVideo
 
         try await assertRequestTransaction(CXEndCallAction.self) {
@@ -151,19 +156,17 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     @MainActor
     func test_reportIncomingCall_stateIsIdleAndCallWasAlreadyHandled_callWasEnded() async throws {
-        let call = MockCall(.dummy())
-        let response = GetCallResponse(
-            call: .dummy(
-                session: .dummy(acceptedBy: [mockedStreamVideo.user.id: Date()]),
-                settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))
-            ),
-            duration: "100",
-            members: [],
-            ownCapabilities: []
+        stubCall(
+            response: .dummy(
+                call: .dummy(
+                    session: .dummy(acceptedBy: [user.id: Date()]),
+                    settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))
+                ),
+                duration: "100",
+                members: [],
+                ownCapabilities: []
+            )
         )
-        call.stub(for: .get, with: response)
-        call.stub(for: \.state, with: .init())
-        mockedStreamVideo.stub(for: .call, with: call)
         subject.streamVideo = mockedStreamVideo
 
         try await assertRequestTransaction(CXEndCallAction.self) {
@@ -177,16 +180,14 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     @MainActor
     func test_reportIncomingCall_stateIsNotIdle_callWasEnded() async throws {
-        let call = MockCall(.dummy())
-        let response = GetCallResponse(
-            call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))),
-            duration: "100",
-            members: [],
-            ownCapabilities: []
+        stubCall(
+            response: .dummy(
+                call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))),
+                duration: "100",
+                members: [],
+                ownCapabilities: []
+            )
         )
-        call.stub(for: .get, with: response)
-        call.stub(for: \.state, with: .init())
-        mockedStreamVideo.stub(for: .call, with: call)
         subject.streamVideo = mockedStreamVideo
 
         try await assertWithoutRequestTransaction {
@@ -211,7 +212,11 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - callAccepted
 
+    @MainActor
     func test_callAccepted_expectedTransactionWasRequested() async throws {
+        stubCall()
+        subject.streamVideo = mockedStreamVideo
+
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
@@ -225,7 +230,11 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - callRejected
 
-    func test_callRejected_expectedTransactionWasRequest() async throws {
+    @MainActor
+    func test_callRejected_expectedTransactionWasRequested() async throws {
+        stubCall()
+        subject.streamVideo = mockedStreamVideo
+
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
@@ -233,13 +242,63 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         ) { _ in }
 
         try await assertRequestTransaction(CXEndCallAction.self) {
-            subject.callRejected(.dummy(call: .dummy(id: callId)))
+            subject.callRejected(
+                .dummy(
+                    call: .dummy(id: callId),
+                    user: .dummy(id: user.id)
+                )
+            )
         }
+    }
+
+    @MainActor
+    func test_callRejected_whileInCall_expectedTransactionWasRequestedAndRemainsInCall() async throws {
+        stubCall()
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId
+        ) { _ in }
+
+        try await assertRequestTransaction(CXAnswerCallAction.self) {
+            subject.callAccepted(.dummy(call: .dummy(id: callId)))
+        }
+
+        XCTAssertEqual(subject.stack.count(), 1)
+
+        // Stub with the new call
+        let secondCallId = "default:test-call-2"
+        stubCall(overrideCallId: secondCallId)
+
+        subject.reportIncomingCall(
+            secondCallId,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId
+        ) { _ in }
+
+        XCTAssertEqual(subject.stack.count(), 2)
+
+        try await assertRequestTransaction(CXEndCallAction.self) {
+            subject.callRejected(
+                .dummy(
+                    call: .dummy(id: secondCallId),
+                    user: .dummy(id: user.id)
+                )
+            )
+        }
+
+        XCTAssertEqual(subject.stack.count(), 1)
     }
 
     // MARK: - callEnded
 
-    func test_callEnded_expectedTransactionWasRequest() async throws {
+    @MainActor
+    func test_callEnded_expectedTransactionWasRequested() async throws {
+        stubCall()
+        subject.streamVideo = mockedStreamVideo
+
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
@@ -255,16 +314,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     @MainActor
     func test_callParticipantLeft_participantsLeftMoreThanOne_callWasNotEnded() async throws {
-        let call = MockCall(.dummy(callId: callId))
-        let response = GetCallResponse(
-            call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))),
-            duration: "100",
-            members: [],
-            ownCapabilities: []
-        )
-        call.stub(for: .get, with: response)
-        call.stub(for: \.state, with: .init())
-        mockedStreamVideo.stub(for: .call, with: call)
+        let call = stubCall()
         subject.streamVideo = mockedStreamVideo
 
         try await assertRequestTransaction(CXAnswerCallAction.self) {
@@ -291,18 +341,14 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     @MainActor
     func test_callParticipantLeft_participantsLeftOnlyOne_callNotEnded() async throws {
-        let call = MockCall(.dummy(callId: callId))
-        let response = GetCallResponse(
-            call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))),
-            duration: "100",
-            members: [],
-            ownCapabilities: []
+        let call = stubCall(
+            response: .dummy(
+                call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))),
+                duration: "100",
+                members: [],
+                ownCapabilities: []
+            )
         )
-        call.stub(for: .get, with: response)
-        call.stub(for: .accept, with: AcceptCallResponse(duration: "100"))
-        call.stub(for: .join, with: JoinCallResponse.dummy())
-        call.stub(for: \.state, with: .init())
-        mockedStreamVideo.stub(for: .call, with: call)
         subject.streamVideo = mockedStreamVideo
 
         try await assertRequestTransaction(CXAnswerCallAction.self) {
@@ -335,27 +381,6 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Private Helpers
 
-    private func makeStreamVideo() async throws -> StreamVideo {
-        let userId = "test_user"
-
-        let authenticationProvider = TestsAuthenticationProvider()
-        let tokenResponse = try await authenticationProvider.authenticate(
-            environment: "demo",
-            baseURL: .init(string: "https://pronto.getstream.io/api/auth/create-token")!,
-            userId: userId
-        )
-
-        let client = StreamVideo(
-            apiKey: tokenResponse.apiKey,
-            user: User(id: userId),
-            token: .init(rawValue: tokenResponse.token)
-        )
-
-        try await client.connect()
-
-        return client
-    }
-
     private func assertRequestTransaction<T>(
         _ expected: T.Type,
         actionBlock: @Sendable() -> Void,
@@ -364,7 +389,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     ) async throws {
         actionBlock()
 
-        await waitExpectation(timeout: 1, description: "Wait for internal async tasks to complete.")
+        await fulfillment(timeout: defaultTimeout) { self.callController.requestWasCalledWith?.0.actions.first != nil }
 
         let action = try XCTUnwrap(
             callController.requestWasCalledWith?.0.actions.first,
@@ -377,6 +402,12 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             file: file,
             line: line
         )
+
+        if let answerAction = action as? CXAnswerCallAction {
+            subject.provider(callProvider, perform: answerAction)
+        } else if let endAction = action as? CXEndCallAction {
+            subject.provider(callProvider, perform: endAction)
+        }
     }
 
     private func assertNotRequestTransaction<T>(
@@ -419,11 +450,10 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         wasRejected: Bool = false,
         wasRejectedByEveryoneElse: Bool = false
     ) async throws {
-        let call = MockCall(.dummy())
-        let acceptedBy = wasAccepted ? [mockedStreamVideo.state.user.id: Date()] : [:]
+        let acceptedBy = wasAccepted ? [user.id: Date()] : [:]
         let rejectedBy: [String: Date] = {
             if wasRejected {
-                return [mockedStreamVideo.state.user.id: Date()]
+                return [user.id: Date()]
             } else if wasRejectedByEveryoneElse {
                 return otherMembers.reduce(into: [String: Date]()) { partialResult, otherMember in
                     partialResult[otherMember.userId] = .init()
@@ -432,21 +462,17 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
                 return [:]
             }
         }()
-
-        let response = GetCallResponse(
-            call: .dummy(
-                session: .dummy(
-                    acceptedBy: acceptedBy,
-                    rejectedBy: rejectedBy
-                )
-            ),
-            duration: "100",
-            members: otherMembers + [.dummy(userId: mockedStreamVideo.state.user.id)],
-            ownCapabilities: []
+        stubCall(
+            response: .dummy(
+                call: .dummy(
+                    session: .dummy(
+                        acceptedBy: acceptedBy,
+                        rejectedBy: rejectedBy
+                    )
+                ),
+                members: otherMembers + [.dummy(userId: user.id)]
+            )
         )
-        call.stub(for: .get, with: response)
-        call.stub(for: \.state, with: .init())
-        mockedStreamVideo.stub(for: .call, with: call)
         subject.streamVideo = mockedStreamVideo
 
         try await assertRequestTransaction(CXEndCallAction.self) {
@@ -458,19 +484,16 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func assertParticipantLeft(
         remainingParticipants: Int = 0
     ) async throws {
-        let call = MockCall(.dummy())
-        let response = GetCallResponse(
-            call: .dummy(),
-            duration: "100",
-            members: (0...remainingParticipants)
-                .map { _ in MemberResponse.dummy() } + [.dummy(userId: mockedStreamVideo.state.user.id)],
-            ownCapabilities: []
+        stubCall(
+            response: .dummy(
+                members: (0...remainingParticipants)
+                    .map { _ in MemberResponse.dummy() } + [.dummy(userId: user.id)]
+            )
         )
-        call.stub(for: .get, with: response)
-        mockedStreamVideo.stub(for: .call, with: call)
         subject.streamVideo = mockedStreamVideo
     }
 
@@ -488,25 +511,20 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         mockedState.connection = status
         mockedStreamVideo.stub(for: \.state, with: mockedState)
     }
-}
 
-// Mock Classes
-
-private final class MockCXProvider: CXProvider {
-    var reportNewIncomingCallCalled = false
-    var reportNewIncomingCallUpdate: CXCallUpdate?
-
-    convenience init() {
-        self.init(configuration: .init(localizedName: "test"))
-    }
-
-    override func reportNewIncomingCall(
-        with UUID: UUID,
-        update: CXCallUpdate,
-        completion: @escaping (Error?) -> Void
-    ) {
-        reportNewIncomingCallCalled = true
-        reportNewIncomingCallUpdate = update
-        completion(nil)
+    @MainActor
+    @discardableResult
+    private func stubCall(
+        overrideCallId: String? = nil,
+        response: GetCallResponse = .dummy(call: .dummy(settings: .dummy(ring: .dummy(autoCancelTimeoutMs: 10 * 1000))))
+    ) -> MockCall {
+        let callId = overrideCallId ?? callId
+        let call = MockCall(.dummy(callId: callId))
+        call.stub(for: .get, with: response)
+        call.stub(for: .join, with: JoinCallResponse.dummy(call: .dummy(id: callId)))
+        call.stub(for: .accept, with: AcceptCallResponse(duration: "0"))
+        call.stub(for: \.state, with: .init())
+        mockedStreamVideo.stub(for: .call, with: call)
+        return call
     }
 }

--- a/StreamVideoTests/Utilities/Dummy/GetCallResponse+Dummy.swift
+++ b/StreamVideoTests/Utilities/Dummy/GetCallResponse+Dummy.swift
@@ -1,0 +1,24 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamVideo
+
+extension GetCallResponse {
+    static func dummy(
+        call: CallResponse = .dummy(),
+        duration: String = "0",
+        members: [MemberResponse] = [],
+        membership: MemberResponse? = nil,
+        ownCapabilities: [OwnCapability] = []
+    ) -> GetCallResponse {
+        .init(
+            call: call,
+            duration: duration,
+            members: members,
+            membership: membership,
+            ownCapabilities: ownCapabilities
+        )
+    }
+}

--- a/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CallKit
+import Foundation
+
+final class MockCXProvider: CXProvider {
+    var reportNewIncomingCallCalled = false
+    var reportNewIncomingCallUpdate: CXCallUpdate?
+
+    convenience init() {
+        self.init(configuration: .init(localizedName: "test"))
+    }
+
+    override func reportNewIncomingCall(
+        with UUID: UUID,
+        update: CXCallUpdate,
+        completion: @escaping (Error?) -> Void
+    ) {
+        reportNewIncomingCallCalled = true
+        reportNewIncomingCallUpdate = update
+        completion(nil)
+    }
+}

--- a/StreamVideoTests/Utils/Stack_Tests.swift
+++ b/StreamVideoTests/Utils/Stack_Tests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class StackTests: XCTestCase {
+
+    func testPush() {
+        var stack = Stack<Int>()
+        stack.push(1)
+        XCTAssertEqual(stack.peek(), 1, "Pushed element should be on top of the stack")
+        XCTAssertEqual(stack.count(), 1, "Stack count should be 1 after one push")
+    }
+
+    func testPop() {
+        var stack = Stack<Int>()
+        stack.push(1)
+        stack.push(2)
+        let poppedElement = stack.pop()
+        XCTAssertEqual(poppedElement, 2, "Popped element should be the last pushed element")
+        XCTAssertEqual(stack.count(), 1, "Stack count should be 1 after one pop")
+        XCTAssertEqual(stack.peek(), 1, "The remaining element should be 1")
+    }
+
+    func testPeek() {
+        var stack = Stack<Int>()
+        stack.push(1)
+        stack.push(2)
+        XCTAssertEqual(stack.peek(), 2, "Peek should return the top element without removing it")
+        XCTAssertEqual(stack.count(), 2, "Stack count should remain the same after peeking")
+    }
+
+    func testIsEmpty() {
+        var stack = Stack<Int>()
+        XCTAssertTrue(stack.isEmpty(), "Stack should be empty initially")
+        stack.push(1)
+        XCTAssertFalse(stack.isEmpty(), "Stack should not be empty after a push")
+        _ = stack.pop()
+        XCTAssertTrue(stack.isEmpty(), "Stack should be empty after popping all elements")
+    }
+
+    func testCount() {
+        var stack = Stack<Int>()
+        XCTAssertEqual(stack.count(), 0, "Stack count should be 0 initially")
+        stack.push(1)
+        stack.push(2)
+        XCTAssertEqual(stack.count(), 2, "Stack count should be 2 after two pushes")
+        _ = stack.pop()
+        XCTAssertEqual(stack.count(), 1, "Stack count should be 1 after one pop")
+    }
+
+    func testIteration() {
+        var stack = Stack<Int>()
+        stack.push(1)
+        stack.push(2)
+        stack.push(3)
+
+        var elements = [Int]()
+        for element in stack {
+            elements.append(element)
+        }
+
+        XCTAssertEqual(elements, [3, 2, 1], "Iteration should follow LIFO order")
+    }
+
+    func testPopEmpty() {
+        var stack = Stack<Int>()
+        let poppedElement = stack.pop()
+        XCTAssertNil(poppedElement, "Pop should return nil when stack is empty")
+    }
+
+    func testPeekEmpty() {
+        let stack = Stack<Int>()
+        XCTAssertNil(stack.peek(), "Peek should return nil when stack is empty")
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Simplify, verify and improve Calling state observation and reaction, from CallKit.

### 📝 Summary

The PR is improving the existing CallKitService by allowing it to handle multiple calls at the same time. This is quite important as while in a call, user may receive another incoming call. CallKitService should be able to reliably report each of those calls and differentiate user action on a call from the others.

### 🛠 Implementation

Calls are being received in a serial manner. For that purpose we are using a Stack implementation. The first entry on the stack will always be the latest call (active or ringing).

### 🎨 Showcase

https://github.com/GetStream/stream-video-swift/assets/472467/b6f06d61-ea0d-4549-b0a9-2848acc5c112

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)