### PR TITLE
[Fix]Async CallViewModel tests

### DIFF
--- a/StreamVideoTests/StreamVideoTestCase.swift
+++ b/StreamVideoTests/StreamVideoTestCase.swift
@@ -7,8 +7,8 @@ import XCTest
 
 open class StreamVideoTestCase: XCTestCase {
 
-    public var streamVideo: StreamVideo?
-    var httpClient = HTTPClient_Mock()
+    public var streamVideo: StreamVideo!
+    var httpClient: HTTPClient_Mock! = HTTPClient_Mock()
 
     override open func setUp() {
         super.setUp()
@@ -18,6 +18,8 @@ open class StreamVideoTestCase: XCTestCase {
     override open func tearDown() async throws {
         try await super.tearDown()
         await streamVideo?.disconnect()
+        streamVideo = nil
+        httpClient = nil
     }
     
     // TODO: replace this with something a bit better

--- a/StreamVideoTests/Utilities/Extensions/XCTestCase+PredicateFulfillment.swift
+++ b/StreamVideoTests/Utilities/Extensions/XCTestCase+PredicateFulfillment.swift
@@ -7,9 +7,9 @@ import XCTest
 
 extension XCTestCase {
 
+    @MainActor
     func fulfillment(
         timeout: TimeInterval = defaultTimeout,
-        enforceOrder: Bool = false,
         file: StaticString = #file,
         line: UInt = #line,
         block: @escaping () -> Bool
@@ -23,12 +23,14 @@ extension XCTestCase {
         await safeFulfillment(
             of: [waitExpectation],
             timeout: timeout,
-            enforceOrder: enforceOrder,
             file: file,
             line: line
         )
+
+        XCTAssertTrue(block(), file: file, line: line)
     }
 
+    @MainActor
     func safeFulfillment(
         of expectations: [XCTestExpectation],
         timeout seconds: TimeInterval = .infinity,


### PR DESCRIPTION
### 📝 Summary

The revision attempts to fix the recent test failures on `CallViewModel` tests by reducing the need to wait for specific amount of time. Instead it relies on BlockPredicate asserts.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)