### PR TITLE
[Enhancement]Participant auto-leave policy implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- A new `ParticipantAutoLeavePolicy` that allows you to set when a user should automatically leave a call. [#434](https://github.com/GetStream/stream-video-swift/pull/434)
+
 ### 🔄 Changed
 
 # [1.0.7](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.7)

--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import StreamVideo
 
 protocol Debuggable: Hashable {
     var title: String { get }
@@ -389,4 +390,32 @@ extension AppEnvironment {
     }
 
     static var callExpiration: CallExpiration = .never
+}
+
+extension AppEnvironment {
+
+    enum AutoLeavePolicy: Hashable, Debuggable {
+        case `default`
+        case lastParticipant
+
+        var title: String {
+            switch self {
+            case .default:
+                return "Default"
+            case .lastParticipant:
+                return "Last Participant"
+            }
+        }
+
+        var policy: ParticipantAutoLeavePolicy {
+            switch self {
+            case .default:
+                DefaultParticipantAutoLeavePolicy()
+            case .lastParticipant:
+                LastParticipantAutoLeavePolicy()
+            }
+        }
+    }
+
+    static var autoLeavePolicy: AutoLeavePolicy = .lastParticipant
 }

--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -417,5 +417,5 @@ extension AppEnvironment {
         }
     }
 
-    static var autoLeavePolicy: AutoLeavePolicy = .lastParticipant
+    static var autoLeavePolicy: AutoLeavePolicy = .default
 }

