### PR TITLE
[Fix]Flakey tests on LLC and SwiftUI

### DIFF
--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -66,7 +66,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     private(set) var storage: [UUID: CallEntry] = [:]
     private var active: UUID?
 
-    private var callEventsSubscription: Task<Void, Never>?
+    private var callEventsSubscription: Task<Void, Error>?
     private var callEndedNotificationCancellable: AnyCancellable?
     private var ringingTimerCancellable: AnyCancellable?
 

--- a/Sources/StreamVideo/Controllers/CallsController.swift
+++ b/Sources/StreamVideo/Controllers/CallsController.swift
@@ -34,8 +34,8 @@ public class CallsController: ObservableObject, @unchecked Sendable {
     
     private var watchTask: Task<Void, Error>?
     private var socketDisconnected = false
-    private var cancellables = Set<AnyCancellable>()
-        
+    private var cancellables = DisposableBag()
+
     init(streamVideo: StreamVideo, callsQuery: CallsQuery) {
         self.callsQuery = callsQuery
         self.streamVideo = streamVideo
@@ -51,9 +51,6 @@ public class CallsController: ObservableObject, @unchecked Sendable {
     public func cleanUp() {
         watchTask?.cancel()
         watchTask = nil
-        for cancellable in cancellables {
-            cancellable.cancel()
-        }
         cancellables.removeAll()
     }
     
@@ -70,7 +67,7 @@ public class CallsController: ObservableObject, @unchecked Sendable {
                 self.reWatchCalls()
             }
         }
-        .store(in: &cancellables)
+        .store(in: cancellables)
     }
     
     private func loadCalls(shouldRefresh: Bool = false) async throws {

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -152,6 +152,10 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         (apiTransport as? URLSessionTransport)?.setTokenUpdater { [weak self] userToken in
             self?.token = userToken
         }
+
+        // Warm up
+        _ = eventNotificationCenter
+
         if user.type != .anonymous {
             let userAuth = UserAuth { [weak self] in
                 self?.token.rawValue ?? ""

--- a/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
+++ b/Sources/StreamVideo/Utils/AudioRecorder/StreamCallAudioRecorder.swift
@@ -21,7 +21,7 @@ open class StreamCallAudioRecorder: @unchecked Sendable {
     let audioSession: AudioSessionProtocol
 
     /// A private task responsible for setting up the recorder in the background.
-    private var setUpTask: Task<Void, Never>?
+    private var setUpTask: Task<Void, Error>?
 
     private var hasActiveCallCancellable: AnyCancellable?
 

--- a/Sources/StreamVideo/Utils/DisposableBag/DisposableBag.swift
+++ b/Sources/StreamVideo/Utils/DisposableBag/DisposableBag.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+public final class DisposableBag: Sequence {
+
+    private let queue = UnfairQueue()
+    private var storage: Set<AnyCancellable> = []
+
+    public init() {}
+
+    public func insert(_ cancellable: AnyCancellable) {
+        queue.sync {
+            _ = storage.insert(cancellable)
+        }
+    }
+
+    public func removeAll() {
+        queue.sync {
+            storage.forEach { $0.cancel() }
+            storage = []
+        }
+    }
+
+    // Sequence conformance
+    public func makeIterator() -> Set<AnyCancellable>.Iterator {
+        queue.sync {
+            storage.makeIterator()
+        }
+    }
+}
+
+extension AnyCancellable {
+    public func store(in disposableBag: DisposableBag) { disposableBag.insert(self) }
+}

--- a/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
+++ b/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
@@ -15,7 +15,7 @@ public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable {
     @Injected(\.streamVideo) private var streamVideo
 
     private var isActive: Bool = false
-    private var activationTask: Task<Void, Never>?
+    private var activationTask: Task<Void, Error>?
 
     private let name: String
     private let initializeClosure: (Int, Int) -> Void

--- a/Sources/StreamVideo/WebRTC/AudioSession.swift
+++ b/Sources/StreamVideo/WebRTC/AudioSession.swift
@@ -7,17 +7,17 @@ import StreamWebRTC
 
 actor AudioSession {
     
+    private let rtcAudioSession: RTCAudioSession = RTCAudioSession.sharedInstance()
+
     func configure(
         _ configuration: RTCAudioSessionConfiguration = .default,
         audioOn: Bool,
         speakerOn: Bool
     ) {
-        let audioSession: RTCAudioSession = RTCAudioSession.sharedInstance()
-        audioSession.lockForConfiguration()
-        audioSession.useManualAudio = true
-        audioSession.isAudioEnabled = true
-
-        defer { audioSession.unlockForConfiguration() }
+        rtcAudioSession.lockForConfiguration()
+        defer { rtcAudioSession.unlockForConfiguration() }
+        rtcAudioSession.useManualAudio = true
+        rtcAudioSession.isAudioEnabled = true
 
         do {
             log.debug("Configuring audio session")
@@ -28,18 +28,22 @@ actor AudioSession {
                 configuration.categoryOptions.remove(.defaultToSpeaker)
                 configuration.mode = AVAudioSession.Mode.voiceChat.rawValue
             }
-            try audioSession.setConfiguration(configuration, active: audioOn)
+            try rtcAudioSession.setConfiguration(configuration, active: audioOn)
         } catch {
             log.error("Error occured while configuring audio session", error: error)
         }
     }
     
     func setAudioSessionEnabled(_ enabled: Bool) {
-        let audioSession: RTCAudioSession = RTCAudioSession.sharedInstance()
-        audioSession.lockForConfiguration()
+        rtcAudioSession.lockForConfiguration()
+        defer { rtcAudioSession.unlockForConfiguration() }
+        rtcAudioSession.isAudioEnabled = enabled
+    }
 
-        defer { audioSession.unlockForConfiguration() }
-        audioSession.isAudioEnabled = enabled
+    deinit {
+        rtcAudioSession.lockForConfiguration()
+        rtcAudioSession.isAudioEnabled = false
+        rtcAudioSession.unlockForConfiguration()
     }
 }
 

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -164,7 +164,7 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     private var screenshareCapturer: VideoCapturing?
     private let user: User
     private let callCid: String
-    private let audioSession = AudioSession()
+    private lazy var audioSession = AudioSession()
     private var connectOptions: ConnectOptions?
     internal var ownCapabilities: [OwnCapability]
     private let videoConfig: VideoConfig

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -24,7 +24,6 @@ class WebRTCClient: NSObject, @unchecked Sendable {
             static let highParticipantDelay: UInt64 = 1_000_000_000
         }
         private var scheduledUpdate = false
-        private var cancellables = Set<AnyCancellable>()
         private(set) var lastUpdate: TimeInterval = Date().timeIntervalSince1970
         var connectionState = ConnectionState.disconnected(reason: nil) {
             didSet {
@@ -134,8 +133,8 @@ class WebRTCClient: NSObject, @unchecked Sendable {
         }
     }
     
-    let state: State
-    
+    private(set) var state: State
+
     let httpClient: HTTPClient
     var signalService: Stream_Video_Sfu_Signal_SignalServer
     let peerConnectionFactory: PeerConnectionFactory
@@ -182,7 +181,7 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     private var currentScreenhsareType: ScreensharingType?
     private var isFastReconnecting = false
     private var disconnectTime: Date?
-    private var addOnParticipantsChangeHandlerTask: Task<Void, Never>?
+    private var addOnParticipantsChangeHandlerTask: Task<Void, Error>?
     private lazy var callStatisticsReporter = StreamCallStatisticsReporter()
 
     @Injected(\.thermalStateObserver) private var thermalStateObserver
@@ -273,6 +272,7 @@ class WebRTCClient: NSObject, @unchecked Sendable {
 
     deinit {
         addOnParticipantsChangeHandlerTask?.cancel()
+        state = .init()
     }
 
     func connect(

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapter.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapter.swift
@@ -37,8 +37,6 @@ final class StreamPictureInPictureTrackStateAdapter {
 
     deinit {
         observerCancellable?.cancel()
-        isEnabled = false
-        activeTrack = nil
     }
 
     // MARK: - Private helpers
@@ -50,6 +48,8 @@ final class StreamPictureInPictureTrackStateAdapter {
     ///
     /// - Parameter isActive: A Boolean value indicating whether the observer should be active.
     private func enableObserver(_ isActive: Bool) {
+        observerCancellable?.cancel()
+        observerCancellable = nil
         if isActive {
             /// If 'isActive' is true, it sets up an observer that checks tracks state periodically.
             observerCancellable = Timer
@@ -62,17 +62,16 @@ final class StreamPictureInPictureTrackStateAdapter {
             log.debug("✅ Activated.")
         } else {
             /// If 'isActive' is false, it cancels the observer.
-            observerCancellable?.cancel()
-            observerCancellable = nil
             log.debug("❌ Disabled.")
         }
     }
 
     /// This private function checks the state of the active track and enables it if it's not already enabled.
     private func checkTracksState() {
+        let activeTrack = self.activeTrack
         if let activeTrack, !activeTrack.isEnabled {
             log.info("⚙️Active track:\(activeTrack.trackId) for picture-in-picture will be enabled now.")
-            self.activeTrack?.isEnabled = true
+            activeTrack.isEnabled = true
         }
     }
 }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		40B499CC2AC1A90F00A53B60 /* DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */; };
 		40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		40B713692A275F1400D1FE67 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8456E6C5287EB55F004E180E /* AppState.swift */; };
+		40C2B5B62C2B605A00EC2C2D /* DisposableBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */; };
 		40C4DF482C1C2BFC0035DBC2 /* LastParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */; };
 		40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */; };
 		40C4DF4B2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */; };
@@ -1342,6 +1343,7 @@
 		40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCallingViewModifier.swift; sourceTree = "<group>"; };
 		40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogDestination.swift; sourceTree = "<group>"; };
 		40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkTests.swift; sourceTree = "<group>"; };
+		40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableBag.swift; sourceTree = "<group>"; };
 		40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WeakAssign.swift"; sourceTree = "<group>"; };
 		40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
@@ -2819,6 +2821,14 @@
 			path = Events;
 			sourceTree = "<group>";
 		};
