### PR TITLE
[Fix]Reactions not showing after logging out and back in

### DIFF
--- a/DemoApp/Sources/Components/Router.swift
+++ b/DemoApp/Sources/Components/Router.swift
@@ -209,6 +209,7 @@ final class Router: ObservableObject {
         appState.currentUser = user
         appState.userState = .loggedIn
         appState.streamVideo = streamVideo
+        ReactionsAdapter.currentValue.streamVideo = streamVideo
 
         let utils = UtilsKey.currentValue
         utils.userListProvider = appState


### PR DESCRIPTION
### 📝 Summary

This PR fixes and issue where reactions aren't visible if the user log out and log back in again.

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

Login > Logout > Login with another user > join call > reactions should be visible

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)