--- a/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
@@ -18,6 +18,7 @@ internal struct DemoCallContainerView: View {
 
     internal init(callId: String) {
         let callViewModel = CallViewModel()
+        callViewModel.participantAutoLeavePolicy = AppEnvironment.autoLeavePolicy.policy
         callViewModel.isPictureInPictureEnabled = AppEnvironment.pictureInPictureIntegration == .enabled
         _viewModel = StateObject(wrappedValue: callViewModel)
         _chatViewModel = StateObject(wrappedValue: .init(callViewModel))

--- a/DemoApp/Sources/Views/Login/DebugMenu.swift
+++ b/DemoApp/Sources/Views/Login/DebugMenu.swift
@@ -86,6 +86,10 @@ struct DebugMenu: View {
     @State private var customTokenExpirationValue: Int = 0
     @State private var presentsCustomTokenExpiration: Bool = false
 
+    @State private var autoLeavePolicy: AppEnvironment.AutoLeavePolicy = AppEnvironment.autoLeavePolicy {
+        didSet { AppEnvironment.autoLeavePolicy = autoLeavePolicy }
+    }
+
     var body: some View {
         Menu {
             makeMenu(
@@ -138,6 +142,12 @@ struct DebugMenu: View {
                 currentValue: pictureInPictureIntegration,
                 label: "Picture in Picture Integration"
             ) { self.pictureInPictureIntegration = $0 }
+
+            makeMenu(
+                for: [.default, .lastParticipant],
+                currentValue: autoLeavePolicy,
+                label: "Auto Leave policy"
+            ) { self.autoLeavePolicy = $0 }
 
             makeMenu(
                 for: [.visible, .hidden],

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/00-ringing.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/00-ringing.swift
@@ -34,4 +34,9 @@ fileprivate func content() {
         let call = streamVideo.call(callType: "default", callId: callId)
         let callResponse = try await call.notify()
     }
+
+    container {
+        let callViewModel = CallViewModel()
+        callViewModel.participantAutoLeavePolicy = LastParticipantAutoLeavePolicy()
+    }
 }

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/DefaultParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/DefaultParticipantAutoLeavePolicy.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public final class DefaultParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
+    public var onPolicyTriggered: (() -> Void)?
+
+    public init() {}
+}

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/DefaultParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/DefaultParticipantAutoLeavePolicy.swift
@@ -4,7 +4,10 @@
 
 import Foundation
 
+/// A default implementation of the `ParticipantAutoLeavePolicy` protocol, that contains no
+/// rules and thus the closure will never be executed.
 public final class DefaultParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
+
     public var onPolicyTriggered: (() -> Void)?
 
     public init() {}

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/LastParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/LastParticipantAutoLeavePolicy.swift
@@ -5,48 +5,69 @@
 import Combine
 import Foundation
 
+/// A policy that triggers an action when during a ringing flow call (incoming or outgoing) there is only one
+/// participant left in a call, after having previously had multiple participants.
 public final class LastParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
 
+    /// Injected dependency for accessing the stream video service.
     @Injected(\.streamVideo) private var streamVideo
 
+    /// Subscription for observing changes to the ringing call.
     private var ringingCallCancellable: AnyCancellable?
+
+    /// The identifier of the latest ringing call.
     private var latestRingingCallCid: String?
 
+    /// Subscription for observing changes to the active call.
     private var activeCallCancellable: AnyCancellable?
+
+    /// The current active call.
     private var activeCall: Call? {
         didSet { didUpdateCall(activeCall, oldValue: oldValue) }
     }
 
+    /// Subscription for observing changes to the call participants.
     private var callParticipantsObservation: AnyCancellable?
+
+    /// The maximum number of participants observed in the current call.
     private var maxAggregatedParticipantsCount: Int = 0
+
+    /// The current number of participants in the call.
     private var currentParticipantsCount: Int = 0 {
         didSet {
             maxAggregatedParticipantsCount = max(maxAggregatedParticipantsCount, currentParticipantsCount)
             let currentCount = currentParticipantsCount
             let maxCount = maxAggregatedParticipantsCount
+            // Check if the policy trigger conditions are met.
             Task { @MainActor in
                 checkTrigger(currentCount: currentCount, maxCount: maxCount)
             }
         }
     }
 
+    /// A closure that will be called once the rules evaluated in the policy have been triggered.
     public var onPolicyTriggered: (() -> Void)?
 
+    /// Initializes a new instance of `LastParticipantAutoLeavePolicy`.
     public init() {
+        // Observing changes to the ringing call state.
         ringingCallCancellable = streamVideo
             .state
             .$ringingCall
             .compactMap(\.?.cId)
             .assign(to: \.latestRingingCallCid, onWeak: self)
 
+        // Observing changes to the active call state.
         activeCallCancellable = streamVideo
             .state
             .$activeCall
             .assign(to: \.activeCall, onWeak: self)
     }
 
+    /// The current call being observed.
     private var call: Call? {
         didSet {
+            // Handle updates to the current call.
             Task { @MainActor in
                 didUpdateCall(call, oldValue: oldValue)
             }
@@ -55,16 +76,24 @@ public final class LastParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
 
     // MARK: - Private API
 
+    /// Handles updates to the current call.
+    /// - Parameters:
+    ///   - call: The new call instance.
+    ///   - oldValue: The previous call instance.
     private func didUpdateCall(_ call: Call?, oldValue: Call?) {
         guard call?.cId != oldValue?.cId else { return }
 
+        // Cancel any existing participant observations.
         callParticipantsObservation?.cancel()
         callParticipantsObservation = nil
         maxAggregatedParticipantsCount = 0
         currentParticipantsCount = 0
 
+        // Start call observation only if the activeCall is an incoming or
+        // outgoing call.
         guard let call, call.cId == latestRingingCallCid else { return }
 
+        // Observe changes to the participants map in the new call.
         Task { @MainActor in
             callParticipantsObservation = call
                 .state
@@ -74,10 +103,16 @@ public final class LastParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
         }
     }
 
+    /// Checks if the policy conditions are met to trigger the action.
+    /// - Parameters:
+    ///   - currentCount: The current number of participants in the call.
+    ///   - maxCount: The maximum number of participants that have been in the call.
     @MainActor
     private func checkTrigger(currentCount: Int, maxCount: Int) {
         guard let activeCall else { return }
 
+        // Conditions to trigger the policy: single participant and previously
+        // had more than one participant.
         guard currentCount == 1, maxCount > 1 else {
             log.debug(
                 """
@@ -90,6 +125,7 @@ public final class LastParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
             return
         }
 
+        // Ensure the session has been accepted by someone.
         guard
             activeCall.state.session?.acceptedBy.isEmpty == false
         else {
@@ -105,6 +141,7 @@ public final class LastParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
             return
         }
 
+        // Log the trigger and execute the closure.
         log.debug(
             """
             Participants updated triggering \(type(of: self)).

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/LastParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/LastParticipantAutoLeavePolicy.swift
@@ -1,0 +1,119 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+public final class LastParticipantAutoLeavePolicy: ParticipantAutoLeavePolicy {
+
+    @Injected(\.streamVideo) private var streamVideo
+
+    private var ringingCallCancellable: AnyCancellable?
+    private var latestRingingCallCid: String?
+
+    private var activeCallCancellable: AnyCancellable?
+    private var activeCall: Call? {
+        didSet { didUpdateCall(activeCall, oldValue: oldValue) }
+    }
+
+    private var callParticipantsObservation: AnyCancellable?
+    private var maxAggregatedParticipantsCount: Int = 0
+    private var currentParticipantsCount: Int = 0 {
+        didSet {
+            maxAggregatedParticipantsCount = max(maxAggregatedParticipantsCount, currentParticipantsCount)
+            let currentCount = currentParticipantsCount
+            let maxCount = maxAggregatedParticipantsCount
+            Task { @MainActor in
+                checkTrigger(currentCount: currentCount, maxCount: maxCount)
+            }
+        }
+    }
+
+    public var onPolicyTriggered: (() -> Void)?
+
+    public init() {
+        ringingCallCancellable = streamVideo
+            .state
+            .$ringingCall
+            .compactMap(\.?.cId)
+            .assign(to: \.latestRingingCallCid, onWeak: self)
+
+        activeCallCancellable = streamVideo
+            .state
+            .$activeCall
+            .assign(to: \.activeCall, onWeak: self)
+    }
+
+    private var call: Call? {
+        didSet {
+            Task { @MainActor in
+                didUpdateCall(call, oldValue: oldValue)
+            }
+        }
+    }
+
+    // MARK: - Private API
+
+    private func didUpdateCall(_ call: Call?, oldValue: Call?) {
+        guard call?.cId != oldValue?.cId else { return }
+
+        callParticipantsObservation?.cancel()
+        callParticipantsObservation = nil
+        maxAggregatedParticipantsCount = 0
+        currentParticipantsCount = 0
+
+        guard let call, call.cId == latestRingingCallCid else { return }
+
+        Task { @MainActor in
+            callParticipantsObservation = call
+                .state
+                .$participantsMap
+                .map(\.count)
+                .assign(to: \.currentParticipantsCount, onWeak: self)
+        }
+    }
+
+    @MainActor
+    private func checkTrigger(currentCount: Int, maxCount: Int) {
+        guard let activeCall else { return }
+
+        guard currentCount == 1, maxCount > 1 else {
+            log.debug(
+                """
+                Participants updated without triggering \(type(of: self)).
+                CallCid: \(activeCall.cId)
+                Participants count: \(currentCount)
+                Max Participants count: \(maxCount)
+                """
+            )
+            return
+        }
+
+        guard
+            activeCall.state.session?.acceptedBy.isEmpty == false
+        else {
+            log.debug(
+                """
+                Participants updated without triggering \(type(of: self)).
+                CallCid: \(activeCall.cId)
+                Participants count: \(currentCount)
+                Max Participants count: \(maxCount)
+                Session acceptedBy: \(String(describing: activeCall.state.session?.acceptedBy))
+                """
+            )
+            return
+        }
+
+        log.debug(
+            """
+            Participants updated triggering \(type(of: self)).
+            CallCid: \(activeCall.cId)
+            Participants count: \(currentCount)
+            Max Participants count: \(maxCount)
+            Session acceptedBy: \(String(describing: activeCall.state.session?.acceptedBy))
+            """
+        )
+        onPolicyTriggered?()
+    }
+}

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/ParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/ParticipantAutoLeavePolicy.swift
@@ -4,6 +4,10 @@
 
 import Foundation
 
+/// A policy that can be used to apply certain business logic depending on the participants state during
+/// a call.
 public protocol ParticipantAutoLeavePolicy {
+
+    /// A closure that will be called once the rules evaluated in the policy have been triggered.
     var onPolicyTriggered: (() -> Void)? { get set }
 }

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/ParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/ParticipantAutoLeavePolicy.swift
@@ -1,0 +1,9 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol ParticipantAutoLeavePolicy {
+    var onPolicyTriggered: (() -> Void)? { get set }
+}

--- a/Sources/StreamVideo/Utils/Publisher+WeakAssign.swift
+++ b/Sources/StreamVideo/Utils/Publisher+WeakAssign.swift
@@ -1,0 +1,17 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+extension Publisher where Failure == Never {
+    public func assign<Root: AnyObject>(
+        to keyPath: ReferenceWritableKeyPath<Root, Output>,
+        onWeak object: Root
+    ) -> AnyCancellable {
+        sink { [weak object] value in
+            object?[keyPath: keyPath] = value
+        }
+    }
+}

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -194,7 +194,7 @@ open class CallViewModel: ObservableObject {
 
     private var automaticLayoutHandling = true
 
-    var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = LastParticipantAutoLeavePolicy() {
+    public var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = LastParticipantAutoLeavePolicy() {
         didSet { participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in self?.participantAutoLeavePolicyTriggered() } }
     }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -194,6 +194,10 @@ open class CallViewModel: ObservableObject {
 
     private var automaticLayoutHandling = true
 
+    var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = LastParticipantAutoLeavePolicy() {
+        didSet { participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in self?.participantAutoLeavePolicyTriggered() } }
+    }
+
     /// A simple value, signalling that the viewModel has been subscribed to receive callEvents from
     /// `StreamVideo`.
     var isSubscribedToCallEvents: Bool { callEventsSubscriptionTask != nil }
@@ -210,6 +214,8 @@ open class CallViewModel: ObservableObject {
         pictureInPictureAdapter.onSizeUpdate = { [weak self] in
             self?.updateTrackSize($0, for: $1)
         }
+        
+        participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in self?.participantAutoLeavePolicyTriggered() }
     }
 
     deinit {
@@ -621,16 +627,9 @@ open class CallViewModel: ObservableObject {
                         log.debug("Skipping participant events for big calls")
                         return
                     }
+
                     self.participantEvent = participantEvent
-                    if participantEvent.action == .leave,
-                       callParticipants.count == 1,
-                       call?.state.session?.acceptedBy.isEmpty == false
-                    {
-                        leaveCall()
-                    } else {
-                        // The event is shown for 2 seconds.
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                    }
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
                     self.participantEvent = nil
                 }
             }
@@ -644,7 +643,7 @@ open class CallViewModel: ObservableObject {
 
         switch callingState {
         case .incoming where event.user?.id == streamVideo.user.id:
-            callingState = .idle
+            break
         case .outgoing where call?.cId == event.callCid:
             enterCall(
                 call: call,
@@ -726,6 +725,10 @@ open class CallViewModel: ObservableObject {
                 cameraPosition: previous.cameraPosition
             )
         }
+    }
+
+    private func participantAutoLeavePolicyTriggered() {
+        leaveCall()
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -194,8 +194,14 @@ open class CallViewModel: ObservableObject {
 
     private var automaticLayoutHandling = true
 
-    public var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = LastParticipantAutoLeavePolicy() {
-        didSet { participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in self?.participantAutoLeavePolicyTriggered() } }
+    /// The policy to whenever call events occur in order to decide if the current user should remain
+    /// in the call or not. Default value is the no operation policy `DefaultParticipantAutoLeavePolicy`,
+    public var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = DefaultParticipantAutoLeavePolicy() {
+        didSet {
+            var oldValue = oldValue
+            oldValue.onPolicyTriggered = nil
+            participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in self?.participantAutoLeavePolicyTriggered() }
+        }
     }
 
     /// A simple value, signalling that the viewModel has been subscribed to receive callEvents from
@@ -215,6 +221,9 @@ open class CallViewModel: ObservableObject {
             self?.updateTrackSize($0, for: $1)
         }
         
+        // As we are setting the value on init, the `didSet` won't trigger, thus
+        // we are firing it manually.
+        // For any subsequent changes, `didSet` will trigger as expected.
         participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in self?.participantAutoLeavePolicyTriggered() }
     }
 

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -274,6 +274,10 @@
 		40B499CC2AC1A90F00A53B60 /* DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */; };
 		40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		40B713692A275F1400D1FE67 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8456E6C5287EB55F004E180E /* AppState.swift */; };
+		40C4DF482C1C2BFC0035DBC2 /* LastParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */; };
+		40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */; };
+		40C4DF4B2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */; };
+		40C4DF4D2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4C2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift */; };
 		40C7B82C2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B82B2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift */; };
 		40C7B8322B61325500FB9DB2 /* ModalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B8312B61325500FB9DB2 /* ModalButton.swift */; };
 		40C7B8342B613A8200FB9DB2 /* ControlBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B8332B613A8200FB9DB2 /* ControlBadgeView.swift */; };
