### PR TITLE
Video tracks for anonymous users not displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Video tracks for anonymous users not displaying
 
 # [1.0.2](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.2)
 _May 17, 2024_

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -26,7 +26,13 @@ class WebRTCClient: NSObject, @unchecked Sendable {
         private var scheduledUpdate = false
         private var cancellables = Set<AnyCancellable>()
         private(set) var lastUpdate: TimeInterval = Date().timeIntervalSince1970
-        var connectionState = ConnectionState.disconnected(reason: nil)
+        var connectionState = ConnectionState.disconnected(reason: nil) {
+            didSet {
+                if connectionState == .connected {
+                    continuation?.yield([true])
+                }
+            }
+        }
         @Published var callParticipants = [String: CallParticipant]() {
             didSet {
                 if !scheduledUpdate {


### PR DESCRIPTION
### 📝 Summary

Video tracks started appearing after the first participant update. The reason was that the flow of events is a bit different for anonymous users - they don't receive all events. 

The fix is that whenever we connect, we instruct one update participation subscriptions call.

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
