### PR TITLE
[Enhancement]Error handling inside SwiftConcurrency tasks

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,17 @@
+# Directory and file filters
+included:
+  - Sources
+  - DemoApp
+  - DemoAppUIKit
+  - StreamVideoTests
+  - StreamVideoUIKitTests
+excluded:
+  - Tests/SwiftLintFrameworkTests/Resources
+  - Sources/StreamVideo/Generated
+  - Sources/StreamVideo/OpenApi
+  - Sources/StreamVideo/protobuf
+  - Sources/StreamVideoSwiftUI/Generated
+
+# Enabled/disabled rules
+only_rules:
+  - unhandled_throwing_task

--- a/DemoApp/Sources/AppDelegate.swift
+++ b/DemoApp/Sources/AppDelegate.swift
@@ -76,9 +76,18 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             let call = streamVideo.call(callType: callType, callId: callId)
             AppState.shared.activeCall = call
             Task {
-                try await streamVideo.connect()
-                try await call.accept()
-                try await call.join()
+                do {
+                    try Task.checkCancellation()
+                    try await streamVideo.connect()
+
+                    try Task.checkCancellation()
+                    try await call.accept()
+
+                    try Task.checkCancellation()
+                    try await call.join()
+                } catch {
+                    log.error(error)
+                }
             }
         }
     }