@@ -1315,6 +1319,10 @@
 		40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCallingViewModifier.swift; sourceTree = "<group>"; };
 		40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogDestination.swift; sourceTree = "<group>"; };
 		40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkTests.swift; sourceTree = "<group>"; };
+		40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
+		40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WeakAssign.swift"; sourceTree = "<group>"; };
+		40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
+		40C4DF4C2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C7B82B2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsListViewModifier.swift; sourceTree = "<group>"; };
 		40C7B8312B61325500FB9DB2 /* ModalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalButton.swift; sourceTree = "<group>"; };
 		40C7B8332B613A8200FB9DB2 /* ControlBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBadgeView.swift; sourceTree = "<group>"; };
@@ -2785,6 +2793,16 @@
 			path = Events;
 			sourceTree = "<group>";
 		};
+		40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */ = {
+			isa = PBXGroup;
+			children = (
+				40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */,
+				40C4DF4C2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift */,
+				40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */,
+			);
+			path = ParticipantAutoLeavePolicy;
+			sourceTree = "<group>";
+		};
 		40C7B82A2B612D5100FB9DB2 /* ViewModifiers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3791,6 +3809,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */,
 				408937892C062B0B000EEB69 /* UUIDProviding */,
 				403FF3DF2BA1D20E0092CE8A /* UnfairQueue */,
 				40FB150D2BF77CA200D5E580 /* StateMachine */,