+		40C2B5B42C2B604800EC2C2D /* DisposableBag */ = {
+			isa = PBXGroup;
+			children = (
+				40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */,
+			);
+			path = DisposableBag;
+			sourceTree = "<group>";
+		};
 		40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */ = {
 			isa = PBXGroup;
 			children = (
@@ -3844,6 +3854,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40C2B5B42C2B604800EC2C2D /* DisposableBag */,
 				40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */,
 				408937892C062B0B000EEB69 /* UUIDProviding */,
 				403FF3DF2BA1D20E0092CE8A /* UnfairQueue */,
@@ -5142,6 +5153,7 @@
 				40FB02052BAC94FB00A1C206 /* CallKitPushNotificationAdapter.swift in Sources */,
 				84C4004129E3F446007B69C2 /* WSClientEvent.swift in Sources */,
 				84AF64D5287C79320012A503 /* RawJSON.swift in Sources */,
+				40C2B5B62C2B605A00EC2C2D /* DisposableBag.swift in Sources */,
 				84F73858287C1A3400A363F4 /* ConnectionState.swift in Sources */,
 				846E4B0129D2D372003733AB /* Sorting.swift in Sources */,
 				841BAA3F2BD15CDE000C73E4 /* QueryCallStatsRequest.swift in Sources */,

--- a/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideoSwiftUI.xcscheme
+++ b/StreamVideo.xcodeproj/xcshareddata/xcschemes/StreamVideoSwiftUI.xcscheme
@@ -59,6 +59,18 @@
       debugServiceExtension = "internal"
       enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/StreamVideoTests/StreamVideo_Tests.swift
+++ b/StreamVideoTests/StreamVideo_Tests.swift
@@ -143,10 +143,6 @@ final class StreamVideo_Tests: StreamVideoTestCase {
             streamVideo.state.activeCall == nil
                 && streamVideo.state.ringingCall == nil
         }
-
-        // Then
-        XCTAssert(streamVideo.state.ringingCall == nil)
-        XCTAssert(streamVideo.state.activeCall == nil)
     }
     
     func test_streamVideo_incomingCallAccept() async throws {


### PR DESCRIPTION
### 🎯 Goal

Fix flakiness on LLC and SwiftUI tests.

### 📝 Summary

#### LLC
The main reasons for our failing tests seems to be:
1. Updating cancellables storage from multiple threads
2. Using assert methods that are simply waiting for a specified amount of time (i didn't eliminate all of them as there are many, i just fixed the ones failing very often)
3. RTCVideoTracks need to be set to `enabled = false` before deallocation

#### SwiftUI
The main reasons for our failing tests seems to be:
1. Our AudioSession wrapper needs to disable the RTCAudioSession on deinit
2. PeerConnectionFactory needs to cleanUpSSL on deinit (thanks WebRTC for the [docs](https://github.com/ahoyconference/webrtc-ios/blob/master/WebRTC.framework/Headers/RTCSSLAdapter.h). I also did some cleanup for the factory as it seems it had many unnecessary things on it (e.g being an actor when it doesn't maintain any local state, using static methods)
3. Lazily create AudioSession objects
4. Small rewrites on PiPAdapter
5. Make sure that RTCVideoTracks created from Tests are being disabled on tearDown

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)