### PR TITLE
[Fix]Disappearing tracks due to lack of capability

### DIFF
--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -59,7 +59,27 @@ public class CallState: ObservableObject {
     @Published public internal(set) var recordingState: RecordingState = .noRecording
     @Published public internal(set) var blockedUserIds: Set<String> = []
     @Published public internal(set) var settings: CallSettingsResponse?
-    @Published public internal(set) var ownCapabilities: [OwnCapability] = []
+    @Published public internal(set) var ownCapabilities: [OwnCapability] = [] {
+        didSet {
+            let oldValue = Set(oldValue)
+            let newValue = Set(ownCapabilities)
+            guard newValue != oldValue else {
+                return
+            }
+            log.debug(
+                """
+                Updating ownCapabilities:
+                From:
+                \(oldValue.map(\.rawValue))
+
+                To:
+                \(ownCapabilities.map(\.rawValue))
+                """,
+                subsystems: .webRTC
+            )
+        }
+    }
+
     @Published public internal(set) var capabilitiesByRole: [String: [String]] = [:]
     @Published public internal(set) var backstage: Bool = false
     @Published public internal(set) var broadcasting: Bool = false

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -195,9 +195,17 @@ class CallController: @unchecked Sendable {
     }
     
     func updateOwnCapabilities(ownCapabilities: [OwnCapability]) {
-        if ownCapabilities != webRTCClient?.ownCapabilities {
-            webRTCClient?.ownCapabilities = ownCapabilities
+        guard let webRTCClient else {
+            return
         }
+        let oldValue = Set(webRTCClient.ownCapabilities)
+        let newValue = Set(ownCapabilities)
+
+        guard oldValue != newValue else {
+            return
+        }
+
+        webRTCClient.ownCapabilities = ownCapabilities
     }
 
     /// Initiates a focus operation at a specific point on the camera's view.


### PR DESCRIPTION
### 📝 Summary

We used to update the ownCapabilities for every received event. That was causing an issue where the ownCapabilities will be set back to empty. 

Now, we are observing the ownCapabilities and on every change update every related component.

### 🧪 Manual Testing Notes

Try by starting calls, sharing the url to a browser, let them join wait a few seconds and leave the call.

Repeat multiple times without breaks in the middle.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)