@@ -3817,6 +3836,7 @@
 				40CB9FA32B7F8EA4006BED93 /* AVCaptureSession+ActiveCaptureDevice.swift */,
 				40013DDB2B87AA2300915453 /* SerialActor.swift */,
 				40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */,
+				40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */,
 				408CE0F22BD905920052EC3A /* Models+Sendable.swift */,
 			);
 			path = Utils;
@@ -5192,6 +5212,7 @@
 				84DC38B029ADFCFD00946713 /* MuteUsersRequest.swift in Sources */,
 				406AF2012AF3D98F00ED4D0C /* SimulatorScreenCapturer.swift in Sources */,
 				84A7E18A2883638200526C98 /* URLSessionWebSocketEngine.swift in Sources */,
+				40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */,
 				408679F72BD12F1000D027E0 /* AudioFilter.swift in Sources */,
 				8456E6D2287EC343004E180E /* ConsoleLogDestination.swift in Sources */,
 				84DC38A529ADFCFD00946713 /* SFUResponse.swift in Sources */,
@@ -5332,6 +5353,7 @@
 				40149DCE2B7E837A00473176 /* StreamCallAudioRecorder.swift in Sources */,
 				84DC389B29ADFCFD00946713 /* PermissionRequestEvent.swift in Sources */,
 				84BAD77A2A6BFEF900733156 /* BroadcastBufferUploader.swift in Sources */,
