### PR TITLE
[Enhancement]Allow configuring CallKit supported call types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- In `CallKitService` you can now configure if calls support Video. Depending on the value `CallKit` will suffix either the word `Audio` (when false) or `Video` when true, next to the application's name. [#420](https://github.com/GetStream/stream-video-swift/pull/420)
 
 # [1.0.5](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.5)
 _May 28, 2024_
@@ -15,7 +16,7 @@ _May 28, 2024_
 _May 27, 2024_
 
 ### 🔄 Changed
-- `CallKitAdapter` will dispatch voIP notification reporting to the MainActor. [#41](https://github.com/GetStream/stream-video-swift/pull/41)
+- `CallKitAdapter` will dispatch voIP notification reporting to the MainActor. [#411](https://github.com/GetStream/stream-video-swift/pull/411)
 
 # [1.0.3](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.3)
 _May 22, 2024_

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -138,4 +138,16 @@ fileprivate func content() {
             }
         }
     }
+
+    container {
+        @Injected(\.callKitService) var callKitService
+
+        // Setting the `supportsVideo` property to `true` will
+        // make the subtitle's format be: `<Application's name> Video`
+        callKitService.supportsVideo = true
+
+        // Setting the `supportsVideo` property to `false` will
+        // make the subtitle's format be: `<Application's name> Audio`
+        callKitService.supportsVideo = false
+    }
 }

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -52,6 +52,11 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// Whether the call can be held on its own or swapped with another call.
     /// - Important: Holding a call isn't supported yet!
     open var supportsHolding: Bool = false
+    /// Whether the service supports Video in addition to Audio calls. If set to true, CallKit push notification
+    /// title, will be suffixed with the word `Video` next to the application's name. Otherwise, it will be
+    /// suffixed with the word `Audio`.
+    /// - Note: defaults to `false`.
+    open var supportsVideo: Bool = false
 
     /// The call controller used for managing calls.
     open internal(set) lazy var callController = CXCallController()
@@ -412,7 +417,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     }
 
     private func buildProvider(
-        supportsVideo: Bool = true,
         supportedHandleTypes: Set<CXHandle.HandleType> = [.generic]
     ) -> CXProvider {
         let configuration = {
@@ -452,7 +456,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
         update.localizedCallerName = localizedCallerName
         update.remoteHandle = CXHandle(type: .generic, value: callerId)
-        update.hasVideo = true
+        update.hasVideo = supportsVideo
         update.supportsDTMF = false
 
         if supportsHolding {

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -57,6 +57,46 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     // MARK: - reportIncomingCall
 
     @MainActor
+    func test_reportIncomingCall_supportsVideo_callUpdateWasConfiguredCorrectly() throws {
+        subject.supportsVideo = true
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId
+        ) { _ in }
+
+        let invocation = try XCTUnwrap(callProvider.invocations.first)
+
+        switch invocation {
+        case let .reportNewIncomingCall(_, update, _):
+            XCTAssertTrue(update.hasVideo)
+        default:
+            XCTFail()
+        }
+    }
+
+    @MainActor
+    func test_reportIncomingCall_doesNotSupportVideo_callUpdateWasConfiguredCorrectly() throws {
+        subject.supportsVideo = false
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId
+        ) { _ in }
+
+        let invocation = try XCTUnwrap(callProvider.invocations.first)
+
+        switch invocation {
+        case let .reportNewIncomingCall(_, update, _):
+            XCTAssertFalse(update.hasVideo)
+        default:
+            XCTFail()
+        }
+    }
+
+    @MainActor
     func test_reportIncomingCall_callProviderWasCalledWithExpectedValues() {
         // Given
         let expectation = self.expectation(description: "Report Incoming Call")

--- a/docusaurus/docs/iOS/06-advanced/03-callkit-integration.mdx
+++ b/docusaurus/docs/iOS/06-advanced/03-callkit-integration.mdx
@@ -161,6 +161,24 @@ If none of the fields above are being set, the property will be an empty string.
 - **created_by_display_name**
 The property is always set and contains the name of the user who created the call.
 
+#### Call's type suffix
+
+Depending on the `Call` type `CallKit` adds a suffix in the push notification's subtitle (which contains the application name). That suffix can either be `Audio` or `Video`. `CallKitService` allows you to configure what the supported call types are, by setting the `CallKitService.supportsVideo` property like below:
+
+```swift
+@Injected(\.callKitService) var callKitService
+
+// Setting the `supportsVideo` property to `true` will 
+// make the subtitle's format be: `<Application's name> Video`
+callKitService.supportsVideo = true 
+
+// Setting the `supportsVideo` property to `false` will 
+// make the subtitle's format be: `<Application's name> Audio`
+callKitService.supportsVideo = false
+```
+
+`CallKitService.supportsVideo` default value is `false`.
+
 ### Registering for VoIP Push Notifications
 
 Even though using the `CallKitAdapter` abstracts most of the `CallKit` & `PushKit` complexity from you, there is still a need for you to register/unregister the deviceToken.


### PR DESCRIPTION
### 🎯 Goal

Allow configuring CallKit supported call types, in order to manage the suffix on the push notification.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)