### PR TITLE
[Enhancement]Provide call rejection reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Support for custom participant sorting in the Call object. [#438](https://github.com/GetStream/stream-video-swift/pull/438)
 - Ability to join call in advance with joinAheadTimeSeconds parameter. [#446](https://github.com/GetStream/stream-video-swift/pull/446)
+- Missed calls support [#449](https://github.com/GetStream/stream-video-swift/pull/449)
 
 # [1.0.8](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.8)
 _June 17, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for custom participant sorting in the Call object. [#438](https://github.com/GetStream/stream-video-swift/pull/438)
 - Ability to join call in advance with joinAheadTimeSeconds parameter. [#446](https://github.com/GetStream/stream-video-swift/pull/446)
 - Missed calls support [#449](https://github.com/GetStream/stream-video-swift/pull/449)
+- IncomingCallViewModel has been simplified and the `hideIncomingCallScreen` property as also the `stopTimer` have been removed. [#449](https://github.com/GetStream/stream-video-swift/pull/449)
 
 # [1.0.8](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.8)
 _June 17, 2024_

--- a/DemoApp/Sources/Examples/Examples.swift
+++ b/DemoApp/Sources/Examples/Examples.swift
@@ -256,14 +256,6 @@ struct CustomIncomingCallView: View {
             .padding()
         }
         .background(Color.white.edgesIgnoringSafeArea(.all))
-        .onChange(of: viewModel.hideIncomingCallScreen) { newValue in
-            if newValue {
-                callViewModel.rejectCall(callType: callInfo.type, callId: callInfo.id)
-            }
-        }
-        .onDisappear {
-            viewModel.stopTimer()
-        }
     }
     
     var callInfo: IncomingCall {

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/05-incoming-call.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/05-incoming-call.swift
@@ -80,20 +80,11 @@ fileprivate func content() {
 
                 }
                 .background(Color.white.edgesIgnoringSafeArea(.all))
-                .onChange(of: viewModel.hideIncomingCallScreen) { newValue in
-                    if newValue {
-                        callViewModel.rejectCall(callType: callInfo.type, callId: callInfo.id)
-                    }
-                }
-                .onDisappear {
-                    viewModel.stopTimer()
-                }
             }
 
             var callInfo: IncomingCall {
                 viewModel.callInfo
             }
-
         }
 
         class CustomViewFactory: ViewFactory {

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -342,13 +342,19 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 """
             )
             do {
-                try await stackEntry.call.reject(
-                    reason: rejectionReasonProvider
-                        .rejectionReason(
-                            for: stackEntry.call.cId,
-                            ringTimeout: false
-                        )
+                let rejectionReason = rejectionReasonProvider
+                    .rejectionReason(
+                        for: stackEntry.call.cId,
+                        ringTimeout: false
+                    )
+                log.debug(
+                    """
+                    Rejecting with reason: \(rejectionReason ?? "nil")
+                    call:\(stackEntry.call.callId)
+                    callType: \(stackEntry.call.callType)
+                    """
                 )
+                try await stackEntry.call.reject(reason: rejectionReason)
             } catch {
                 log.error(error)
             }

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -12,7 +12,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
     @Injected(\.callCache) private var callCache
     @Injected(\.uuidFactory) private var uuidFactory
-    @Injected(\.rejectionReasonProvider) private var rejectionReasonProvider
 
     /// Represents a call that is being managed by the service.
     final class CallEntry: Equatable, @unchecked Sendable {
@@ -342,8 +341,9 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 """
             )
             do {
-                let rejectionReason = rejectionReasonProvider
-                    .rejectionReason(
+                let rejectionReason = streamVideo?
+                    .rejectionReasonProvider
+                    .reason(
                         for: stackEntry.call.cId,
                         ringTimeout: false
                     )
@@ -419,7 +419,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// - Parameter streamVideo: The new StreamVideo instance (nil if none)
     open func didUpdate(_ streamVideo: StreamVideo?) {
         subscribeToCallEvents()
-        rejectionReasonProvider.streamVideo = streamVideo
     }
 
     // MARK: - Private helpers

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -158,9 +158,11 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 } else {
                     log.debug(
                         """
-                        Rejecting VoIP incoming call with callUUID:\(callUUID)
-                        cid:\(cid) callerId:\(callerId) callerName:\(localizedCallerName)
-                        as it has been handled.
+                        Rejecting VoIP incoming call as it has been handled.
+                        callUUID:\(callUUID)
+                        cid:\(cid) 
+                        callerId:\(callerId)
+                        callerName:\(localizedCallerName)
                         """
                     )
                     callEnded(cid)
@@ -343,7 +345,8 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 try await stackEntry.call.reject(
                     reason: rejectionReasonProvider
                         .rejectionReason(
-                            for: stackEntry.call.cId
+                            for: stackEntry.call.cId,
+                            ringTimeout: false
                         )
                 )
             } catch {

--- a/Sources/StreamVideo/Models/Extensions/RejectCallRequest+Reason.swift
+++ b/Sources/StreamVideo/Models/Extensions/RejectCallRequest+Reason.swift
@@ -18,5 +18,8 @@ extension RejectCallRequest {
 
         /// Indicates that the caller cancels the call.
         public static let cancel = "cancel"
+
+        /// Indicates that the callee didn't answer the call in a given time amount.
+        public static let timeout = "timeout"
     }
 }

--- a/Sources/StreamVideo/Models/Extensions/RejectCallRequest+Reason.swift
+++ b/Sources/StreamVideo/Models/Extensions/RejectCallRequest+Reason.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An extension of `RejectCallRequest` that defines various reasons for rejecting a call.
+extension RejectCallRequest {
+
+    /// Enum containing possible reasons for rejecting a call.
+    public enum Reason {
+
+        /// Indicates that the callee is busy and cannot accept the call.
+        public static let busy = "busy"
+
+        /// Indicates that the callee intentionally declines the call.
+        public static let decline = "decline"
+
+        /// Indicates that the caller cancels the call.
+        public static let cancel = "cancel"
+    }
+}

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -187,8 +187,12 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
                     log.error("Error connecting as guest", error: error)
                 }
             } else {
-                try Task.checkCancellation()
-                try await self.connectUser(isInitial: true)
+                do {
+                    try Task.checkCancellation()
+                    try await self.connectUser(isInitial: true)
+                } catch {
+                    log.error(error)
+                }
             }
         }
     }

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -48,6 +48,9 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     /// Provides information regarding hardware-acceleration capabilities (neuralEngine) on device.
     public var isHardwareAccelerationAvailable: Bool { neuralEngineExists }
 
+    /// A protocol that provides a method to determine the rejection reason for a call.
+    public lazy var rejectionReasonProvider: RejectionReasonProviding = StreamRejectionReasonProvider(self)
+
     var token: UserToken
 
     private var tokenProvider: UserTokenProvider

--- a/Sources/StreamVideo/Utils/RejectionReasonProvider/RejectionReasonProvider.swift
+++ b/Sources/StreamVideo/Utils/RejectionReasonProvider/RejectionReasonProvider.swift
@@ -8,9 +8,6 @@ import Foundation
 /// A protocol that provides a method to determine the rejection reason for a call.
 public protocol RejectionReasonProviding {
 
-    /// The stream video associated with this provider.
-    var streamVideo: StreamVideo? { get set }
-
     /// Determines the rejection reason for a call with the specified call ID.
     ///
     /// - Parameters:
@@ -22,36 +19,34 @@ public protocol RejectionReasonProviding {
     ///
     /// - Note: ``ringTimeout`` being true, has an effect **only** when it's set  from the side of
     /// the caller when the callee doesn't reply the ringing call in the amount of time set on the dashboard.
-    func rejectionReason(for callCid: String, ringTimeout: Bool) -> String?
+    func reason(for callCid: String, ringTimeout: Bool) -> String?
 }
 
 /// A provider that determines the rejection reason for a call based on its state.
 final class StreamRejectionReasonProvider: RejectionReasonProviding {
 
     /// The stream video associated with this provider.
-    var streamVideo: StreamVideo? {
-        didSet { didUpdate(streamVideo) }
-    }
-
-    /// The currently active call, if any.
-    private weak var activeCall: Call?
-
-    /// The currently ringing call, if any.
-    private weak var ringingCall: Call?
+    private weak var streamVideo: StreamVideo?
 
     /// A container for managing cancellable subscriptions.
     private let cancellables: DisposableBag = .init()
 
+    init(_ streamVideo: StreamVideo) {
+        self.streamVideo = streamVideo
+    }
+
     // MARK: - RejectionReasonProviding
 
     @MainActor
-    func rejectionReason(
+    func reason(
         for callCid: String,
         ringTimeout: Bool
     ) -> String? {
+        let activeCall = streamVideo?.state.activeCall
+
         guard
-            ringingCall?.cId == callCid,
-            let rejectingCall = ringingCall
+            let rejectingCall = streamVideo?.state.ringingCall,
+            rejectingCall.cId == callCid
         else {
             return nil
         }
@@ -68,38 +63,5 @@ final class StreamRejectionReasonProvider: RejectionReasonProviding {
         } else {
             return RejectCallRequest.Reason.decline
         }
-    }
-
-    // MARK: - Private helpers
-
-    /// Updates the provider with the new stream video and sets up subscriptions to its state.
-    ///
-    /// - Parameter streamVideo: The new stream video to associate with this provider.
-    private func didUpdate(_ streamVideo: StreamVideo?) {
-        cancellables.removeAll()
-        guard let streamVideo else { return }
-
-        streamVideo
-            .state
-            .$activeCall
-            .assign(to: \.activeCall, onWeak: self)
-            .store(in: cancellables)
-
-        streamVideo
-            .state
-            .$ringingCall
-            .assign(to: \.ringingCall, onWeak: self)
-            .store(in: cancellables)
-    }
-}
-
-enum RejectionReasonProviderKey: InjectionKey {
-    static var currentValue: RejectionReasonProviding = StreamRejectionReasonProvider()
-}
-
-extension InjectedValues {
-    public var rejectionReasonProvider: RejectionReasonProviding {
-        get { Self[RejectionReasonProviderKey.self] }
-        set { Self[RejectionReasonProviderKey.self] = newValue }
     }
 }

--- a/Sources/StreamVideo/Utils/RejectionReasonProvider/RejectionReasonProvider.swift
+++ b/Sources/StreamVideo/Utils/RejectionReasonProvider/RejectionReasonProvider.swift
@@ -1,0 +1,95 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// A protocol that provides a method to determine the rejection reason for a call.
+public protocol RejectionReasonProviding {
+
+    /// The stream video associated with this provider.
+    var streamVideo: StreamVideo? { get set }
+
+    /// Determines the rejection reason for a call with the specified call ID.
+    ///
+    /// - Parameter callCid: The call ID to evaluate.
+    /// - Returns: A string representing the rejection reason, or `nil` if there is no reason to reject
+    /// the call.
+    func rejectionReason(for callCid: String) -> String?
+}
+
+/// A provider that determines the rejection reason for a call based on its state.
+final class StreamRejectionReasonProvider: RejectionReasonProviding {
+
+    /// The stream video associated with this provider.
+    var streamVideo: StreamVideo? {
+        didSet { didUpdate(streamVideo) }
+    }
+
+    /// The currently active call, if any.
+    private weak var activeCall: Call?
+
+    /// The currently ringing call, if any.
+    private weak var ringingCall: Call?
+
+    /// A container for managing cancellable subscriptions.
+    private let cancellables: DisposableBag = .init()
+
+    // MARK: - RejectionReasonProviding
+
+    /// Determines the rejection reason for a call with the specified call ID.
+    ///
+    /// - Parameter callCid: The call ID to evaluate.
+    /// - Returns: A string representing the rejection reason, or `nil` if there is no reason to reject
+    /// the call.
+    func rejectionReason(for callCid: String) -> String? {
+        let activeCall = self.activeCall
+        let ringingCall = self.ringingCall
+
+        if callCid == activeCall?.cId {
+            return nil
+        } else if callCid == ringingCall?.cId {
+            if activeCall != nil {
+                return RejectCallRequest.Reason.busy
+            } else {
+                return RejectCallRequest.Reason.decline
+            }
+        } else {
+            return nil
+        }
+    }
+
+    // MARK: - Private helpers
+
+    /// Updates the provider with the new stream video and sets up subscriptions to its state.
+    ///
+    /// - Parameter streamVideo: The new stream video to associate with this provider.
+    private func didUpdate(_ streamVideo: StreamVideo?) {
+        cancellables.removeAll()
+        guard let streamVideo else { return }
+
+        streamVideo
+            .state
+            .$activeCall
+            .assign(to: \.activeCall, onWeak: self)
+            .store(in: cancellables)
+
+        streamVideo
+            .state
+            .$ringingCall
+            .assign(to: \.ringingCall, onWeak: self)
+            .store(in: cancellables)
+    }
+}
+
+enum RejectionReasonProviderKey: InjectionKey {
+    static var currentValue: RejectionReasonProviding = StreamRejectionReasonProvider()
+}
+
+extension InjectedValues {
+    public var rejectionReasonProvider: RejectionReasonProviding {
+        get { Self[RejectionReasonProviderKey.self] }
+        set { Self[RejectionReasonProviderKey.self] = newValue }
+    }
+}

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -14,6 +14,7 @@ open class CallViewModel: ObservableObject {
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.pictureInPictureAdapter) var pictureInPictureAdapter
     @Injected(\.callAudioRecorder) var audioRecorder
+    @Injected(\.rejectionReasonProvider) var rejectionReasonProvider
 
     /// Provides access to the current call.
     @Published public private(set) var call: Call? {
@@ -430,10 +431,15 @@ open class CallViewModel: ObservableObject {
     /// - Parameters:
     ///  - callType: the type of the call.
     ///  - callId: the id of the call.
-    public func rejectCall(callType: String, callId: String) {
+    public func rejectCall(
+        callType: String,
+        callId: String
+    ) {
         Task {
             let call = streamVideo.call(callType: callType, callId: callId)
-            _ = try? await call.reject()
+            let rejectionReason = rejectionReasonProvider
+                .rejectionReason(for: call.cId)
+            _ = try? await call.reject(reason: rejectionReason)
             self.callingState = .idle
         }
     }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -439,6 +439,14 @@ open class CallViewModel: ObservableObject {
             let call = streamVideo.call(callType: callType, callId: callId)
             let rejectionReason = rejectionReasonProvider
                 .rejectionReason(for: call.cId, ringTimeout: false)
+            log.debug(
+                """
+                Rejecting with reason: \(rejectionReason ?? "nil")
+                call:\(call.callId)
+                callType: \(call.callType)
+                ringTimeout: \(false)
+                """
+            )
             _ = try? await call.reject(reason: rejectionReason)
             self.callingState = .idle
         }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -14,7 +14,6 @@ open class CallViewModel: ObservableObject {
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.pictureInPictureAdapter) var pictureInPictureAdapter
     @Injected(\.callAudioRecorder) var audioRecorder
-    @Injected(\.rejectionReasonProvider) var rejectionReasonProvider
 
     /// Provides access to the current call.
     @Published public private(set) var call: Call? {
@@ -437,8 +436,9 @@ open class CallViewModel: ObservableObject {
     ) {
         Task {
             let call = streamVideo.call(callType: callType, callId: callId)
-            let rejectionReason = rejectionReasonProvider
-                .rejectionReason(for: call.cId, ringTimeout: false)
+            let rejectionReason = streamVideo
+                .rejectionReasonProvider
+                .reason(for: call.cId, ringTimeout: false)
             log.debug(
                 """
                 Rejecting with reason: \(rejectionReason ?? "nil")
@@ -645,8 +645,9 @@ open class CallViewModel: ObservableObject {
 
         Task {
             do {
-                let rejectionReason = rejectionReasonProvider
-                    .rejectionReason(for: call.cId, ringTimeout: ringTimeout)
+                let rejectionReason = streamVideo
+                    .rejectionReasonProvider
+                    .reason(for: call.cId, ringTimeout: ringTimeout)
                 log.debug(
                     """
                     Rejecting with reason: \(rejectionReason ?? "nil")

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -639,6 +639,14 @@ open class CallViewModel: ObservableObject {
             do {
                 let rejectionReason = rejectionReasonProvider
                     .rejectionReason(for: call.cId, ringTimeout: ringTimeout)
+                log.debug(
+                    """
+                    Rejecting with reason: \(rejectionReason ?? "nil")
+                    call:\(call.callId)
+                    callType: \(call.callType)
+                    ringTimeout: \(ringTimeout)
+                    """
+                )
                 try await call.reject(reason: rejectionReason)
             } catch {
                 log.error(error)

--- a/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallView.swift
@@ -43,14 +43,6 @@ public struct IncomingCallView: View {
             onCallAccepted: onCallAccepted,
             onCallRejected: onCallRejected
         )
-        .onChange(of: viewModel.hideIncomingCallScreen) { newValue in
-            if newValue {
-                onCallRejected(viewModel.callInfo.id)
-            }
-        }
-        .onDisappear {
-            viewModel.stopTimer()
-        }
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallViewModel.swift
@@ -13,37 +13,11 @@ public class IncomingViewModel: ObservableObject {
     
     public private(set) var callInfo: IncomingCall
     
-    @Published public var hideIncomingCallScreen = false
-    
     var callParticipants: [Member] {
         callInfo.members.filter { $0.id != streamVideo.user.id }
     }
     
-    private var ringingTimer: Foundation.Timer?
-    
     public init(callInfo: IncomingCall) {
         self.callInfo = callInfo
-        startTimer(timeout: callInfo.timeout)
-    }
-    
-    private func startTimer(timeout: TimeInterval) {
-        ringingTimer = Foundation.Timer.scheduledTimer(
-            withTimeInterval: timeout,
-            repeats: false,
-            block: { [weak self] _ in
-                guard let self = self else { return }
-                log.debug("Detected ringing timeout, hanging up...")
-                Task {
-                    await MainActor.run {
-                        self.hideIncomingCallScreen = true
-                    }
-                }
-            }
-        )
-    }
-    
-    public func stopTimer() {
-        ringingTimer?.invalidate()
-        ringingTimer = nil
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/IncomingCallView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/IncomingCallView_iOS13.swift
@@ -37,13 +37,5 @@ public struct IncomingCallView_iOS13: View {
             onCallAccepted: onCallAccepted,
             onCallRejected: onCallRejected
         )
-        .onReceive(viewModel.$hideIncomingCallScreen, perform: { value in
-            if value {
-                onCallRejected(viewModel.callInfo.id)
-            }
-        })
-        .onDisappear {
-            viewModel.stopTimer()
-        }
     }
 }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		40C2B5B62C2B605A00EC2C2D /* DisposableBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */; };
 		40C2B5BB2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5BA2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift */; };
 		40C2B5BE2C2C448200EC2C2D /* RejectionReasonProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5BD2C2C448200EC2C2D /* RejectionReasonProvider.swift */; };
+		40C2B5C62C2D7AED00EC2C2D /* RejectionReasonProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5C52C2D7AED00EC2C2D /* RejectionReasonProvider_Tests.swift */; };
 		40C4DF482C1C2BFC0035DBC2 /* LastParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */; };
 		40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */; };
 		40C4DF4B2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */; };
@@ -1348,6 +1349,7 @@
 		40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableBag.swift; sourceTree = "<group>"; };
 		40C2B5BA2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RejectCallRequest+Reason.swift"; sourceTree = "<group>"; };
 		40C2B5BD2C2C448200EC2C2D /* RejectionReasonProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RejectionReasonProvider.swift; sourceTree = "<group>"; };
+		40C2B5C52C2D7AED00EC2C2D /* RejectionReasonProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RejectionReasonProvider_Tests.swift; sourceTree = "<group>"; };
 		40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WeakAssign.swift"; sourceTree = "<group>"; };
 		40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
@@ -2849,6 +2851,14 @@
 			path = RejectionReasonProvider;
 			sourceTree = "<group>";
 		};
+		40C2B5C42C2D7ADE00EC2C2D /* RejectionReasonProvider */ = {
+			isa = PBXGroup;
+			children = (
+				40C2B5C52C2D7AED00EC2C2D /* RejectionReasonProvider_Tests.swift */,
+			);
+			path = RejectionReasonProvider;
+			sourceTree = "<group>";
+		};
 		40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */ = {
 			isa = PBXGroup;
 			children = (
@@ -3424,6 +3434,7 @@
 		842747F429EEDACB00E063AD /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40C2B5C42C2D7ADE00EC2C2D /* RejectionReasonProvider */,
 				40C4DF4E2C1C41470035DBC2 /* ParticipantAutoLeavePolicy */,
 				403FB14A2BFE14690047A696 /* StateMachine */,
 				8490031829D2E0DF00AD9BB4 /* Sorting_Tests.swift */,
@@ -5572,6 +5583,7 @@
 				84F58B9329EEB53E00010C4C /* EventMiddleware_Mock.swift in Sources */,
 				842747EC29EED59000E063AD /* JSONDecoder_Tests.swift in Sources */,
 				841FF5052A5D815700809BBB /* VideoCapturerUtils_Tests.swift in Sources */,
+				40C2B5C62C2D7AED00EC2C2D /* RejectionReasonProvider_Tests.swift in Sources */,
 				403FB15C2BFE22170047A696 /* StreamCallStateMachineStageAcceptingStage_Tests.swift in Sources */,
 				841FF5172A5EA7F600809BBB /* CallParticipants_Tests.swift in Sources */,
 				40F017452BBEEE6D00E89FD1 /* UserResponse+Dummy.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -275,6 +275,8 @@
 		40B499CE2AC1AA0900A53B60 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
 		40B713692A275F1400D1FE67 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8456E6C5287EB55F004E180E /* AppState.swift */; };
 		40C2B5B62C2B605A00EC2C2D /* DisposableBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */; };
+		40C2B5BB2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5BA2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift */; };
+		40C2B5BE2C2C448200EC2C2D /* RejectionReasonProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C2B5BD2C2C448200EC2C2D /* RejectionReasonProvider.swift */; };
 		40C4DF482C1C2BFC0035DBC2 /* LastParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */; };
 		40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */; };
 		40C4DF4B2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */; };