+				40C4DF4B2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift in Sources */,
 				84DC38A429ADFCFD00946713 /* BackstageSettings.swift in Sources */,
 				84BBF62D28AFC72700387A02 /* DefaultRTCMediaConstraints.swift in Sources */,
 				40A0E9622B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift in Sources */,
@@ -5355,6 +5377,7 @@
 				84A7E1892883638200526C98 /* WebSocketEngine.swift in Sources */,
 				4065838A2B87695500B4F979 /* BlurBackgroundVideoFilter.swift in Sources */,
 				84DC38B429ADFCFD00946713 /* ICEServer.swift in Sources */,
+				40C4DF482C1C2BFC0035DBC2 /* LastParticipantAutoLeavePolicy.swift in Sources */,
 				82686160290A7556005BFFED /* SystemEnvironment.swift in Sources */,
 				842B8E182A2DFED900863A87 /* TargetResolutionRequest.swift in Sources */,
 				406583922B877A1600B4F979 /* BackgroundImageFilterProcessor.swift in Sources */,
@@ -5364,6 +5387,7 @@
 				84DC389629ADFCFD00946713 /* EndCallResponse.swift in Sources */,
 				847BE09C29DADE0100B55D21 /* Call.swift in Sources */,
 				848CCCEF2AB8ED8F002E83A2 /* ThumbnailsSettings.swift in Sources */,
+				40C4DF4D2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift in Sources */,
 				84FC2C2228ACF2E000181490 /* PeerConnection.swift in Sources */,
 				401A0F032AB1C1B600BE2DBD /* ThermalStateObserver.swift in Sources */,
 				84D2E37929DC856D001D2118 /* CallMemberAddedEvent.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */; };
 		40C4DF4B2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */; };
 		40C4DF4D2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4C2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift */; };
+		40C4DF502C1C415F0035DBC2 /* LastParticipantAutoLeavePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4F2C1C415F0035DBC2 /* LastParticipantAutoLeavePolicyTests.swift */; };
 		40C7B82C2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B82B2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift */; };
 		40C7B8322B61325500FB9DB2 /* ModalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B8312B61325500FB9DB2 /* ModalButton.swift */; };
 		40C7B8342B613A8200FB9DB2 /* ControlBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B8332B613A8200FB9DB2 /* ControlBadgeView.swift */; };
@@ -1323,6 +1324,7 @@
 		40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WeakAssign.swift"; sourceTree = "<group>"; };
 		40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C4DF4C2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
+		40C4DF4F2C1C415F0035DBC2 /* LastParticipantAutoLeavePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastParticipantAutoLeavePolicyTests.swift; sourceTree = "<group>"; };
 		40C7B82B2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsListViewModifier.swift; sourceTree = "<group>"; };
 		40C7B8312B61325500FB9DB2 /* ModalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalButton.swift; sourceTree = "<group>"; };
 		40C7B8332B613A8200FB9DB2 /* ControlBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBadgeView.swift; sourceTree = "<group>"; };
@@ -2803,6 +2805,14 @@
 			path = ParticipantAutoLeavePolicy;
 			sourceTree = "<group>";
 		};
+		40C4DF4E2C1C41470035DBC2 /* ParticipantAutoLeavePolicy */ = {
+			isa = PBXGroup;
+			children = (
+				40C4DF4F2C1C415F0035DBC2 /* LastParticipantAutoLeavePolicyTests.swift */,
+			);
+			path = ParticipantAutoLeavePolicy;
+			sourceTree = "<group>";
+		};
 		40C7B82A2B612D5100FB9DB2 /* ViewModifiers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3360,6 +3370,7 @@
 		842747F429EEDACB00E063AD /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40C4DF4E2C1C41470035DBC2 /* ParticipantAutoLeavePolicy */,
 				403FB14A2BFE14690047A696 /* StateMachine */,
 				8490031829D2E0DF00AD9BB4 /* Sorting_Tests.swift */,
 				846A06CF29E0591D0084C264 /* StringExtensions_Tests.swift */,
