### PR TITLE
[Enhancement]Use single instances for Call objects with the same cId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🔄 Changed
+- `Call` objects for the same `cId` will reference the same memory instance. [#404](https://github.com/GetStream/stream-video-swift/pull/404)
+
 ### 🐞 Fixed
 - Video tracks for anonymous users not displaying
 

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -11,6 +11,7 @@ import StreamWebRTC
 public class Call: @unchecked Sendable, WSEventsSubscriber {
 
     @Injected(\.streamVideo) var streamVideo
+    @Injected(\.callCache) var callCache
 
     @MainActor public internal(set) var state = CallState()
 
@@ -374,6 +375,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         cancellables.removeAll()
         eventHandlers.removeAll()
         callController.cleanUp()
+        callCache.removeCall(callType: callType, callId: callId)
         Task { @MainActor in
             if streamVideo.state.ringingCall?.cId == cId {
                 streamVideo.state.ringingCall = nil

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -375,7 +375,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         cancellables.removeAll()
         eventHandlers.removeAll()
         callController.cleanUp()
-        callCache.removeCall(callType: callType, callId: callId)
+        /// Upon `Call.leave` we remove the call from the cache. Any further actions that are required
+        /// to happen on the call object (e.g. rejoin) will need to fetch a new instance from `StreamVideo`
+        /// client.
+        callCache.remove(for: cId)
         Task { @MainActor in
             if streamVideo.state.ringingCall?.cId == cId {
                 streamVideo.state.ringingCall = nil

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -192,7 +192,7 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         callType: String,
         callId: String
     ) -> Call {
-        callCache.getCall(callType: callType, callId: callId) {
+        callCache.call(for: callCid(from: callType, callType: callId)) {
             let callController = makeCallController(callType: callType, callId: callId)
             let call = Call(
                 callType: callType,

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -145,14 +145,21 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         // This is used from the `StreamCallAudioRecorder` to observe active
         // calls and activate/deactivate the AudioSession.
         StreamActiveCallProviderKey.currentValue = self
+
+        // Clear up the call cache to avoid stale call objects.
+        callCache.removeAll()
+
         (apiTransport as? URLSessionTransport)?.setTokenUpdater { [weak self] userToken in
             self?.token = userToken
         }
         if user.type != .anonymous {
-            let userAuth = UserAuth { [unowned self] in
-                self.token.rawValue
-            } connectionId: { [unowned self] in
-                await self.loadConnectionId()
+            let userAuth = UserAuth { [weak self] in
+                self?.token.rawValue ?? ""
+            } connectionId: { [weak self] in
+                guard let self else {
+                    throw ClientError.Unexpected()
+                }
+                return await self.loadConnectionId()
             }
             coordinatorClient.middlewares.append(userAuth)
         } else {

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -14,6 +14,8 @@ public typealias UserTokenUpdater = (UserToken) -> Void
 /// Needs to be initalized with a valid api key, user and token (and token provider).
 public class StreamVideo: ObservableObject, @unchecked Sendable {
     
+    @Injected(\.callCache) private var callCache
+
     public class State: ObservableObject {
         @Published public internal(set) var connection: ConnectionStatus = .initialized
         @Published public internal(set) var user: User
@@ -190,15 +192,17 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         callType: String,
         callId: String
     ) -> Call {
-        let callController = makeCallController(callType: callType, callId: callId)
-        let call = Call(
-            callType: callType,
-            callId: callId,
-            coordinatorClient: coordinatorClient,
-            callController: callController
-        )
-        eventsMiddleware.add(subscriber: call)
-        return call
+        callCache.getCall(callType: callType, callId: callId) {
+            let callController = makeCallController(callType: callType, callId: callId)
+            let call = Call(
+                callType: callType,
+                callId: callId,
+                coordinatorClient: coordinatorClient,
+                callController: callController
+            )
+            eventsMiddleware.add(subscriber: call)
+            return call
+        }
     }
 
     /// Creates a controller used for querying and watching calls.

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -199,7 +199,7 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         callType: String,
         callId: String
     ) -> Call {
-        callCache.call(for: callCid(from: callType, callType: callId)) {
+        callCache.call(for: callCid(from: callId, callType: callType)) {
             let callController = makeCallController(callType: callType, callId: callId)
             let call = Call(
                 callType: callType,

--- a/Sources/StreamVideo/Utils/CallCache/CallCache.swift
+++ b/Sources/StreamVideo/Utils/CallCache/CallCache.swift
@@ -41,6 +41,12 @@ final class CallCache {
             storage[cId] = nil
         }
     }
+
+    func removeAll() {
+        queue.sync {
+            storage.removeAll()
+        }
+    }
 }
 
 extension CallCache: InjectionKey {

--- a/Sources/StreamVideo/Utils/CallCache/CallCache.swift
+++ b/Sources/StreamVideo/Utils/CallCache/CallCache.swift
@@ -4,17 +4,24 @@
 
 import Foundation
 
+/// A cache for managing `Call` instances, ensuring thread-safe operations.
 final class CallCache {
+    /// A queue for synchronizing access to the cache.
     private let queue = UnfairQueue()
+    /// The underlying storage for cached calls.
     private var storage: [String: Call] = [:]
 
-    func getCall(
-        callType: String,
-        callId: String,
+    /// Dequeues a `Call` from the cache or creates a new one using the provided factory.
+    ///
+    /// - Parameters:
+    ///   - cId: The ``cId`` of the call.
+    ///   - factory: A closure that creates a new `Call` instance if none exists in the cache.
+    /// - Returns: A `Call` instance, either from the cache or newly created.
+    func call(
+        for cId: String,
         factory: () -> Call
     ) -> Call {
-        let cId = callCid(from: callType, callType: callId)
-        return queue.sync {
+        queue.sync {
             if let cached = storage[cId] {
                 return cached
             } else {
@@ -25,8 +32,11 @@ final class CallCache {
         }
     }
 
-    func removeCall(callType: String, callId: String) {
-        let cId = callCid(from: callType, callType: callId)
+    /// Remove a `Call` from the cache.
+    ///
+    /// - Parameters:
+    ///   - cId: The ``cID`` of the call.
+    func remove(for cId: String) {
         queue.sync {
             storage[cId] = nil
         }

--- a/Sources/StreamVideo/Utils/CallCache/CallCache.swift
+++ b/Sources/StreamVideo/Utils/CallCache/CallCache.swift
@@ -23,8 +23,10 @@ final class CallCache {
     ) -> Call {
         queue.sync {
             if let cached = storage[cId] {
+                log.debug("Will reuse call:\(cId).")
                 return cached
             } else {
+                log.debug("Will create and cache call:\(cId)")
                 let call = factory()
                 storage[cId] = call
                 return call
@@ -37,6 +39,7 @@ final class CallCache {
     /// - Parameters:
     ///   - cId: The ``cID`` of the call.
     func remove(for cId: String) {
+        log.debug("Will remove call:\(cId)")
         queue.sync {
             storage[cId] = nil
         }
@@ -44,6 +47,7 @@ final class CallCache {
 
     func removeAll() {
         queue.sync {
+            log.debug("Will remove \(storage.count) calls.")
             storage.removeAll()
         }
     }

--- a/Sources/StreamVideo/Utils/CallCache/CallCache.swift
+++ b/Sources/StreamVideo/Utils/CallCache/CallCache.swift
@@ -1,0 +1,45 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+final class CallCache {
+    private let queue = UnfairQueue()
+    private var storage: [String: Call] = [:]
+
+    func getCall(
+        callType: String,
+        callId: String,
+        factory: () -> Call
+    ) -> Call {
+        let cId = callCid(from: callType, callType: callId)
+        return queue.sync {
+            if let cached = storage[cId] {
+                return cached
+            } else {
+                let call = factory()
+                storage[cId] = call
+                return call
+            }
+        }
+    }
+
+    func removeCall(callType: String, callId: String) {
+        let cId = callCid(from: callType, callType: callId)
+        queue.sync {
+            storage[cId] = nil
+        }
+    }
+}
+
+extension CallCache: InjectionKey {
+    static var currentValue: CallCache = .init()
+}
+
+extension InjectedValues {
+    var callCache: CallCache {
+        get { Self[CallCache.self] }
+        set { Self[CallCache.self] = newValue }
+    }
+}

--- a/Sources/StreamVideoSwiftUI/CallView/CallControls/Stateless/StatelessHangUpIconView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallControls/Stateless/StatelessHangUpIconView.swift
@@ -15,7 +15,7 @@ public struct StatelessHangUpIconView: View {
     @Injected(\.images) private var images
 
     /// The associated call for the hang-up icon.
-    public var call: Call?
+    public weak var call: Call?
 
     /// The size of the hang-up icon.
     public var size: CGFloat

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -338,8 +338,8 @@ public struct VideoCallParticipantView: View {
                 showVideo: showVideo && isVisible,
                 handleRendering: { [weak call] view in
                     guard call != nil else { return }
-                    view.handleViewRendering(for: participant) { size, participant in
-                        Task {
+                    view.handleViewRendering(for: participant) { [weak call] size, participant in
+                        Task { [weak call] in
                             await call?.updateTrackSize(size, for: participant)
                         }
                     }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		40FB02012BAC8A4A00A1C206 /* CallKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FB02002BAC8A4A00A1C206 /* CallKitService.swift */; };
 		40FB02032BAC93A800A1C206 /* CallKitAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FB02022BAC93A800A1C206 /* CallKitAdapter.swift */; };
 		40FB02052BAC94FB00A1C206 /* CallKitPushNotificationAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FB02042BAC94FB00A1C206 /* CallKitPushNotificationAdapter.swift */; };
+		40FB150A2BF74C1300D5E580 /* CallCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FB15092BF74C1300D5E580 /* CallCache.swift */; };
 		40FBEF492AC30343007CFF17 /* Safari.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF482AC30343007CFF17 /* Safari.swift */; };
 		40FBEF4B2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */; };
 		43217A0C2A44A28B002B5857 /* ConnectionErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43217A0B2A44A28B002B5857 /* ConnectionErrorEvent.swift */; };
@@ -1340,6 +1341,7 @@
 		40FB02002BAC8A4A00A1C206 /* CallKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitService.swift; sourceTree = "<group>"; };
 		40FB02022BAC93A800A1C206 /* CallKitAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitAdapter.swift; sourceTree = "<group>"; };
 		40FB02042BAC94FB00A1C206 /* CallKitPushNotificationAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitPushNotificationAdapter.swift; sourceTree = "<group>"; };
+		40FB15092BF74C1300D5E580 /* CallCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCache.swift; sourceTree = "<group>"; };
 		40FBEF482AC30343007CFF17 /* Safari.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Safari.swift; sourceTree = "<group>"; };
 		40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+KeyboardIntroduction.swift"; sourceTree = "<group>"; };
 		43217A0B2A44A28B002B5857 /* ConnectionErrorEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionErrorEvent.swift; sourceTree = "<group>"; };
@@ -2941,6 +2943,14 @@
 			path = CallKit;
 			sourceTree = "<group>";
 		};
+		40FB15082BF74C0A00D5E580 /* CallCache */ = {
+			isa = PBXGroup;
+			children = (
+				40FB15092BF74C1300D5E580 /* CallCache.swift */,
+			);
+			path = CallCache;
+			sourceTree = "<group>";
+		};
 		40FBEF472AC3030C007CFF17 /* UITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -3613,6 +3623,7 @@
 			isa = PBXGroup;
 			children = (
 				403FF3DF2BA1D20E0092CE8A /* UnfairQueue */,
+				40FB15082BF74C0A00D5E580 /* CallCache */,
 				40149DCA2B7E813500473176 /* AudioRecorder */,
 				8456E6C7287EC343004E180E /* Logger */,
 				84C2997C28784BB30034B735 /* Utils.swift */,
@@ -5019,6 +5030,7 @@
 				84DC389329ADFCFD00946713 /* ScreensharingSettingsRequest.swift in Sources */,
 				40013DDC2B87AA2300915453 /* SerialActor.swift in Sources */,
 				84EBA4A22A72B81100577297 /* BroadcastBufferConnection.swift in Sources */,
+				40FB150A2BF74C1300D5E580 /* CallCache.swift in Sources */,
 				40FB02012BAC8A4A00A1C206 /* CallKitService.swift in Sources */,
 				840F598F2A77FDCB00EF3EB2 /* PinRequest.swift in Sources */,
 				84DC389F29ADFCFD00946713 /* JoinCallResponse.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		403BE0FE2A24C07300988F65 /* DeeplinkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE0FD2A24C07300988F65 /* DeeplinkAdapter.swift */; };
 		403BE1012A24C70000988F65 /* DemoApp+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403BE1002A24C70000988F65 /* DemoApp+Sentry.swift */; };
 		403EFCA12BDC003A0057C248 /* DemoFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403EFCA02BDC003A0057C248 /* DemoFeedbackView.swift */; };
+		403FB1492BFDF3950047A696 /* CallCache_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FB1482BFDF3950047A696 /* CallCache_Tests.swift */; };
 		403FF3E72BA1D2D40092CE8A /* StreamPixelBufferRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3E32BA1D2460092CE8A /* StreamPixelBufferRepository.swift */; };
 		403FF3E82BA1D2D70092CE8A /* StreamPixelBufferPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3E52BA1D2610092CE8A /* StreamPixelBufferPool.swift */; };
 		403FF3F32BA1DC650092CE8A /* StreamRTCYUVBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403FF3EA2BA1D2F90092CE8A /* StreamRTCYUVBuffer.swift */; };
@@ -1176,6 +1177,7 @@
 		403BE1002A24C70000988F65 /* DemoApp+Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoApp+Sentry.swift"; sourceTree = "<group>"; };
 		403EFC9E2BDBFE050057C248 /* CallEndedViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallEndedViewModifier.swift; sourceTree = "<group>"; };
 		403EFCA02BDC003A0057C248 /* DemoFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoFeedbackView.swift; sourceTree = "<group>"; };
+		403FB1482BFDF3950047A696 /* CallCache_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCache_Tests.swift; sourceTree = "<group>"; };
 		403FF3E02BA1D21E0092CE8A /* UnfairQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfairQueue.swift; sourceTree = "<group>"; };
 		403FF3E32BA1D2460092CE8A /* StreamPixelBufferRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPixelBufferRepository.swift; sourceTree = "<group>"; };
 		403FF3E52BA1D2610092CE8A /* StreamPixelBufferPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPixelBufferPool.swift; sourceTree = "<group>"; };
@@ -3194,6 +3196,7 @@
 				84D6E5392B3AD10000D0056C /* RepeatingTimer_Tests.swift */,
 				4031D7F72B83C087002EC6E4 /* StreamCallAudioRecorderTests.swift */,
 				40A0E9632B88DE830089E8D3 /* SerialActor_Tests.swift */,
+				403FB1482BFDF3950047A696 /* CallCache_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5295,6 +5298,7 @@
 				40F017652BBEF1A200E89FD1 /* RTMPIngress+Dummy.swift in Sources */,
 				84DCA2112A389160000C3411 /* AssertDelay.swift in Sources */,
 				40F0173B2BBEB1A900E89FD1 /* CallKitAdapterTests.swift in Sources */,
+				403FB1492BFDF3950047A696 /* CallCache_Tests.swift in Sources */,
 				40A0E9642B88DE830089E8D3 /* SerialActor_Tests.swift in Sources */,
 				40F017692BBEF1DA00E89FD1 /* EgressHLSResponse+Dummy.swift in Sources */,
 				84F58B8B29EEACAD00010C4C /* WebSocketEngine_Mock.swift in Sources */,

--- a/StreamVideoTests/Mock/MockResponseBuilder.swift
+++ b/StreamVideoTests/Mock/MockResponseBuilder.swift
@@ -52,19 +52,19 @@ class MockResponseBuilder {
             cid: cid,
             createdAt: Date(),
             createdBy: userResponse,
-            currentSessionId: "123",
+            currentSessionId: String(cid.split(separator: ":")[1]),
             custom: [:],
             egress: EgressResponse(
                 broadcasting: false,
                 rtmps: []
             ),
-            id: "123",
+            id: String(cid.split(separator: ":")[1]),
             ingress: callIngressResponse,
             recording: recording,
             session: session,
             settings: makeCallSettingsResponse(),
             transcribing: false,
-            type: "default",
+            type: String(cid.split(separator: ":")[0]),
             updatedAt: Date()
         )
         return callResponse

--- a/StreamVideoTests/Utilities/Extensions/XCTestCase+PredicateFulfillment.swift
+++ b/StreamVideoTests/Utilities/Extensions/XCTestCase+PredicateFulfillment.swift
@@ -8,7 +8,7 @@ import XCTest
 extension XCTestCase {
 
     func fulfillment(
-        timeout: TimeInterval = .infinity,
+        timeout: TimeInterval = defaultTimeout,
         enforceOrder: Bool = false,
         block: @escaping () -> Bool,
         file: StaticString = #file,

--- a/StreamVideoTests/Utils/CallCache_Tests.swift
+++ b/StreamVideoTests/Utils/CallCache_Tests.swift
@@ -1,0 +1,63 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class CallCacheTests: StreamVideoTestCase {
+
+    private lazy var callId: String! = .unique
+    private lazy var callType: String! = "test"
+    private var cId: String { callCid(from: callId, callType: callType) }
+    private lazy var subject: CallCache! = .init()
+
+    override func tearDown() {
+        callId = nil
+        callType = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func testCallCreatesNewCallWhenNotCached() {
+
+        let factory: () -> Call = { [callType, callId] in
+            .dummy(callType: callType!, callId: callId!)
+        }
+
+        let call = subject.call(for: cId, factory: factory)
+
+        XCTAssertEqual(call.cId, cId)
+    }
+
+    func testCallReturnsCachedCall() {
+        let call = Call.dummy(callType: callType, callId: callId)
+
+        // Add call to cache manually
+        _ = subject.call(for: cId) { call }
+
+        // Call should return the cached call
+        let cachedCall = subject.call(for: cId, factory: { .dummy() })
+
+        XCTAssertTrue(call === cachedCall)
+    }
+
+    func testRemoveCallById() {
+        let call = Call.dummy(callType: callType, callId: callId)
+
+        // Add call to cache
+        _ = subject.call(for: cId, factory: { call })
+
+        // Remove call by id
+        subject.remove(for: cId)
+
+        // Call should create a new call since the cache is empty
+        let factory: () -> Call = { [callType, callId] in
+            .dummy(callType: callType!, callId: callId!)
+        }
+        let newCall = subject.call(for: cId, factory: factory)
+
+        XCTAssertFalse(call === newCall)
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Use single instances for `Call` objects with the same `cId`. That helps ensuring that irregardless of the `Call` object creation point, actions performed to it will be synced across every observer.

### 📝 Summary

`StreamVideo` and `Call` internally use a thread-safe cache that ensures that only a single instance of `Call` object will exist for the same cId.

### 🧪 Manual Testing Notes

- Regular join call flows should remain working.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)