--- a/DemoApp/Sources/Components/Reactions/ReactionsAdapter.swift
+++ b/DemoApp/Sources/Components/Reactions/ReactionsAdapter.swift
@@ -40,17 +40,22 @@ final class ReactionsAdapter: ObservableObject {
     // MARK: - Actions
 
     func send(reaction: Reaction) {
+        guard let call else { return }
         Task {
-            try await call?.sendReaction(
-                type: reaction.id.rawValue,
-                custom: [
-                    "id": .string(reaction.id.rawValue),
-                    "duration": .number(reaction.duration ?? 0),
-                    "userSpecific": .bool(reaction.userSpecific),
-                    "isReverted": .bool(shouldRevert(reaction: reaction))
-                ],
-                emojiCode: reaction.id.rawValue
-            )
+            do {
+                try await call.sendReaction(
+                    type: reaction.id.rawValue,
+                    custom: [
+                        "id": .string(reaction.id.rawValue),
+                        "duration": .number(reaction.duration ?? 0),
+                        "userSpecific": .bool(reaction.userSpecific),
+                        "isReverted": .bool(shouldRevert(reaction: reaction))
+                    ],
+                    emojiCode: reaction.id.rawValue
+                )
+            } catch {
+                log.error(error)
+            }
         }
     }
 
@@ -83,7 +88,7 @@ final class ReactionsAdapter: ObservableObject {
             forName: .init(CallNotification.callEnded),
             object: nil,
             queue: nil
-        ) { _ in Task { await MainActor.run { [weak self] in self?.handleCallEnded() } } }
+        ) { _ in Task { @MainActor [weak self] in self?.handleCallEnded() } }
     }
 
     private func subscribeToReactionEvents() {

--- a/DemoApp/Sources/Components/Router.swift
+++ b/DemoApp/Sources/Components/Router.swift
@@ -50,7 +50,11 @@ final class Router: ObservableObject {
         appState.unsecureRepository.save(baseURL: AppEnvironment.baseURL)
 
         Task {
-            try await loadLoggedInUser()
+            do {
+                try await loadLoggedInUser()
+            } catch {
+                log.error(error)
+            }
         }
     }
 
@@ -71,9 +75,13 @@ final class Router: ObservableObject {
             deeplinkInfo.baseURL != AppEnvironment.baseURL,
             let currentUser = appState.currentUser {
             Task {
-                await appState.logout()
-                AppEnvironment.baseURL = deeplinkInfo.baseURL
-                try await handleLoggedInUserCredentials(.init(userInfo: currentUser, token: .empty), deeplinkInfo: deeplinkInfo)
+                do {
+                    await appState.logout()
+                    AppEnvironment.baseURL = deeplinkInfo.baseURL
+                    try await handleLoggedInUserCredentials(.init(userInfo: currentUser, token: .empty), deeplinkInfo: deeplinkInfo)
+                } catch {
+                    log.error(error)
+                }
             }
         } else {
             log.debug("Request to handle deeplink \(url) accepted ✅")
@@ -81,7 +89,11 @@ final class Router: ObservableObject {
                 appState.deeplinkInfo = deeplinkInfo
             } else {
                 Task {
-                    try await handleGuestUser(deeplinkInfo: deeplinkInfo)
+                    do {
+                        try await handleGuestUser(deeplinkInfo: deeplinkInfo)
+                    } catch {
+                        log.error(error)
+                    }
                 }
             }
         }
@@ -96,7 +108,11 @@ final class Router: ObservableObject {
             if userCredentials.userInfo.id.contains("@getstream") {
                 GIDSignIn.sharedInstance.restorePreviousSignIn { [weak self] _, _ in
                     Task {
-                        try await self?.setupUser(with: userCredentials)
+                        do {
+                            try await self?.setupUser(with: userCredentials)
+                        } catch {
+                            log.error(error)
+                        }
                     }
                 }
             } else {

--- a/DemoApp/Sources/Components/Snapshot/LocalParticipantSnapshotViewModel.swift
+++ b/DemoApp/Sources/Components/Snapshot/LocalParticipantSnapshotViewModel.swift
@@ -64,12 +64,16 @@ final class LocalParticipantSnapshotViewModel: NSObject, AVCapturePhotoCaptureDe
 
     func zoom() {
         Task {
-            if await state.zoomFactor > 1 {
-                await state.setZoomFactor(1)
-                try call?.zoom(by: 1)
-            } else {
-                await state.setZoomFactor(1.5)
-                try call?.zoom(by: 1.5)
+            do {
+                if await state.zoomFactor > 1 {
+                    await state.setZoomFactor(1)
+                    try call?.zoom(by: 1)
+                } else {
+                    await state.setZoomFactor(1.5)
+                    try call?.zoom(by: 1.5)
+                }
+            } catch {
+                log.error(error)
             }
         }
     }

--- a/DemoApp/Sources/DemoApp.swift
+++ b/DemoApp/Sources/DemoApp.swift
@@ -44,10 +44,14 @@ struct DemoApp: App {
                         NavigationView {
                             LoginView() { credentials in
                                 Task {
-                                    try await router.handleLoggedInUserCredentials(
-                                        credentials,
-                                        deeplinkInfo: router.appState.deeplinkInfo
-                                    )
+                                    do {
+                                        try await router.handleLoggedInUserCredentials(
+                                            credentials,
+                                            deeplinkInfo: router.appState.deeplinkInfo
+                                        )
+                                    } catch {
+                                        log.error(error)
+                                    }
                                 }
                             }
                         }

--- a/DemoApp/Sources/Views/CallTopView/DemoCallTopView.swift
+++ b/DemoApp/Sources/Views/CallTopView/DemoCallTopView.swift
@@ -12,8 +12,6 @@ struct DemoCallTopView: View {
     @Injected(\.colors) var colors
     @Injected(\.images) var images
 
-    @ObservedObject private var reactionsAdapter = InjectedValues[\.reactionsAdapter]
-
     @ObservedObject var viewModel: CallViewModel
     @ObservedObject var appState = AppState.shared
     @State var sharingPopupDismissed = false
@@ -65,36 +63,6 @@ struct DemoCallTopView: View {
     private var hideLayoutMenu: Bool {
         viewModel.call?.state.screenSharingSession != nil
             && viewModel.call?.state.isCurrentUserScreensharing == false
-    }
-
-    @ViewBuilder
-    private func reactionsList() -> some View {
-        ForEach(availableReactions) { reaction in
-            Button {
-                reactionsAdapter.send(reaction: reaction.id == .lowerHand ? .raiseHand : reaction)
-            } label: {
-                Label(
-                    title: {
-                        Text(reaction.title)
-                    },
-                    icon: { Image(systemName: reaction.iconName) }
-                )
-            }
-        }
-    }
-
-    private var availableReactions: [Reaction] {
-        guard let userId = viewModel.localParticipant?.userId else {
-            return []
-        }
-
-        let hasRaisedHand = reactionsAdapter.activeReactions[userId]?.first(where: { $0.id == .raiseHand }) != nil
-
-        if hasRaisedHand {
-            return reactionsAdapter.availableReactions.filter { $0.id != .raiseHand }
-        } else {
-            return reactionsAdapter.availableReactions.filter { $0.id != .lowerHand }
-        }
     }
 }
 

--- a/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
@@ -87,9 +87,13 @@ struct DemoCallingViewModifier: ViewModifier {
         }
 
         Task {
-            try await streamVideo.connect()
-            await MainActor.run {
-                viewModel.joinCall(callType: callType, callId: callId)
+            do {
+                try await streamVideo.connect()
+                await MainActor.run {
+                    viewModel.joinCall(callType: callType, callId: callId)
+                }
+            } catch {
+                log.error(error)
             }
         }
     }

--- a/DemoApp/Sources/Views/CallView/DemoCallsViewModel.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallsViewModel.swift
@@ -30,9 +30,13 @@ class DemoCallsViewModel: ObservableObject {
     
     func loadEmployees() {
         Task {
-            let allEmployees = try await GoogleHelper.loadUsers()
-            self.streamEmployees = allEmployees.filter { $0.isFavorite == false }
-            self.favorites = allEmployees.filter { $0.isFavorite }
+            do {
+                let allEmployees = try await GoogleHelper.loadUsers()
+                self.streamEmployees = allEmployees.filter { $0.isFavorite == false }
+                self.favorites = allEmployees.filter { $0.isFavorite }
+            } catch {
+                log.error(error)
+            }
         }
     }
         

--- a/DemoApp/Sources/Views/CallsView/CallsViewModel.swift
+++ b/DemoApp/Sources/Views/CallsView/CallsViewModel.swift
@@ -42,7 +42,11 @@ final class CallsViewModel: ObservableObject {
 
     func loadCalls() {
         Task {
-            try await callsController.loadNextCalls()
+            do {
+                try await callsController.loadNextCalls()
+            } catch {
+                log.error(error)
+            }
         }
     }
 

--- a/DemoAppUIKit/SceneDelegate.swift
+++ b/DemoAppUIKit/SceneDelegate.swift
@@ -24,10 +24,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             rootView: NavigationView {
                 LoginView { [router] credentials in
                     Task {
-                        try await router.handleLoggedInUserCredentials(
-                            credentials,
-                            deeplinkInfo: router.appState.deeplinkInfo
-                        )
+                        do {
+                            try await router.handleLoggedInUserCredentials(
+                                credentials,
+                                deeplinkInfo: router.appState.deeplinkInfo
+                            )
+                        } catch {
+                            log.error(error)
+                        }
                     }
                 }
             }

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,3 @@
 nicklockwood/SwiftFormat@0.47.12
 SwiftGen/SwiftGen@6.5.1
+realm/SwiftLint@0.55.1

--- a/Sources/StreamVideo/Controllers/CallsController.swift
+++ b/Sources/StreamVideo/Controllers/CallsController.swift
@@ -180,8 +180,12 @@ public class CallsController: ObservableObject, @unchecked Sendable {
         prev = nil
         next = nil
         Task {
-            await state.update(loadedAllCalls: false)
-            try await loadCalls(shouldRefresh: true)
+            do {
+                await state.update(loadedAllCalls: false)
+                try await loadCalls(shouldRefresh: true)
+            } catch {
+                log.error(error)
+            }
         }
     }
     

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -624,7 +624,11 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     
     private func prefetchLocation() {
         Task {
-            self.cachedLocation = try await LocationFetcher.getLocation()
+            do {
+                self.cachedLocation = try await LocationFetcher.getLocation()
+            } catch {
+                log.error(error)
+            }
         }
     }
 }

--- a/Sources/StreamVideo/WebRTC/PeerConnection.swift
+++ b/Sources/StreamVideo/WebRTC/PeerConnection.swift
@@ -384,15 +384,19 @@ class PeerConnection: NSObject, RTCPeerConnectionDelegate, @unchecked Sendable {
             return
         }
         Task {
-            let encoder = JSONEncoder()
-            let iceCandidate = candidate.toIceCandidate()
-            let json = try encoder.encode(iceCandidate)
-            let jsonString = String(data: json, encoding: .utf8) ?? ""
-            var iceTrickle = Stream_Video_Sfu_Models_ICETrickle()
-            iceTrickle.iceCandidate = jsonString
-            iceTrickle.sessionID = sessionId
-            iceTrickle.peerType = type == .publisher ? .publisherUnspecified : .subscriber
-            _ = try await signalService.iceTrickle(iCETrickle: iceTrickle)
+            do {
+                let encoder = JSONEncoder()
+                let iceCandidate = candidate.toIceCandidate()
+                let json = try encoder.encode(iceCandidate)
+                let jsonString = String(data: json, encoding: .utf8) ?? ""
+                var iceTrickle = Stream_Video_Sfu_Models_ICETrickle()
+                iceTrickle.iceCandidate = jsonString
+                iceTrickle.sessionID = sessionId
+                iceTrickle.peerType = type == .publisher ? .publisherUnspecified : .subscriber
+                _ = try await signalService.iceTrickle(iCETrickle: iceTrickle)
+            } catch {
+                log.error(error)
+            }
         }
     }
 

--- a/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
+++ b/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
@@ -48,53 +48,57 @@ class SfuMiddleware: EventMiddleware {
     func handle(event: WrappedEvent) -> WrappedEvent? {
         log.debug("Received an event \(event)")
         Task {
-            guard case let .sfuEvent(event) = event else {
-                return
-            }
-            switch event {
-            case let .subscriberOffer(event):
-                await handleSubscriberEvent(event)
-            case .publisherAnswer:
-                log.warning("Publisher answer event shouldn't be sent")
-            case let .connectionQualityChanged(event):
-                await handleConnectionQualityChangedEvent(event)
-            case let .audioLevelChanged(event):
-                await handleAudioLevelsChanged(event)
-            case let .iceTrickle(event):
-                try await handleICETrickle(event)
-            case let .changePublishQuality(event):
-                handleChangePublishQualityEvent(event)
-            case let .participantJoined(event):
-                await handleParticipantJoined(event)
-            case let .participantLeft(event):
-                await handleParticipantLeft(event)
-            case let .dominantSpeakerChanged(event):
-                await handleDominantSpeakerChanged(event)
-            case let .joinResponse(event):
-                onSocketConnected?(event.reconnected)
-                await loadParticipants(from: event)
-            case let .healthCheckResponse(event):
-                onParticipantCountUpdated?(event.participantCount.total)
-            case let .trackPublished(event):
-                await handleTrackPublishedEvent(event)
-            case let .trackUnpublished(event):
-                await handleTrackUnpublishedEvent(event)
-            case let .error(event):
-                log.error(event.error.message, error: event.error)
-            case .callGrantsUpdated:
-                log.warning("TODO: callGrantsUpdated")
-            case let .goAway(event):
-                log.info("Received go away event with reason: \(event.reason.rawValue)")
-                onSessionMigrationEvent?()
-            case .iceRestart:
-                log.info("Received ice restart message")
-            case let .pinsUpdated(event):
-                log.debug("Pins changed \(event.pins.map(\.sessionID))")
-                onPinsChanged?(event.pins)
-            case let .callEnded(event):
-                log.debug("Received call ended event with reason \(event.reason)")
-            case let .participantUpdated(event):
-                await handleParticipantUpdated(event)
+            do {
+                guard case let .sfuEvent(event) = event else {
+                    return
+                }
+                switch event {
+                case let .subscriberOffer(event):
+                    await handleSubscriberEvent(event)
+                case .publisherAnswer:
+                    log.warning("Publisher answer event shouldn't be sent")
+                case let .connectionQualityChanged(event):
+                    await handleConnectionQualityChangedEvent(event)
+                case let .audioLevelChanged(event):
+                    await handleAudioLevelsChanged(event)
+                case let .iceTrickle(event):
+                    try await handleICETrickle(event)
+                case let .changePublishQuality(event):
+                    handleChangePublishQualityEvent(event)
+                case let .participantJoined(event):
+                    await handleParticipantJoined(event)
+                case let .participantLeft(event):
+                    await handleParticipantLeft(event)
+                case let .dominantSpeakerChanged(event):
+                    await handleDominantSpeakerChanged(event)
+                case let .joinResponse(event):
+                    onSocketConnected?(event.reconnected)
+                    await loadParticipants(from: event)
+                case let .healthCheckResponse(event):
+                    onParticipantCountUpdated?(event.participantCount.total)
+                case let .trackPublished(event):
+                    await handleTrackPublishedEvent(event)
+                case let .trackUnpublished(event):
+                    await handleTrackUnpublishedEvent(event)
+                case let .error(event):
+                    log.error(event.error.message, error: event.error)
+                case .callGrantsUpdated:
+                    log.warning("TODO: callGrantsUpdated")
+                case let .goAway(event):
+                    log.info("Received go away event with reason: \(event.reason.rawValue)")
+                    onSessionMigrationEvent?()
+                case .iceRestart:
+                    log.info("Received ice restart message")
+                case let .pinsUpdated(event):
+                    log.debug("Pins changed \(event.pins.map(\.sessionID))")
+                    onPinsChanged?(event.pins)
+                case let .callEnded(event):
+                    log.debug("Received call ended event with reason \(event.reason)")
+                case let .participantUpdated(event):
+                    await handleParticipantUpdated(event)
+                }
+            } catch {
+                log.error(error)
             }
         }
         return event

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantPopoverView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantPopoverView.swift
@@ -33,15 +33,23 @@ public struct ParticipantPopoverView<CustomView: View>: View {
                 ) {
                     if participant.isPinned {
                         Task {
-                            try await call?.unpin(
-                                sessionId: participant.sessionId
-                            )
+                            do {
+                                try await call?.unpin(
+                                    sessionId: participant.sessionId
+                                )
+                            } catch {
+                                log.error(error)
+                            }
                         }
                     } else {
                         Task {
-                            try await call?.pin(
-                                sessionId: participant.sessionId
-                            )
+                            do {
+                                try await call?.pin(
+                                    sessionId: participant.sessionId
+                                )
+                            } catch {
+                                log.error(error)
+                            }
                         }
                     }
                 }
@@ -54,17 +62,25 @@ public struct ParticipantPopoverView<CustomView: View>: View {
                 ) {
                     if participant.isPinnedRemotely {
                         Task {
-                            try await call?.unpinForEveryone(
-                                userId: participant.userId,
-                                sessionId: participant.id
-                            )
+                            do {
+                                _ = try await call?.unpinForEveryone(
+                                    userId: participant.userId,
+                                    sessionId: participant.id
+                                )
+                            } catch {
+                                log.error(error)
+                            }
                         }
                     } else {
                         Task {
-                            try await call?.pinForEveryone(
-                                userId: participant.userId,
-                                sessionId: participant.id
-                            )
+                            do {
+                                _ = try await call?.pinForEveryone(
+                                    userId: participant.userId,
+                                    sessionId: participant.id
+                                )
+                            } catch {
+                                log.error(error)
+                            }
                         }
                     }
                 }

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoViewModel.swift
@@ -97,21 +97,33 @@ class CallParticipantsInfoViewModel: ObservableObject {
     private func block(userId: String) {
         guard let call else { return }
         Task {
-            try await call.blockUser(with: userId)
+            do {
+                try await call.blockUser(with: userId)
+            } catch {
+                log.error(error)
+            }
         }
     }
     
     private func unblock(userId: String) {
         guard let call else { return }
         Task {
-            try await call.unblockUser(with: userId)
+            do {
+                try await call.unblockUser(with: userId)
+            } catch {
+                log.error(error)
+            }
         }
     }
     
     private func executeMute(userId: String, audio: Bool = true, video: Bool = true) {
         guard let call else { return }
         Task {
-            try await call.mute(userId: userId, audio: audio, video: video)
+            do {
+                try await call.mute(userId: userId, audio: audio, video: video)
+            } catch {
+                log.error(error)
+            }
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/InviteParticipantsViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/InviteParticipantsViewModel.swift
@@ -93,17 +93,21 @@ class InviteParticipantsViewModel: ObservableObject {
 
         loading = true
         Task {
-            let newUsers = try await userListProvider.loadNextUsers(
-                pagination: Pagination(pageSize: limit, offset: offset)
-            )
-            var temp = [User]()
-            for user in allUsers {
-                temp.append(user)
+            do {
+                let newUsers = try await userListProvider.loadNextUsers(
+                    pagination: Pagination(pageSize: limit, offset: offset)
+                )
+                var temp = [User]()
+                for user in allUsers {
+                    temp.append(user)
+                }
+                temp.append(contentsOf: newUsers)
+                allUsers = temp
+                offset = allUsers.count
+                loading = false
+            } catch {
+                log.error(error)
             }
-            temp.append(contentsOf: newUsers)
-            allUsers = temp
-            offset = allUsers.count
-            loading = false
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -232,35 +232,51 @@ public struct VideoCallParticipantOptionsModifier: ViewModifier {
 
     private func unpin() {
         Task {
-            try await call?.unpin(
-                sessionId: participant.sessionId
-            )
+            do {
+                try await call?.unpin(
+                    sessionId: participant.sessionId
+                )
+            } catch {
+                log.error(error)
+            }
         }
     }
 
     private func pin() {
         Task {
-            try await call?.pin(
-                sessionId: participant.sessionId
-            )
+            do {
+                try await call?.pin(
+                    sessionId: participant.sessionId
+                )
+            } catch {
+                log.error(error)
+            }
         }
     }
 
     private func unpinForEveryone() {
         Task {
-            try await call?.unpinForEveryone(
-                userId: participant.userId,
-                sessionId: participant.id
-            )
+            do {
+                _ = try await call?.unpinForEveryone(
+                    userId: participant.userId,
+                    sessionId: participant.id
+                )
+            } catch {
+                log.error(error)
+            }
         }
     }
 
     private func pinForEveryone() {
         Task {
-            try await call?.pinForEveryone(
-                userId: participant.userId,
-                sessionId: participant.id
-            )
+            do {
+                _ = try await call?.pinForEveryone(
+                    userId: participant.userId,
+                    sessionId: participant.id
+                )
+            } catch {
+                log.error(error)
+            }
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -397,9 +397,13 @@ open class CallViewModel: ObservableObject {
         callingState = .lobby(lobbyInfo)
         if !localCallSettingsChange {
             Task {
-                let call = streamVideo.call(callType: callType, callId: callId)
-                let info = try await call.get()
-                self.callSettings = info.call.settings.toCallSettings
+                do {
+                    let call = streamVideo.call(callType: callType, callId: callId)
+                    let info = try await call.get()
+                    self.callSettings = info.call.settings.toCallSettings
+                } catch {
+                    log.error(error)
+                }
             }
         }
     }
@@ -457,13 +461,21 @@ open class CallViewModel: ObservableObject {
 
     public func startScreensharing(type: ScreensharingType) {
         Task {
-            try await call?.startScreensharing(type: type)
+            do {
+                try await call?.startScreensharing(type: type)
+            } catch {
+                log.error(error)
+            }
         }
     }
 
     public func stopScreensharing() {
         Task {
-            try await call?.stopScreensharing()
+            do {
+                try await call?.stopScreensharing()
+            } catch {
+                log.error(error)
+            }
         }
     }
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningViewModel.swift
@@ -81,9 +81,13 @@ public class LobbyViewModel: ObservableObject, @unchecked Sendable {
     
     private func loadCurrentMembers() {
         Task {
-            let response = try await call.get()
-            withAnimation {
-                participants = response.call.session?.participants.map(\.user.toUser) ?? []
+            do {
+                let response = try await call.get()
+                withAnimation {
+                    participants = response.call.session?.participants.map(\.user.toUser) ?? []
+                }
+            } catch {
+                log.error(error)
             }
         }
     }

--- a/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayerViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayerViewModel.swift
@@ -66,19 +66,27 @@ final class LivestreamPlayerViewModel: ObservableObject {
     func muteLivestreamOnJoin() {
         guard !mutedOnJoin else { return }
         Task {
-            try await call.speaker.disableAudioOutput()
-            mutedOnJoin = true
+            do {
+                try await call.speaker.disableAudioOutput()
+                mutedOnJoin = true
+            } catch {
+                log.error(error)
+            }
         }
     }
     
     func toggleAudioOutput() {
         Task {
-            if !muted {
-                try await call.speaker.disableAudioOutput()
-            } else {
-                try await call.speaker.enableAudioOutput()
+            do {
+                if !muted {
+                    try await call.speaker.disableAudioOutput()
+                } else {
+                    try await call.speaker.enableAudioOutput()
+                }
+                muted.toggle()
+            } catch {
+                log.error(error)
             }
-            muted.toggle()
         }
     }
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -647,11 +647,9 @@ end
 desc 'Run source code formatting/linting'
 lane :run_swift_format do |options|
   Dir.chdir('..') do
-    swiftFormatAction = options[:lint] ? "--lint" : ""
-    swiftLintAction = options[:lint] ? "lint" : "analyze --fix"
-    
+    action = options[:lint] ? "--lint" : ""
     swiftformat_source_paths.each do |path|
-      sh("mint run swiftformat #{swiftFormatAction} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(',')} #{path}")
+      sh("mint run swiftformat #{action} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(',')} #{path}")
       sh("mint run swiftlint lint --config .swiftlint.yml --progress --quiet --reporter json #{path}")
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -647,10 +647,12 @@ end
 desc 'Run source code formatting/linting'
 lane :run_swift_format do |options|
   Dir.chdir('..') do
-    action = options[:lint] ? "--lint" : ""
-
+    swiftFormatAction = options[:lint] ? "--lint" : ""
+    swiftLintAction = options[:lint] ? "lint" : "analyze --fix"
+    
     swiftformat_source_paths.each do |path|
-      sh("mint run swiftformat #{action} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(',')} #{path}")
+      sh("mint run swiftformat #{swiftFormatAction} --config .swiftformat --exclude #{swiftformat_excluded_paths.join(',')} #{path}")
+      sh("mint run swiftlint lint --config .swiftlint.yml --progress --quiet --reporter json #{path}")
     end
   end
 end


### PR DESCRIPTION
### 🎯 Goal

Provide clear error logs for every task that can fail.

### 📝 Summary

SwiftConcurrency tasks swallowing any error that was thrown inside their body outside of an do/catch block ([reference](https://forums.swift.org/t/task-initializer-with-throwing-closure-swallows-error/56066)).

As those errors may produce unwanted behaviour we need to be able at least to track the error. 

### 🛠 Implementation

This PR does 2 things:
- Integrate SwiftLint into our swift format/lint flow. Currently the only rule that's enabled for swiftLint is the [unhandled_throwing_task](https://realm.github.io/SwiftLint/unhandled_throwing_task.html).
- Fixes all errors produced from SwiftLint by wrapping throwing operations inside tasks into simple do/catch blocks with error logging. Future implementations should consider more extensive error handling.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)