@@ -5549,6 +5560,7 @@
 				403FB1582BFE21470047A696 /* StreamCallStateMachineStageJoiningStage_Tests.swift in Sources */,
 				40F0176B2BBEF1F400E89FD1 /* EgressRTMPResponse+Dummy.swift in Sources */,
 				400D63F72AC3273F0000BB30 /* ThermalStateObserverTests.swift in Sources */,
+				40C4DF502C1C415F0035DBC2 /* LastParticipantAutoLeavePolicyTests.swift in Sources */,
 				4013387C2BF248E9007318BD /* Mockable.swift in Sources */,
 				402C545B2B6BE50500672BFB /* MockStreamStatistics.swift in Sources */,
 				8414081529F28FFC00FF2D7C /* CallSettings_Tests.swift in Sources */,

--- a/StreamVideoTests/Utilities/Extensions/XCTestCase+PredicateFulfillment.swift
+++ b/StreamVideoTests/Utilities/Extensions/XCTestCase+PredicateFulfillment.swift
@@ -12,7 +12,7 @@ extension XCTestCase {
         timeout: TimeInterval = defaultTimeout,
         file: StaticString = #file,
         line: UInt = #line,
-        block: @escaping () -> Bool
+        block: @MainActor @Sendable @escaping () -> Bool
     ) async {
         let predicate = NSPredicate { _, _ in block() }
         let waitExpectation = XCTNSPredicateExpectation(
@@ -33,7 +33,7 @@ extension XCTestCase {
     @MainActor
     func safeFulfillment(
         of expectations: [XCTestExpectation],
-        timeout seconds: TimeInterval = .infinity,
+        timeout seconds: TimeInterval = defaultTimeout,
         enforceOrder: Bool = false,
         file: StaticString = #file,
         line: UInt = #line

--- a/StreamVideoTests/Utils/ParticipantAutoLeavePolicy/LastParticipantAutoLeavePolicyTests.swift
+++ b/StreamVideoTests/Utils/ParticipantAutoLeavePolicy/LastParticipantAutoLeavePolicyTests.swift
@@ -1,0 +1,152 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamVideo
+@preconcurrency import XCTest
+
+final class LastParticipantAutoLeavePolicyTests: XCTestCase, @unchecked Sendable {
+
+    private lazy var user: User! = .dummy()
+    private lazy var mockStreamVideo: MockStreamVideo! = MockStreamVideo(
+        stubbedProperty: [
+            MockStreamVideo.propertyKey(for: \.state): MockStreamVideo.State(user: user)
+        ],
+        user: user
+    )
+    private lazy var subject: LastParticipantAutoLeavePolicy! = .init()
+
+    override func setUp() {
+        super.setUp()
+        _ = mockStreamVideo
+    }
+
+    override func tearDown() {
+        user = nil
+        mockStreamVideo = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_ringingCallAndActiveCallUpdates_maxParticipantsWasMoreThanOne_whenParticipantCountBecomesOneTriggersPolicy() async {
+        await assertPolicyWasTriggered(
+            true,
+            ringingCall: .dummy(callType: .default, callId: "123"),
+            activeCall: .dummy(callType: .default, callId: "123"),
+            maxParticipantsCount: 3,
+            currentParticipantsCount: 1,
+            acceptedBy: 2
+        )
+    }
+
+    func test_ringingCallAndActiveCallUpdates_maxParticipantsWasNotMoreThanOne_whenParticipantCountBecomesOneDoesNotTriggerPolicy(
+    ) async {
+        await assertPolicyWasTriggered(
+            false,
+            ringingCall: .dummy(callType: .default, callId: "123"),
+            activeCall: .dummy(callType: .default, callId: "123"),
+            maxParticipantsCount: 1,
+            currentParticipantsCount: 1,
+            acceptedBy: 1
+        )
+    }
+
+    func test_ringingCallAndActiveCallUpdates_maxParticipantsWasMoreThanOneNotAcceptedBy_whenParticipantCountBecomesOneDoesNotTriggerPolicy(
+    ) async {
+        await assertPolicyWasTriggered(
+            false,
+            ringingCall: .dummy(callType: .default, callId: "123"),
+            activeCall: .dummy(callType: .default, callId: "123"),
+            maxParticipantsCount: 2,
+            currentParticipantsCount: 1,
+            acceptedBy: 0
+        )
+    }
+
+    func test_ringingCallAndActiveCallUpdatesButAreDifferent_maxParticipantsWasMoreThanOne_whenParticipantCountBecomesOneDoesNotTriggerPolicy(
+    ) async {
+        await assertPolicyWasTriggered(
+            false,
+            ringingCall: .dummy(callType: .default, callId: "1234"),
+            activeCall: .dummy(callType: .default, callId: "123"),
+            maxParticipantsCount: 3,
+            currentParticipantsCount: 1,
+            acceptedBy: 2
+        )
+    }
+
+    func test_noRingingCallAndActiveCallUpdates_maxParticipantsWasMoreThanOne_whenParticipantCountBecomesOneDoesNotTriggerPolicy(
+    ) async {
+        await assertPolicyWasTriggered(
+            false,
+            ringingCall: nil,
+            activeCall: .dummy(callType: .default, callId: "123"),
+            maxParticipantsCount: 3,
+            currentParticipantsCount: 1,
+            acceptedBy: 2
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func assertPolicyWasTriggered(
+        _ expectsTrigger: Bool,
+        ringingCall: Call?,
+        activeCall: Call,
+        maxParticipantsCount: Int,
+        currentParticipantsCount: Int,
+        acceptedBy: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        let triggerExpectation = XCTestExpectation(description: "Policy was triggered!")
+        triggerExpectation.isInverted = !expectsTrigger
+        subject.onPolicyTriggered = { triggerExpectation.fulfill() }
+
+        if let ringingCall {
+            mockRingingCall(ringingCall)
+            await fulfillment(file: file, line: line) { self.mockStreamVideo.state.ringingCall?.cId == ringingCall.cId }
+        }
+
+        mockActiveCall(activeCall)
+        await fulfillment(file: file, line: line) { self.mockStreamVideo.state.activeCall?.cId == activeCall.cId }
+
+        mockSessionAcceptedBy(acceptedBy, on: activeCall)
+        await fulfillment(file: file, line: line) { activeCall.state.session?.acceptedBy.count == acceptedBy }
+
+        mockParticipantsJoined(maxParticipantsCount, on: activeCall)
+        await fulfillment(file: file, line: line) { activeCall.state.participantsMap.count == maxParticipantsCount }
+
+        mockParticipantsJoined(currentParticipantsCount, on: activeCall)
+        await fulfillment(file: file, line: line) { activeCall.state.participantsMap.count == currentParticipantsCount }
+
+        await safeFulfillment(of: [triggerExpectation], file: file, line: line)
+    }
+
+    private func mockRingingCall(_ call: Call?) {
+        mockStreamVideo.state.ringingCall = call
+    }
+
+    private func mockActiveCall(_ call: Call?) {
+        mockStreamVideo.state.activeCall = call
+    }
+
+    private func mockParticipantsJoined(_ count: Int, on call: Call) {
+        let participants = (0..<count)
+            .map { _ in CallParticipant.dummy() }
+            .reduce(into: [String: CallParticipant]()) { $0[$1.id] = $1 }
+        Task { @MainActor in
+            call.state.participantsMap = participants
+        }
+    }
+
+    private func mockSessionAcceptedBy(_ count: Int, on call: Call) {
+        let acceptedBy = (0..<count)
+            .map { _ in Date() }
+            .reduce(into: [String: Date]()) { $0[.unique] = $1 }
+        Task { @MainActor in
+            call.state.session = .dummy(acceptedBy: acceptedBy)
+        }
+    }
+}

--- a/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageAcceptedStage_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageAcceptedStage_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 @testable import StreamVideo
-import XCTest
+@preconcurrency import XCTest
 
-final class StreamCallStateMachineStageAcceptedStage_Tests: StreamVideoTestCase {
+final class StreamCallStateMachineStageAcceptedStage_Tests: StreamVideoTestCase, @unchecked Sendable {
 
     private struct TestError: Error {}
 

--- a/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageAcceptingStage_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageAcceptingStage_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 @testable import StreamVideo
-import XCTest
+@preconcurrency import XCTest
 
-final class StreamCallStateMachineStageAcceptingStage_Tests: StreamVideoTestCase {
+final class StreamCallStateMachineStageAcceptingStage_Tests: StreamVideoTestCase, @unchecked Sendable {
 
     private struct TestError: Error {}
 
@@ -18,6 +18,7 @@ final class StreamCallStateMachineStageAcceptingStage_Tests: StreamVideoTestCase
         .idle
     ]
     private lazy var subject: StreamCallStateMachine.Stage! = .accepting(call) { .init(duration: "123") }
+    private var transitionedToStage: StreamCallStateMachine.Stage?
 
     override func tearDown() {
         call = nil
@@ -39,10 +40,9 @@ final class StreamCallStateMachineStageAcceptingStage_Tests: StreamVideoTestCase
     func testTransition() async {
         for nextStage in allOtherStages {
             if validOtherStages.contains(nextStage.id) {
-                var transitionedToStage: StreamCallStateMachine.Stage?
-                subject.transition = { transitionedToStage = $0 }
+                subject.transition = { self.transitionedToStage = $0 }
                 XCTAssertNotNil(subject.transition(from: nextStage))
-                await fulfillment(timeout: defaultTimeout) { transitionedToStage != nil }
+                await fulfillment(timeout: defaultTimeout) { self.transitionedToStage != nil }
                 XCTAssertEqual(transitionedToStage?.id, .accepted)
             } else {
                 XCTAssertNil(subject.transition(from: nextStage), "No error was thrown for \(nextStage.id)")
@@ -53,11 +53,10 @@ final class StreamCallStateMachineStageAcceptingStage_Tests: StreamVideoTestCase
     func testTransitionAfterError() async {
         for nextStage in allOtherStages {
             if validOtherStages.contains(nextStage.id) {
-                var transitionedToStage: StreamCallStateMachine.Stage?
                 subject = .accepting(call) { throw TestError() }
-                subject.transition = { transitionedToStage = $0 }
+                subject.transition = { self.transitionedToStage = $0 }
                 XCTAssertNotNil(subject.transition(from: nextStage))
-                await fulfillment(timeout: defaultTimeout) { transitionedToStage != nil }
+                await fulfillment(timeout: defaultTimeout) { self.transitionedToStage != nil }
                 XCTAssertEqual(transitionedToStage?.id, .error)
             } else {
                 XCTAssertNil(subject.transition(from: nextStage), "No error was thrown for \(nextStage.id)")

--- a/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageIdleStage_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageIdleStage_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 @testable import StreamVideo
-import XCTest
+@preconcurrency import XCTest
 
-final class StreamCallStateMachineStageIdleStage_Tests: StreamVideoTestCase {
+final class StreamCallStateMachineStageIdleStage_Tests: StreamVideoTestCase, @unchecked Sendable {
 
     private lazy var call: Call! = .dummy()
     private lazy var allOtherStages: [StreamCallStateMachine.Stage]! = StreamCallStateMachine.Stage.ID

--- a/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageJoinedStage_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageJoinedStage_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 @testable import StreamVideo
-import XCTest
+@preconcurrency import XCTest
 
-final class StreamCallStateMachineStageJoinedStage_Tests: StreamVideoTestCase {
+final class StreamCallStateMachineStageJoinedStage_Tests: StreamVideoTestCase, @unchecked Sendable {
 
     private struct TestError: Error {}
 

--- a/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageRejectedStage_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/CallStateMachine/Stages/StreamCallStateMachineStageRejectedStage_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 @testable import StreamVideo
-import XCTest
+@preconcurrency import XCTest
 
-final class StreamCallStateMachineStageRejectedStage_Tests: StreamVideoTestCase {
+final class StreamCallStateMachineStageRejectedStage_Tests: StreamVideoTestCase, @unchecked Sendable {
 
     private struct TestError: Error {}
 

--- a/docusaurus/docs/iOS/06-advanced/00-ringing.mdx
+++ b/docusaurus/docs/iOS/06-advanced/00-ringing.mdx
@@ -56,3 +56,18 @@ You can also use a shortcut of this method, with the `notify` method:
 let call = streamVideo.call(callType: "default", callId: callId)
 let callResponse = try await call.notify()
 ```
+
+### AutoLeave Policy
+
+There may be scenarios where once a call is concluded there is no point for a user to remain in the call if the other participants have already left. In cases like that you may find youself in a position where you need to last participant to automatically leave the call. Luckily, the StreamVideoSwiftUI SDK makes that very easy by allowing you to set the `ParticipantAutoLeavePolicy`, like below:
+
+```swift
+let callViewModel = CallViewModel()
+callViewModel.participantAutoLeavePolicy = LastParticipantAutoLeavePolicy()
+```
+
+By doing that, we are instructing the `CallViewModel` to observe the participants during the ringing flow call (incoming or outgoing). Once a user remain the last one, the callViewModel will automatically trigger the flow to leave the call.
+
+:::note
+The `participantAutoLeavePolicy` is set to `DefaultParticipantAutoLeavePolicy` which is a no-operation policy, meaning that if the user remain in the call alone, no automatic action will be performed.
+:::


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/871

### 🎯 Goal

Ensure that during a ringing-flow call (incoming or outgoing) when the current user become the only one in the call, they will be automatically kicked out.

### 🛠 Implementation

As the coordinator seems to require some time to be fully running after a connection has been recovered from an expired token, rather than relying on the participant_left event from the coordinator, we apply a similar logic when the participants update.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  https://youtu.be/G3Dq48T0ZBk | https://youtu.be/8-bXIMQEdzE |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)