### PR TITLE
[Fix]Reused VideoRenderer artifacts

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -345,6 +345,7 @@ public struct VideoCallParticipantView: View {
                     }
                 }
             )
+            .id(participant.id)
         }
         .onAppear { isVisible = true }
         .onDisappear { isVisible = false }

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRenderer.swift
@@ -194,7 +194,7 @@ public class VideoRenderer: RTCMTLVideoView {
         if newSuperview == nil {
             videoRendererPool.releaseRenderer(self)
             // Clean up any rendered frames.
-            renderFrame(nil)
+            setSize(.zero)
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/ReusePool.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/ReusePool.swift
@@ -60,12 +60,16 @@ final class ReusePool<Element: AnyObject & Hashable> {
 
     /// Releases an element back to the pool for reuse.
     ///
-    /// - Parameter element: The element to release.
-    func release(_ element: Element) {
+    /// - Parameters:
+    ///   - element: The element to release.
+    ///   - replaceAvailableElementWithNew: If set to `true` rather than moving the item to
+    ///   available, it will throw it away and instead place a newly created element in `available` storage.
+    ///   Defaults to `false`.
+    func release(_ element: Element, replaceAvailableElementWithNew: Bool = false) {
         queue.sync {
             if inUse.contains(element), available.endIndex < initialCapacity {
                 inUse.remove(element)
-                available.append(element)
+                available.append(replaceAvailableElementWithNew ? factory() : element)
                 log.debug("Will make available \(type(of: element)):\(String(describing: element)).")
             } else {
                 inUse.remove(element)

--- a/Sources/StreamVideoSwiftUI/Utils/VideoRendererPool/VideoRendererPool.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/VideoRendererPool/VideoRendererPool.swift
@@ -15,8 +15,8 @@ final class VideoRendererPool {
 
     /// Initializes the `VideoRendererPool` with a specified initial capacity.
     ///
-    /// - Parameter initialCapacity: The initial capacity of the pool (default is 10).
-    init(initialCapacity: Int = 10) {
+    /// - Parameter initialCapacity: The initial capacity of the pool (default is 2).
+    init(initialCapacity: Int = 2) {
         // Initialize the pool with a capacity and a factory closure to create `VideoRenderer` instances
         pool = ReusePool(initialCapacity: initialCapacity) {
             VideoRenderer(frame: CGRect(origin: .zero, size: .zero))
@@ -43,7 +43,7 @@ final class VideoRendererPool {
     ///
     /// - Parameter renderer: The `VideoRenderer` instance to release.
     func releaseRenderer(_ renderer: VideoRenderer) {
-        pool.release(renderer)
+        pool.release(renderer, replaceAvailableElementWithNew: true)
     }
 }
 

--- a/StreamVideoSwiftUITests/Utils/ReusePool_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/ReusePool_Tests.swift
@@ -65,6 +65,43 @@ final class ReusePoolTests: XCTestCase {
         XCTAssertNotNil(object7)
     }
 
+    func test_acquireAndReleaseWithReplace() {
+        // Acquire objects from the pool and then release them
+        let object1 = subject.acquire()
+        let object2 = subject.acquire()
+
+        XCTAssertNotNil(object1)
+        XCTAssertNotNil(object2)
+        XCTAssertNotEqual(object1, object2)
+
+        subject.release(object2, replaceAvailableElementWithNew: true)
+        subject.release(object1, replaceAvailableElementWithNew: true)
+
+        // After releasing, these objects should be available for reuse
+        let object3 = subject.acquire()
+        let object4 = subject.acquire()
+
+        XCTAssertNotNil(object3)
+        XCTAssertNotNil(object4)
+        XCTAssertFalse(object1 === object3) // Reused object
+        XCTAssertFalse(object2 === object4) // Reused object
+
+        // Now, the pool should be at initial capacity
+        let object5 = subject.acquire()
+        XCTAssertNotNil(object5)
+
+        // Try to acquire more than the initial capacity
+        let object6 = subject.acquire()
+        XCTAssertNotNil(object6)
+
+        // Release all objects
+        subject.releaseAll()
+
+        // After releasing all, all objects should be back in the pool
+        let object7 = subject.acquire()
+        XCTAssertNotNil(object7)
+    }
+
     func test_exceedCapacity() {
         // Acquire objects up to the initial capacity
         let objects = (0..<3).map { _ in subject.acquire() }


### PR DESCRIPTION
### 🎯 Goal

Avoid outdated artifacts when reusing VideoRenderer instances.

### 🧪 Manual Testing Notes

- Join multiple calls. You shouldn't see artifacts on any screen from any previous call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)