### PR TITLE
Dispatch CallKit reporting to mainActor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- `CallKitAdapter` will dispatch voIP notification reporting to the MainActor. [#41](https://github.com/GetStream/stream-video-swift/pull/41)
 
 # [1.0.3](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.3)
 _May 22, 2024_

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -86,6 +86,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
     }
 
     /// Delegate method called when the device receives a VoIP push notification.
+    @MainActor
     open func pushRegistry(
         _ registry: PKPushRegistry,
         didReceiveIncomingPushWith payload: PKPushPayload,

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -82,6 +82,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     ///   - localizedCallerName: The localized caller name.
     ///   - callerId: The caller's identifier.
     ///   - completion: A closure to be called upon completion.
+    @MainActor
     open func reportIncomingCall(
         _ cid: String,
         localizedCallerName: String,

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -67,6 +67,7 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
 
     // MARK: - pushRegistry(_:didReceiveIncomingPushWith:for:completion:)
 
+    @MainActor
     func test_pushRegistryDidReceiveIncomingPush_typeIsVoIP_reportIncomingCallWasCalledAsExpected() {
         assertDidReceivePushNotification(
             .init(
@@ -77,6 +78,7 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_pushRegistryDidReceiveIncomingPush_typeIsVoIPWithDisplayNameAndCallerName_reportIncomingCallWasCalledAsExpected() {
         assertDidReceivePushNotification(
             .init(
@@ -88,6 +90,7 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_pushRegistryDidReceiveIncomingPush_typeIsNotVoIP_reportIncomingCallWasNotCalled() {
         assertDidReceivePushNotification(contentType: .fileProvider)
     }
@@ -108,6 +111,7 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
         )
     }
 
+    @MainActor
     private func assertDidReceivePushNotification(
         _ content: CallKitPushNotificationAdapter.Content? = nil,
         contentType: PKPushType = .voIP,

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -53,6 +53,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - reportIncomingCall
 
+    @MainActor
     func test_reportIncomingCall_callProviderWasCalledWithExpectedValues() {
         // Given
         let expectation = self.expectation(description: "Report Incoming Call")
@@ -429,9 +430,10 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Private Helpers
 
+    @MainActor
     private func assertRequestTransaction<T>(
         _ expected: T.Type,
-        actionBlock: @Sendable() -> Void,
+        actionBlock: @MainActor @Sendable() -> Void,
         file: StaticString = #file,
         line: UInt = #line
     ) async throws {
@@ -477,8 +479,9 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    @MainActor
     private func assertWithoutRequestTransaction(
-        actionBlock: @Sendable() -> Void,
+        actionBlock: @MainActor @Sendable() -> Void,
         file: StaticString = #file,
         line: UInt = #line
     ) async throws {


### PR DESCRIPTION
### 📝 Summary

CallKitAdapter will dispatch call reporting to the mainActor. That allows accessing callState without additional dispatching (which CallKit dislikes).

### 🧪 Manual Testing Notes

- Ring calls on device with the app running, backgrounded, killed. All calls should be reported from CallKit

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)