### PR TITLE
[Fix]Memory issues causing Call objects to leak

### DIFF
--- a/DemoApp/Sources/Components/Snapshot/LocalParticipantSnapshotViewModel.swift
+++ b/DemoApp/Sources/Components/Snapshot/LocalParticipantSnapshotViewModel.swift
@@ -28,7 +28,7 @@ final class LocalParticipantSnapshotViewModel: NSObject, AVCapturePhotoCaptureDe
     private lazy var videoOutput: AVCaptureVideoDataOutput = .init()
     private var state = State()
 
-    var call: Call? {
+    weak var call: Call? {
         didSet {
             guard call?.cId != oldValue?.cId else { return }
             do {

--- a/DemoApp/Sources/Extensions/DemoApp+Sentry.swift
+++ b/DemoApp/Sources/Extensions/DemoApp+Sentry.swift
@@ -38,7 +38,7 @@ func configureSentry() {
         LogConfig.level = .debug
         LogConfig.destinationTypes = [
             MemoryLogDestination.self,
-            OSLogDestination.self
+            ConsoleLogDestination.self
         ]
         LogConfig.formatters = [
             DemoLogFormatter()

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -82,6 +82,11 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         }
     }
 
+    deinit {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+    }
+
     /// Joins the current call.
     /// - Parameters:
     ///  - create: whether the call should be created if it doesn't exist.

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -30,7 +30,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// The call provider responsible for handling call-related actions.
     open internal(set) lazy var callProvider = buildProvider()
 
-    private var call: Call?
+    private weak var call: Call?
     private var state: State = .idle
     private var callKitId: UUID?
     private var createdBy: User?

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -347,9 +347,10 @@ class CallController: @unchecked Sendable {
         call = nil
         statsCancellable?.cancel()
         statsCancellable = nil
-        Task {
-            await webRTCClient?.cleanUp()
-            webRTCClient = nil
+        let _webRTCClient = webRTCClient
+        webRTCClient = nil
+        Task { [weak _webRTCClient] in
+            await _webRTCClient?.cleanUp()
         }
     }
     

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -420,9 +420,9 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         let webSocketClient = environment.webSocketClientBuilder(eventNotificationCenter, url)
         
         webSocketClient.connectionStateDelegate = self
-        webSocketClient.onWSConnectionEstablished = { [weak self] in
-            guard let self = self else { return }
-            
+        webSocketClient.onWSConnectionEstablished = { [weak self, weak webSocketClient] in
+            guard let self = self, let webSocketClient else { return }
+
             let connectUserRequest = ConnectUserDetailsRequest(
                 custom: self.user.customData,
                 id: self.user.id,
@@ -654,7 +654,8 @@ extension StreamVideo: WSEventsSubscriber {
                 callType: ringEvent.call.type,
                 callId: ringEvent.call.id
             )
-            executeOnMain {
+            executeOnMain { [weak self, call] in
+                guard let self else { return }
                 call.state.update(from: ringEvent)
                 self.state.ringingCall = call
             }

--- a/Sources/StreamVideo/Utils/UnfairQueue/UnfairQueue.swift
+++ b/Sources/StreamVideo/Utils/UnfairQueue/UnfairQueue.swift
@@ -23,7 +23,7 @@ import Foundation
 /// additional overhead of dispatching tasks and managing thread execution in a DispatchQueue could result
 /// in unnecessary latency, making `os_unfair_lock` the superior choice for scenarios where rapid, lightweight
 /// synchronization is paramount.
-final class UnfairQueue {
+public final class UnfairQueue {
 
     /// The unfair lock variable, managed as an unsafe mutable pointer to `os_unfair_lock`.
     private let lock: os_unfair_lock_t
@@ -31,7 +31,7 @@ final class UnfairQueue {
     /// Initializes a new instance of `UnfairQueue`.
     ///
     /// It allocates memory for an `os_unfair_lock` and initializes it.
-    init() {
+    public init() {
         lock = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         lock.initialize(to: os_unfair_lock())
     }
@@ -49,7 +49,7 @@ final class UnfairQueue {
     /// - Parameter block: The block of code to execute safely under the lock.
     /// - Returns: The value returned by the block, if any.
     /// - Throws: Rethrows any errors that are thrown by the block.
-    func sync<T>(_ block: () throws -> T) rethrows -> T {
+    public func sync<T>(_ block: () throws -> T) rethrows -> T {
         os_unfair_lock_lock(lock)
         defer { os_unfair_lock_unlock(lock) }
         return try block()

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -183,7 +183,7 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     private var isFastReconnecting = false
     private var disconnectTime: Date?
     private lazy var callStatisticsReporter = StreamCallStatisticsReporter()
-    
+
     @Injected(\.thermalStateObserver) private var thermalStateObserver
     
     var onParticipantsUpdated: (([String: CallParticipant]) -> Void)?
@@ -282,7 +282,7 @@ class WebRTCClient: NSObject, @unchecked Sendable {
             await setupUserMedia(callSettings: callSettings)
             log.debug("Connecting WS channel", subsystems: .webRTC)
             signalChannel?.connect()
-            sfuMiddleware.onSocketConnected = handleOnSocketConnected
+            sfuMiddleware.onSocketConnected = { [weak self] in self?.handleOnSocketConnected(reconnected: $0) }
         } else if migrating {
             log.debug("Performing session migration", subsystems: .webRTC)
             migratingWSClient?.connect()
@@ -841,8 +841,8 @@ class WebRTCClient: NSObject, @unchecked Sendable {
             videoOptions: videoOptions
         )
         
-        subscriber?.onStreamAdded = handleStreamAdded
-        subscriber?.onStreamRemoved = handleStreamRemoved
+        subscriber?.onStreamAdded = { [weak self] in self?.handleStreamAdded($0) }
+        subscriber?.onStreamRemoved = { [weak self] in self?.handleStreamRemoved($0) }
         subscriber?.onDisconnect = { [weak self] _ in
             log.debug("subscriber disconnected")
             if self?.isFastReconnecting == false {
@@ -1310,10 +1310,10 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     }
     
     private func addOnParticipantsChangeHandler() {
-        Task {
+        Task { [weak self] in
             for await _ in await state.callParticipantsUpdates() {
                 log.debug("received participant event", subsystems: .webRTC)
-                await self.handleParticipantsUpdated()
+                await self?.handleParticipantsUpdated()
             }
         }
     }
@@ -1409,14 +1409,16 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     
     private func subscribeToInternetConnectionUpdates() {
         NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleConnectionStateChange),
-            name: .internetConnectionStatusDidChange,
-            object: nil
+            forName: .internetConnectionStatusDidChange,
+            object: nil,
+            queue: nil,
+            using: { [weak self] in
+                self?.handleConnectionStateChange($0)
+            }
         )
     }
     
-    @objc private func handleConnectionStateChange(_ notification: NSNotification) {
+    @objc private func handleConnectionStateChange(_ notification: Notification) {
         guard let status = notification.userInfo?[Notification.internetConnectionStatusUserInfoKey] as? InternetConnection.Status
         else {
             return

--- a/Sources/StreamVideoSwiftUI/CallView/CallControls/Stateless/StatelessParticipantsListButton.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallControls/Stateless/StatelessParticipantsListButton.swift
@@ -17,7 +17,7 @@ public struct StatelessParticipantsListButton: View {
     @Injected(\.colors) var colors
 
     /// The associated call for the participants list button.
-    public var call: Call?
+    public weak var call: Call?
 
     /// The size of the participants list button.
     public var size: CGFloat

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRenderer.swift
@@ -193,6 +193,8 @@ public class VideoRenderer: RTCMTLVideoView {
         super.willMove(toSuperview: newSuperview)
         if newSuperview == nil {
             videoRendererPool.releaseRenderer(self)
+            // Clean up any rendered frames.
+            renderFrame(nil)
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -485,6 +485,7 @@ open class CallViewModel: ObservableObject {
         callingState = .idle
         isMinimized = false
         localVideoPrimary = false
+        Task { await audioRecorder.stopRecording() }
     }
     
     private func enterCall(

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureAdapter.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureAdapter.swift
@@ -55,6 +55,8 @@ final class StreamPictureInPictureAdapter {
     @MainActor
     private func didUpdate(_ call: Call?) {
         participantUpdatesCancellable?.cancel()
+        activeParticipant = nil
+        pictureInPictureController?.track = nil
 
         guard let call = call else { return }
 

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		400D63F72AC3273F0000BB30 /* ThermalStateObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D63F62AC3273F0000BB30 /* ThermalStateObserverTests.swift */; };
 		400E50532BD2A900008C939E /* StreamAudioFilterCapturePostProcessingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400E50522BD2A900008C939E /* StreamAudioFilterCapturePostProcessingModule.swift */; };
 		400E50552BD2AAD0008C939E /* StreamAudioProcessingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400E50542BD2AAD0008C939E /* StreamAudioProcessingModule.swift */; };
+		4012B1892BFC9E6F006B0031 /* UnfairQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3E02BA1D21E0092CE8A /* UnfairQueue.swift */; };
 		401338762BF2489C007318BD /* MockCXCallController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338752BF2489C007318BD /* MockCXCallController.swift */; };
 		401338782BF248B9007318BD /* MockStreamVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338772BF248B9007318BD /* MockStreamVideo.swift */; };
 		4013387A2BF248CC007318BD /* MockCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338792BF248CC007318BD /* MockCall.swift */; };
@@ -101,7 +102,6 @@
 		403EFCA12BDC003A0057C248 /* DemoFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403EFCA02BDC003A0057C248 /* DemoFeedbackView.swift */; };
 		403FF3E72BA1D2D40092CE8A /* StreamPixelBufferRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3E32BA1D2460092CE8A /* StreamPixelBufferRepository.swift */; };
 		403FF3E82BA1D2D70092CE8A /* StreamPixelBufferPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3E52BA1D2610092CE8A /* StreamPixelBufferPool.swift */; };
-		403FF3E92BA1D2E10092CE8A /* UnfairQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3E02BA1D21E0092CE8A /* UnfairQueue.swift */; };
 		403FF3F32BA1DC650092CE8A /* StreamRTCYUVBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3EA2BA1D2F90092CE8A /* StreamRTCYUVBuffer.swift */; };
 		403FF3F42BA1DC690092CE8A /* StreamYUVToARGBConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3EF2BA1DC230092CE8A /* StreamYUVToARGBConversion.swift */; };
 		403FF3F52BA1DC6C0092CE8A /* YpCbCrPixelRange+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3F12BA1DC480092CE8A /* YpCbCrPixelRange+Default.swift */; };
@@ -3612,6 +3612,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				403FF3DF2BA1D20E0092CE8A /* UnfairQueue */,
 				40149DCA2B7E813500473176 /* AudioRecorder */,
 				8456E6C7287EC343004E180E /* Logger */,
 				84C2997C28784BB30034B735 /* Utils.swift */,
@@ -3929,7 +3930,6 @@
 				40F0C3A42BC7F8CB00AB75AD /* VideoRendererPool */,
 				4049CE802BBBF73A003D07D2 /* AsyncImage */,
 				403FF3E22BA1D2270092CE8A /* StreamPixelBufferRepository */,
-				403FF3DF2BA1D20E0092CE8A /* UnfairQueue */,
 				40FA12EE2B76AC4B00CE3EC9 /* Extensions */,
 				402F04AC2B714E9B00CA1986 /* DeviceOrientation */,
 				40E1104A2B5A9F5B007DF492 /* Formatters */,
@@ -5164,6 +5164,7 @@
 				848CCCE82AB8ED8F002E83A2 /* StartHLSBroadcastingResponse.swift in Sources */,
 				84D2E37629DC856D001D2118 /* CallMemberRemovedEvent.swift in Sources */,
 				84F73859287C1A3400A363F4 /* StreamVideo.swift in Sources */,
+				4012B1892BFC9E6F006B0031 /* UnfairQueue.swift in Sources */,
 				840F59922A77FDCB00EF3EB2 /* UnpinResponse.swift in Sources */,
 				8487D8AD2A67F4EC00536ED4 /* ScreenshareCapturer.swift in Sources */,
 				84BAD7782A6BFE8A00733156 /* BroadcastBufferUploadConnection.swift in Sources */,
@@ -5383,7 +5384,6 @@
 				84D419B828E7155100F574F9 /* CallContainer.swift in Sources */,
 				8434C531289AA8770001490A /* StreamVideoUI.swift in Sources */,
 				8457BF7C2A5BF9E0000AE567 /* ToastView.swift in Sources */,
-				403FF3E92BA1D2E10092CE8A /* UnfairQueue.swift in Sources */,
 				844299412942394C0037232A /* VideoView_iOS13.swift in Sources */,
 				846E4AFF29D236EA003733AB /* CallTopView.swift in Sources */,
 				846FBE8928AAD83C00147F6E /* InviteParticipantsView.swift in Sources */,

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -106,6 +106,18 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
### 🎯 Goal

Allow `Call` objects to release when not in use to deallocate unnecessarily used resources.

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)