@@ -1344,6 +1346,8 @@
 		40B499C92AC1A5E100A53B60 /* OSLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogDestination.swift; sourceTree = "<group>"; };
 		40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkTests.swift; sourceTree = "<group>"; };
 		40C2B5B52C2B605A00EC2C2D /* DisposableBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableBag.swift; sourceTree = "<group>"; };
+		40C2B5BA2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RejectCallRequest+Reason.swift"; sourceTree = "<group>"; };
+		40C2B5BD2C2C448200EC2C2D /* RejectionReasonProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RejectionReasonProvider.swift; sourceTree = "<group>"; };
 		40C4DF412C1C215E0035DBC2 /* LastParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WeakAssign.swift"; sourceTree = "<group>"; };
 		40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
@@ -2829,6 +2833,22 @@
 			path = DisposableBag;
 			sourceTree = "<group>";
 		};
+		40C2B5B92C2C41CF00EC2C2D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				40C2B5BA2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		40C2B5BC2C2C447700EC2C2D /* RejectionReasonProvider */ = {
+			isa = PBXGroup;
+			children = (
+				40C2B5BD2C2C448200EC2C2D /* RejectionReasonProvider.swift */,
+			);
+			path = RejectionReasonProvider;
+			sourceTree = "<group>";
+		};
 		40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */ = {
 			isa = PBXGroup;
 			children = (
@@ -3603,6 +3623,7 @@
 		8456E6D9287EC46D004E180E /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				40C2B5B92C2C41CF00EC2C2D /* Extensions */,
 				84AF64D1287C78E70012A503 /* User.swift */,
 				84AF64D6287C79610012A503 /* Token.swift */,
 				84C2997828784B180034B735 /* CallType.swift */,
@@ -3854,6 +3875,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40C2B5BC2C2C447700EC2C2D /* RejectionReasonProvider */,
 				40C2B5B42C2B604800EC2C2D /* DisposableBag */,
 				40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */,
 				408937892C062B0B000EEB69 /* UUIDProviding */,
@@ -5199,6 +5221,7 @@
 				84DCA20E2A3885FE000C3411 /* Permissions.swift in Sources */,
 				842E70D82B91BE1700D2D68B /* StatsOptions.swift in Sources */,
 				84BAD77E2A6BFFB200733156 /* BroadcastSampleHandler.swift in Sources */,
+				40C2B5BB2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift in Sources */,
 				840042C92A6FF9A200917B30 /* BroadcastConstants.swift in Sources */,
 				84F73854287C1A2D00A363F4 /* InjectedValuesExtensions.swift in Sources */,
 				841BAA462BD15CDE000C73E4 /* CallStatsReportSummaryResponse.swift in Sources */,
@@ -5338,6 +5361,7 @@
 				842B8E162A2DFED900863A87 /* CallRingEvent.swift in Sources */,
 				842B8E2D2A2DFED900863A87 /* StopTranscriptionResponse.swift in Sources */,
 				400E50532BD2A900008C939E /* StreamAudioFilterCapturePostProcessingModule.swift in Sources */,
+				40C2B5BE2C2C448200EC2C2D /* RejectionReasonProvider.swift in Sources */,
 				842D3B5A29F667660051698A /* ModelResponse.swift in Sources */,
 				8469593729BB6B4E00134EA0 /* EdgeResponse.swift in Sources */,
 				841BAA412BD15CDE000C73E4 /* Subsession.swift in Sources */,

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -15,7 +15,7 @@ final class MockCall: Call, Mockable {
         case join
     }
 
-    var stubbedProperty: [String: Any] = [:]
+    var stubbedProperty: [String: Any]
     var stubbedFunction: [FunctionKey: Any] = [:]
 
     override var state: CallState {
@@ -23,10 +23,15 @@ final class MockCall: Call, Mockable {
         set { _ = newValue }
     }
 
-    convenience init(
+    @MainActor
+    init(
         _ source: Call = .dummy()
     ) {
-        self.init(
+        stubbedProperty = [
+            MockCall.propertyKey(for: \.state): CallState()
+        ]
+
+        super.init(
             callType: source.callType,
             callId: source.callId,
             coordinatorClient: source.coordinatorClient,

--- a/StreamVideoTests/Mock/MockStreamVideo.swift
+++ b/StreamVideoTests/Mock/MockStreamVideo.swift
@@ -33,6 +33,11 @@ final class MockStreamVideo: StreamVideo, Mockable {
         pushNotificationsConfig: PushNotificationsConfig = .default,
         environment: Environment = .init()
     ) {
+        var stubbedProperty = stubbedProperty
+        if stubbedProperty[MockStreamVideo.propertyKey(for: \.state)] == nil {
+            stubbedProperty[MockStreamVideo.propertyKey(for: \.state)] = MockStreamVideo.State(user: user)
+        }
+
         self.stubbedProperty = stubbedProperty
         self.stubbedFunction = stubbedFunction
 

--- a/StreamVideoTests/Utils/RejectionReasonProvider/RejectionReasonProvider_Tests.swift
+++ b/StreamVideoTests/Utils/RejectionReasonProvider/RejectionReasonProvider_Tests.swift
@@ -9,11 +9,7 @@ import XCTest
 final class StreamRejectionReasonProviderTests: XCTestCase {
 
     private lazy var mockStreamVideo: MockStreamVideo! = MockStreamVideo()
-    private lazy var subject: StreamRejectionReasonProvider! = {
-        let subject = StreamRejectionReasonProvider()
-        subject.streamVideo = mockStreamVideo
-        return subject
-    }()
+    private lazy var subject: StreamRejectionReasonProvider! = StreamRejectionReasonProvider(mockStreamVideo)
 
     override func tearDown() {
         subject = nil
@@ -27,7 +23,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase {
         mockStreamVideo.state.activeCall = MockCall(.dummy())
         mockStreamVideo.state.ringingCall = ringingCall
 
-        let reason = subject.rejectionReason(
+        let reason = subject.reason(
             for: ringingCall.cId,
             ringTimeout: true
         )
@@ -42,7 +38,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase {
         mockStreamVideo.state.ringingCall = ringingCall
         ringingCall.state.createdBy = mockStreamVideo.user
 
-        let reason = subject.rejectionReason(
+        let reason = subject.reason(
             for: ringingCall.cId,
             ringTimeout: true
         )
@@ -57,7 +53,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase {
         mockStreamVideo.state.ringingCall = ringingCall
         ringingCall.state.createdBy = mockStreamVideo.user
 
-        let reason = subject.rejectionReason(
+        let reason = subject.reason(
             for: ringingCall.cId,
             ringTimeout: false
         )
@@ -72,7 +68,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase {
         mockStreamVideo.state.ringingCall = ringingCall
         ringingCall.state.createdBy = .dummy()
 
-        let reason = subject.rejectionReason(
+        let reason = subject.reason(
             for: ringingCall.cId,
             ringTimeout: false
         )
@@ -86,7 +82,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase {
         mockStreamVideo.state.ringingCall = ringingCall
         ringingCall.state.createdBy = .dummy()
 
-        let reason = subject.rejectionReason(
+        let reason = subject.reason(
             for: .unique,
             ringTimeout: false
         )
@@ -96,7 +92,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase {
 
     @MainActor
     func test_rejectionReason_givenNoRingingCall_thenReturnsNil() {
-        let reason = subject.rejectionReason(
+        let reason = subject.reason(
             for: .unique,
             ringTimeout: false
         )

--- a/StreamVideoTests/Utils/RejectionReasonProvider/RejectionReasonProvider_Tests.swift
+++ b/StreamVideoTests/Utils/RejectionReasonProvider/RejectionReasonProvider_Tests.swift
@@ -1,0 +1,106 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class StreamRejectionReasonProviderTests: XCTestCase {
+
+    private lazy var mockStreamVideo: MockStreamVideo! = MockStreamVideo()
+    private lazy var subject: StreamRejectionReasonProvider! = {
+        let subject = StreamRejectionReasonProvider()
+        subject.streamVideo = mockStreamVideo
+        return subject
+    }()
+
+    override func tearDown() {
+        subject = nil
+        mockStreamVideo = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func test_rejectionReason_givenRingingCallWithMatchingCidAndRingTimeout_whenUserIsBusy_thenReturnsBusyReason() {
+        let ringingCall = MockCall(.dummy())
+        mockStreamVideo.state.activeCall = MockCall(.dummy())
+        mockStreamVideo.state.ringingCall = ringingCall
+
+        let reason = subject.rejectionReason(
+            for: ringingCall.cId,
+            ringTimeout: true
+        )
+
+        XCTAssertEqual(reason, RejectCallRequest.Reason.busy)
+    }
+
+    @MainActor
+    func test_rejectionReason_givenRingingCallWithMatchingCidAndRingTimeout_whenUserIsRejectingOutgoingCall_thenReturnsTimeoutReason(
+    ) {
+        let ringingCall = MockCall(.dummy())
+        mockStreamVideo.state.ringingCall = ringingCall
+        ringingCall.state.createdBy = mockStreamVideo.user
+
+        let reason = subject.rejectionReason(
+            for: ringingCall.cId,
+            ringTimeout: true
+        )
+
+        XCTAssertEqual(reason, RejectCallRequest.Reason.timeout)
+    }
+
+    @MainActor
+    func test_rejectionReason_givenRingingCallWithMatchingCidAndNoRingTimeout_whenUserIsRejectingOutgoingCall_thenReturnsCancelReason(
+    ) {
+        let ringingCall = MockCall(.dummy())
+        mockStreamVideo.state.ringingCall = ringingCall
+        ringingCall.state.createdBy = mockStreamVideo.user
+
+        let reason = subject.rejectionReason(
+            for: ringingCall.cId,
+            ringTimeout: false
+        )
+
+        XCTAssertEqual(reason, RejectCallRequest.Reason.cancel)
+    }
+
+    @MainActor
+    func test_rejectionReason_givenRingingCallWithMatchingCidAndNoRingTimeout_whenUserIsNotBusyAndNotRejectingOutgoingCall_thenReturnsDeclineReason(
+    ) {
+        let ringingCall = MockCall(.dummy())
+        mockStreamVideo.state.ringingCall = ringingCall
+        ringingCall.state.createdBy = .dummy()
+
+        let reason = subject.rejectionReason(
+            for: ringingCall.cId,
+            ringTimeout: false
+        )
+
+        XCTAssertEqual(reason, RejectCallRequest.Reason.decline)
+    }
+
+    @MainActor
+    func test_rejectionReason_givenNoRingingCallMatchingCid_thenReturnsNil() {
+        let ringingCall = MockCall(.dummy())
+        mockStreamVideo.state.ringingCall = ringingCall
+        ringingCall.state.createdBy = .dummy()
+
+        let reason = subject.rejectionReason(
+            for: .unique,
+            ringTimeout: false
+        )
+
+        XCTAssertNil(reason)
+    }
+
+    @MainActor
+    func test_rejectionReason_givenNoRingingCall_thenReturnsNil() {
+        let reason = subject.rejectionReason(
+            for: .unique,
+            ringTimeout: false
+        )
+
+        XCTAssertNil(reason)
+    }
+}

--- a/docusaurus/docs/iOS/05-ui-cookbook/05-incoming-call.mdx
+++ b/docusaurus/docs/iOS/05-ui-cookbook/05-incoming-call.mdx
@@ -95,14 +95,6 @@ struct CustomIncomingCallView: View {
             
         }
         .background(Color.white.edgesIgnoringSafeArea(.all))
-        .onChange(of: viewModel.hideIncomingCallScreen) { newValue in
-            if newValue {
-                callViewModel.rejectCall(callType: callInfo.type, callId: callInfo.id)
-            }
-        }
-        .onDisappear {
-            viewModel.stopTimer()
-        }
     }
     
     var callInfo: IncomingCall {


### PR DESCRIPTION
### 🎯 Goal

Provide a rejection reason based on this [specification](https://www.notion.so/stream-wiki/Missed-Calls-Spec-4a039b2c97c447688b62842007510456?pvs=4). 

### 🛠 Implementation

Rejection reason should be added **only** on methods handling explicit user requests (we shouldn't include any rejection reason in methods that respond to call events).

Due to changes the following breaking changes have been introduced as they remove unnecessary code from `IncomingCallViewModel`
- the `hideIncomingCallScreen` property
- the `stopTimer` method.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)