### PR TITLE
[Feature]Allow PiP window to resize based on rendering track size

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -8,7 +8,7 @@ import StreamVideo
 import StreamWebRTC
 
 /// Describes an object that can be used to present picture-in-picture content.
-protocol StreamAVPictureInPictureViewControlling {
+protocol StreamAVPictureInPictureViewControlling: AnyObject {
     
     /// The closure to call whenever the picture-in-picture window size changes.
     var onSizeUpdate: ((CGSize) -> Void)? { get set }
@@ -29,7 +29,8 @@ protocol StreamAVPictureInPictureViewControlling {
 final class StreamAVPictureInPictureVideoCallViewController: AVPictureInPictureVideoCallViewController,
     StreamAVPictureInPictureViewControlling {
 
-    private let contentView: StreamPictureInPictureVideoRenderer = .init()
+    private let contentView: StreamPictureInPictureVideoRenderer =
+        .init(windowSizePolicy: StreamPictureInPictureAdaptiveWindowSizePolicy())
 
     var onSizeUpdate: ((CGSize) -> Void)?
 
@@ -41,6 +42,16 @@ final class StreamAVPictureInPictureVideoCallViewController: AVPictureInPictureV
     var displayLayer: CALayer { contentView.displayLayer }
 
     // MARK: - Lifecycle
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Initializes a new instance and sets the `preferredContentSize` to `Self.defaultPreferredContentSize`
+    /// value.
+    required init() {
+        super.init(nibName: nil, bundle: nil)
+        contentView.pictureInPictureWindowSizePolicy.controller = self
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
@@ -75,14 +75,13 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
             return nil
         }
 
-        var contentViewController: StreamAVPictureInPictureViewControlling? = {
+        let contentViewController: StreamAVPictureInPictureViewControlling? = {
             if #available(iOS 15.0, *) {
                 return StreamAVPictureInPictureVideoCallViewController()
             } else {
                 return nil
             }
         }()
-        contentViewController?.preferredContentSize = .init(width: 640, height: 480)
         self.contentViewController = contentViewController
         self.canStartPictureInPictureAutomaticallyFromInline = canStartPictureInPictureAutomaticallyFromInline
         super.init()

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureAdaptiveWindowSizePolicy.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureAdaptiveWindowSizePolicy.swift
@@ -1,0 +1,26 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An adaptive window size policy for Picture-in-Picture (PiP) views.
+final class StreamPictureInPictureAdaptiveWindowSizePolicy: PictureInPictureWindowSizePolicy {
+
+    /// The current size of the track to be displayed in the PiP window.
+    var trackSize: CGSize = .zero {
+        didSet {
+            // Only update the controller's preferred content size if the track size has changed and is not zero.
+            guard trackSize != oldValue, trackSize != .zero else {
+                return
+            }
+            controller?.preferredContentSize = trackSize
+        }
+    }
+
+    /// The controller that manages the PiP view.
+    weak var controller: StreamAVPictureInPictureViewControlling?
+
+    /// Initializes a new instance of the adaptive window size policy.
+    init() {}
+}

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureFixedWindowSizePolicy.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureFixedWindowSizePolicy.swift
@@ -1,0 +1,29 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A fixed window size policy for Picture-in-Picture (PiP) views.
+final class StreamPictureInPictureFixedWindowSizePolicy: PictureInPictureWindowSizePolicy {
+
+    /// The current size of the track to be displayed in the PiP window. This is not used in this policy.
+    var trackSize: CGSize = .zero
+
+    /// The controller that manages the PiP view.
+    weak var controller: (any StreamAVPictureInPictureViewControlling)? {
+        didSet {
+            // Set the preferred content size of the controller to the fixed size.
+            controller?.preferredContentSize = fixedSize
+        }
+    }
+
+    /// The fixed size for the PiP window.
+    private let fixedSize: CGSize
+
+    /// Initializes a new instance of the fixed window size policy with a specified fixed size.
+    /// - Parameter fixedSize: The fixed size for the PiP window. Default is 640x480.
+    init(_ fixedSize: CGSize = .init(width: 640, height: 480)) {
+        self.fixedSize = fixedSize
+    }
+}

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureWindowSizePolicy.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureWindowSizePolicy.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol defining the policy for determining the window size of a Picture-in-Picture (PiP) view.
+protocol PictureInPictureWindowSizePolicy {
+    /// The current size of the track to be displayed in the PiP window.
+    var trackSize: CGSize { get set }
+
+    /// The controller that manages the PiP view.
+    var controller: StreamAVPictureInPictureViewControlling? { get set }
+}

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -8,6 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		40013DDC2B87AA2300915453 /* SerialActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40013DDB2B87AA2300915453 /* SerialActor.swift */; };
+		40073B6F2C456CB4006A2867 /* StreamPictureInPictureVideoRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B6E2C456CB4006A2867 /* StreamPictureInPictureVideoRendererTests.swift */; };
+		40073B752C456E06006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B732C456DFC006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy.swift */; };
+		40073B762C456E0E006A2867 /* StreamPictureInPictureWindowSizePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B682C456250006A2867 /* StreamPictureInPictureWindowSizePolicy.swift */; };
+		40073B772C456E1A006A2867 /* StreamPictureInPictureFixedWindowSizePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B712C456DF6006A2867 /* StreamPictureInPictureFixedWindowSizePolicy.swift */; };
+		40073B7A2C456E44006A2867 /* StreamPictureInPictureFixedWindowSizePolicy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B792C456E44006A2867 /* StreamPictureInPictureFixedWindowSizePolicy_Tests.swift */; };
+		40073B7D2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B7C2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift */; };
+		40073B7F2C456F30006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40073B7E2C456F30006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift */; };
 		400D63F72AC3273F0000BB30 /* ThermalStateObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400D63F62AC3273F0000BB30 /* ThermalStateObserverTests.swift */; };
 		400E50532BD2A900008C939E /* StreamAudioFilterCapturePostProcessingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400E50522BD2A900008C939E /* StreamAudioFilterCapturePostProcessingModule.swift */; };
 		400E50552BD2AAD0008C939E /* StreamAudioProcessingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400E50542BD2AAD0008C939E /* StreamAudioProcessingModule.swift */; };
@@ -1192,6 +1199,13 @@
 
 /* Begin PBXFileReference section */
 		40013DDB2B87AA2300915453 /* SerialActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialActor.swift; sourceTree = "<group>"; };
+		40073B682C456250006A2867 /* StreamPictureInPictureWindowSizePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureWindowSizePolicy.swift; sourceTree = "<group>"; };
+		40073B6E2C456CB4006A2867 /* StreamPictureInPictureVideoRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureVideoRendererTests.swift; sourceTree = "<group>"; };
+		40073B712C456DF6006A2867 /* StreamPictureInPictureFixedWindowSizePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureFixedWindowSizePolicy.swift; sourceTree = "<group>"; };
+		40073B732C456DFC006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureAdaptiveWindowSizePolicy.swift; sourceTree = "<group>"; };
+		40073B792C456E44006A2867 /* StreamPictureInPictureFixedWindowSizePolicy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureFixedWindowSizePolicy_Tests.swift; sourceTree = "<group>"; };
+		40073B7C2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStreamAVPictureInPictureViewControlling.swift; sourceTree = "<group>"; };
+		40073B7E2C456F30006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift; sourceTree = "<group>"; };
 		400D63F62AC3273F0000BB30 /* ThermalStateObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateObserverTests.swift; sourceTree = "<group>"; };
 		400E50522BD2A900008C939E /* StreamAudioFilterCapturePostProcessingModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioFilterCapturePostProcessingModule.swift; sourceTree = "<group>"; };
 		400E50542BD2AAD0008C939E /* StreamAudioProcessingModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAudioProcessingModule.swift; sourceTree = "<group>"; };
@@ -2138,6 +2152,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		40073B702C456DE0006A2867 /* WindowSizePolicy */ = {
+			isa = PBXGroup;
+			children = (
+				40073B682C456250006A2867 /* StreamPictureInPictureWindowSizePolicy.swift */,
+				40073B712C456DF6006A2867 /* StreamPictureInPictureFixedWindowSizePolicy.swift */,
+				40073B732C456DFC006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy.swift */,
+			);
+			path = WindowSizePolicy;
+			sourceTree = "<group>";
+		};
+		40073B782C456E30006A2867 /* WindowSizePolicy */ = {
+			isa = PBXGroup;
+			children = (
+				40073B792C456E44006A2867 /* StreamPictureInPictureFixedWindowSizePolicy_Tests.swift */,
+				40073B7E2C456F30006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift */,
+			);
+			path = WindowSizePolicy;
+			sourceTree = "<group>";
+		};
+		40073B7B2C456F01006A2867 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				40073B7C2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		401480332A5423C70029166A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -2724,8 +2765,11 @@
 		40914C962B567B6B00F6A13E /* PictureInPicture */ = {
 			isa = PBXGroup;
 			children = (
+				40073B7B2C456F01006A2867 /* Mocks */,
+				40073B782C456E30006A2867 /* WindowSizePolicy */,
 				40914C972B567C8200F6A13E /* StreamPictureInPictureTrackStateAdapterTests.swift */,
 				40914C9B2B56AA6600F6A13E /* StreamBufferTransformerTests.swift */,
+				40073B6E2C456CB4006A2867 /* StreamPictureInPictureVideoRendererTests.swift */,
 			);
 			path = PictureInPicture;
 			sourceTree = "<group>";
@@ -2786,6 +2830,7 @@
 		40A9416C2B4D958A006D6965 /* PictureInPicture */ = {
 			isa = PBXGroup;
 			children = (
+				40073B702C456DE0006A2867 /* WindowSizePolicy */,
 				40A9416D2B4D959F006D6965 /* StreamPictureInPictureAdapter.swift */,
 				40A9416F2B4D96E6006D6965 /* StreamPictureInPictureController.swift */,
 				40A941712B4D9750006D6965 /* StreamAVPictureInPictureVideoCallViewController.swift */,
@@ -5684,6 +5729,7 @@
 			files = (
 				8434C542289BC0B00001490A /* L10n.swift in Sources */,
 				846FBE8628AA696900147F6E /* ColorExtensions.swift in Sources */,
+				40073B752C456E06006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy.swift in Sources */,
 				84231E4728B2506B007985EF /* VideoRenderer.swift in Sources */,
 				40A941742B4D97A1006D6965 /* StreamPictureInPictureVideoRenderer.swift in Sources */,
 				846BA2AD2A9F602C001AD0AF /* SampleBufferVideoCallView.swift in Sources */,
@@ -5771,6 +5817,7 @@
 				8458B704290ACF2A00F8E487 /* CallSoundsPlayer.swift in Sources */,
 				849EDA8F297AFE1C0072A12D /* PreJoiningViewModel.swift in Sources */,
 				8458872728A3F34D002A81BF /* HelperViews.swift in Sources */,
+				40073B772C456E1A006A2867 /* StreamPictureInPictureFixedWindowSizePolicy.swift in Sources */,
 				84EA5D3C28BFB890004D3531 /* CallParticipantImageView.swift in Sources */,
 				840425B628D0A96F0084C637 /* VideoParticipantsView.swift in Sources */,
 				840626722A37A431004B8748 /* IncomingCall.swift in Sources */,
@@ -5796,6 +5843,7 @@
 				84E7CD3728D64609009F3542 /* CallingIndicator.swift in Sources */,
 				40E110472B5A9DF4007DF492 /* CallDurationView.swift in Sources */,
 				40A9416E2B4D959F006D6965 /* StreamPictureInPictureAdapter.swift in Sources */,
+				40073B762C456E0E006A2867 /* StreamPictureInPictureWindowSizePolicy.swift in Sources */,
 				846FBE8B28AAD84A00147F6E /* InviteParticipantsViewModel.swift in Sources */,
 				40F18B8C2BEBAC4C00ADF76E /* CallEndedViewModifier.swift in Sources */,
 				40E110492B5A9F03007DF492 /* Formatters.swift in Sources */,
@@ -5862,6 +5910,7 @@
 				40245F5B2BE2746300FCF075 /* RingSettings+Dummy.swift in Sources */,
 				40245F5C2BE2746300FCF075 /* ThumbnailResponse+Dummy.swift in Sources */,
 				40245F5D2BE2746300FCF075 /* ThumbnailsSettings+Dummy.swift in Sources */,
+				40073B6F2C456CB4006A2867 /* StreamPictureInPictureVideoRendererTests.swift in Sources */,
 				82E3BA422A0BAE09001AB93E /* EventBatcher_Mock.swift in Sources */,
 				84DCA2122A389167000C3411 /* AssertDelay.swift in Sources */,
 				82FF40C22A17C74600B4D95E /* CallingParticipantView_Tests.swift in Sources */,
@@ -5883,6 +5932,7 @@
 				845C09892C0DFA5E00F725B3 /* LimitsSettingsResponse+Dummy.swift in Sources */,
 				401BEC4F2AE1738D00EEEAC5 /* HorizontalParticipantsListView_Tests.swift in Sources */,
 				401480342A5423D60029166A /* AudioValuePercentageNormaliser_Tests.swift in Sources */,
+				40073B7D2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift in Sources */,
 				8493223B29082EDB0013C029 /* StreamVideoUITestCase.swift in Sources */,
 				84DCA20C2A38300C000C3411 /* StreamVideoTestCase.swift in Sources */,
 				82E3BA362A0BABA2001AB93E /* HTTPClient_Mock.swift in Sources */,
@@ -5895,8 +5945,10 @@
 				829F7BFD29FAC116003EBACE /* ParticipantsFullScreenLayout_Tests.swift in Sources */,
 				82FF40C62A17C75400B4D95E /* JoiningCallView_Tests.swift in Sources */,
 				407D5D3D2ACEF0C500B5044E /* VisibilityThresholdModifier_Tests.swift in Sources */,
+				40073B7F2C456F30006A2867 /* StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift in Sources */,
 				82E3BA4C2A0BAE40001AB93E /* EquatableEvent.swift in Sources */,
 				40245F632BE27AE900FCF075 /* StatelessHangUpIconView_Tests.swift in Sources */,
+				40073B7A2C456E44006A2867 /* StreamPictureInPictureFixedWindowSizePolicy_Tests.swift in Sources */,
 				40914C9C2B56AA6600F6A13E /* StreamBufferTransformerTests.swift in Sources */,
 				82FF40C42A17C74D00B4D95E /* IncomingCallView_Tests.swift in Sources */,
 				404C27CB2BF2552800DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */,

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateful/CallControlsView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateful/CallControlsView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessAudioOutputIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessAudioOutputIconView_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessAudioOutputIconView_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessAudioOutputIconView_Tests: StreamVideoUITestCase {
@@ -65,5 +62,3 @@ final class StatelessAudioOutputIconView_Tests: StreamVideoUITestCase {
         return .init(call: call, actionHandler: actionHandler)
     }
 }
-
-

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessHangUpIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessHangUpIconView_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessHangUpIconView.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessHangUpIconView_Tests: StreamVideoUITestCase {
@@ -43,5 +40,3 @@ final class StatelessHangUpIconView_Tests: StreamVideoUITestCase {
         return .init(call: call)
     }
 }
-
-

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessMicrophoneIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessMicrophoneIconView_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessMicrophoneIconView_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessMicrophoneIconView_Tests: StreamVideoUITestCase {
@@ -65,4 +62,3 @@ final class StatelessMicrophoneIconView_Tests: StreamVideoUITestCase {
         return .init(call: call, actionHandler: actionHandler)
     }
 }
-

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessParticipantsListButton_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessParticipantsListButton_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessParticipantsListButton_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessParticipantsListButton_Tests: StreamVideoUITestCase {
@@ -104,12 +101,11 @@ final class StatelessParticipantsListButton_Tests: StreamVideoUITestCase {
             file: file,
             line: line
         )
-        call.state.participantsMap = (0..<participantsCount).reduce(into: [String: CallParticipant](), { partialResult, _ in
+        call.state.participantsMap = (0..<participantsCount).reduce(into: [String: CallParticipant]()) { partialResult, _ in
             let userId = UUID().uuidString
             partialResult[userId] = .dummy(id: userId)
-        })
+        }
 
         return .init(call: call, isActive: .constant(isActive))
     }
 }
-

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessSpeakerIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessSpeakerIconView_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessSpeakerIconView_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessSpeakerIconView_Tests: StreamVideoUITestCase {
@@ -100,6 +97,3 @@ final class StatelessSpeakerIconView_Tests: StreamVideoUITestCase {
         return .init(call: call, actionHandler: actionHandler)
     }
 }
-
-
-

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessToggleCameraIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessToggleCameraIconView_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessToggleCameraIconView_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessToggleCameraIconView_Tests: StreamVideoUITestCase {
@@ -43,4 +40,3 @@ final class StatelessToggleCameraIconView_Tests: StreamVideoUITestCase {
         return .init(call: call)
     }
 }
-

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessVideoIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessVideoIconView_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  StatelessVideoIconView_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 1/5/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class StatelessVideoIconView_Tests: StreamVideoUITestCase {

--- a/StreamVideoSwiftUITests/CallView/CallDurationView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallDurationView_Tests.swift
@@ -2,11 +2,11 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import SwiftUI
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
+import SwiftUI
 import XCTest
 
 @MainActor
@@ -76,4 +76,3 @@ final class CallDurationView_Tests: StreamVideoUITestCase {
         )
     }
 }
-

--- a/StreamVideoSwiftUITests/CallView/ControlBadgeView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ControlBadgeView_Tests.swift
@@ -2,11 +2,11 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import SwiftUI
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
+import SwiftUI
 import XCTest
 
 @MainActor
@@ -17,7 +17,7 @@ final class ControlBadgeView_Tests: StreamVideoUITestCase {
     }
 
     func test_controlBadgeView_valueIsZero_viewWasConfiguredCorrectly() throws {
-        assertSubject {makeSubject(0) }
+        assertSubject { makeSubject(0) }
     }
 
     func test_controlBadgeView_valueIsLessThan100_viewWasConfiguredCorrectly() throws {
@@ -52,4 +52,3 @@ final class ControlBadgeView_Tests: StreamVideoUITestCase {
         )
     }
 }
-

--- a/StreamVideoSwiftUITests/CallView/LayoutComponents/HorizontalParticipantsListView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/LayoutComponents/HorizontalParticipantsListView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import SnapshotTesting
+import StreamSwiftTestHelpers
 import StreamVideo
 @testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
-import SnapshotTesting
 import XCTest
 
 @MainActor
@@ -53,7 +53,7 @@ final class HorizontalParticipantsListView_Tests: StreamVideoUITestCase {
                 viewFactory: DefaultViewFactory.shared,
                 participants: participants,
                 frame: .init(origin: .zero, size: .init(width: screenWidth, height: thumbnailSize)),
-                call: call, 
+                call: call,
                 showAllInfo: showAllInfo
             ).frame(width: screenWidth),
             variants: snapshotVariants,

--- a/StreamVideoSwiftUITests/CallView/LayoutComponents/SpotlightSpeakerView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/LayoutComponents/SpotlightSpeakerView_Tests.swift
@@ -2,12 +2,12 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import Foundation
+import SnapshotTesting
+import StreamSwiftTestHelpers
 import StreamVideo
 @testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
-import SnapshotTesting
 import XCTest
-import Foundation
 
 @MainActor
 final class SpotlightSpeakerView_Tests: StreamVideoUITestCase {

--- a/StreamVideoSwiftUITests/CallView/ParticipantListButton_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ParticipantListButton_Tests.swift
@@ -2,11 +2,11 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import SwiftUI
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
+import SwiftUI
 import XCTest
 
 final class ParticipantListButton_Tests: StreamVideoUITestCase {
@@ -71,4 +71,3 @@ final class ParticipantListButton_Tests: StreamVideoUITestCase {
         )
     }
 }
-

--- a/StreamVideoSwiftUITests/CallView/ParticipantsFullScreenLayout_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ParticipantsFullScreenLayout_Tests.swift
@@ -2,9 +2,9 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor
@@ -18,7 +18,7 @@ final class ParticipantsFullScreenLayout_Tests: StreamVideoUITestCase {
             participant: ParticipantFactory.get(1, withAudio: true).first!,
             call: call,
             frame: .init(origin: .zero, size: defaultScreenSize),
-            onChangeTrackVisibility: {_,_ in }
+            onChangeTrackVisibility: { _, _ in }
         )
         AssertSnapshot(layout, variants: snapshotVariants)
     }
@@ -29,7 +29,7 @@ final class ParticipantsFullScreenLayout_Tests: StreamVideoUITestCase {
             participant: ParticipantFactory.get(1, withAudio: false).first!,
             call: call,
             frame: .init(origin: .zero, size: defaultScreenSize),
-            onChangeTrackVisibility: {_,_ in }
+            onChangeTrackVisibility: { _, _ in }
         )
         AssertSnapshot(layout, variants: snapshotVariants)
     }
@@ -41,7 +41,7 @@ final class ParticipantsFullScreenLayout_Tests: StreamVideoUITestCase {
                 participant: ParticipantFactory.get(1, connectionQuality: quality).first!,
                 call: call,
                 frame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "\(quality)")
         }
@@ -53,7 +53,7 @@ final class ParticipantsFullScreenLayout_Tests: StreamVideoUITestCase {
             participant: ParticipantFactory.get(1, withAudio: true, speaking: true).first!,
             call: call,
             frame: .init(origin: .zero, size: defaultScreenSize),
-            onChangeTrackVisibility: {_,_ in }
+            onChangeTrackVisibility: { _, _ in }
         )
         AssertSnapshot(layout, variants: snapshotVariants)
     }

--- a/StreamVideoSwiftUITests/CallView/ParticipantsGridLayout_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ParticipantsGridLayout_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import SnapshotTesting
+import StreamSwiftTestHelpers
 @testable import StreamVideo
 @testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
-import SnapshotTesting
 import XCTest
 
 final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
@@ -53,7 +53,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: ParticipantFactory.get(count, withAudio: true),
                 availableFrame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "with_\(count)_participants")
         }
@@ -69,7 +69,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: ParticipantFactory.get(count, withAudio: false),
                 availableFrame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "with_\(count)_participants")
         }
@@ -86,7 +86,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: ParticipantFactory.get(count, connectionQuality: quality),
                 availableFrame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "\(quality)")
         }
@@ -108,7 +108,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: participants,
                 availableFrame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "with_\(count)_participants")
         }

--- a/StreamVideoSwiftUITests/CallView/ParticipantsSpotlightLayout_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ParticipantsSpotlightLayout_Tests.swift
@@ -2,9 +2,9 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class ParticipantsSpotlightLayout_Tests: StreamVideoUITestCase {
@@ -21,7 +21,7 @@ final class ParticipantsSpotlightLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: participants,
                 frame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "with_\(count)_participants")
         }
@@ -37,7 +37,7 @@ final class ParticipantsSpotlightLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: participants,
                 frame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "with_\(count)_participants")
         }
@@ -53,7 +53,7 @@ final class ParticipantsSpotlightLayout_Tests: StreamVideoUITestCase {
                 call: call,
                 participants: participants,
                 frame: .init(origin: .zero, size: defaultScreenSize),
-                onChangeTrackVisibility: {_,_ in }
+                onChangeTrackVisibility: { _, _ in }
             )
             
             AssertSnapshot(layout, variants: snapshotVariants, suffix: "\(quality)")
@@ -69,7 +69,7 @@ final class ParticipantsSpotlightLayout_Tests: StreamVideoUITestCase {
             call: call,
             participants: participants,
             frame: .init(origin: .zero, size: defaultScreenSize),
-            onChangeTrackVisibility: {_,_ in }
+            onChangeTrackVisibility: { _, _ in }
         )
         AssertSnapshot(layout, variants: snapshotVariants)
     }

--- a/StreamVideoSwiftUITests/CallView/ReconnectionView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ReconnectionView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/CallView/RecordingView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/RecordingView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/CallView/ScreenSharingView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ScreenSharingView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class ScreenSharingView_Tests: StreamVideoUITestCase {
@@ -32,7 +32,5 @@ private final class MockCallViewModel: CallViewModel {
 
     var _participants: [CallParticipant] = ParticipantFactory.get(4)
 
-    override var participants: [CallParticipant] {
-        get { _participants }
-    }
+    override var participants: [CallParticipant] { _participants }
 }

--- a/StreamVideoSwiftUITests/CallView/VideoRenderer_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/VideoRenderer_Tests.swift
@@ -2,11 +2,11 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
-import XCTest
 import Combine
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
+import XCTest
 
 final class VideoRenderer_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/CallView/VisibilityThresholdModifier_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/VisibilityThresholdModifier_Tests.swift
@@ -2,12 +2,12 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
-import XCTest
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import SwiftUI
+import XCTest
 
 final class VisibilityThresholdModifier_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -261,13 +261,12 @@ final class CallViewModel_Tests: StreamVideoTestCase {
         eventNotificationCenter.process(wrapped)
         
         await fulfillment {
-            if case .incoming(_) = callViewModel.callingState {
+            if case .incoming = callViewModel.callingState {
                 return true
             } else {
                 return false
             }
         }
-
 
         // Then
         guard case let .incoming(call) = callViewModel.callingState else {
@@ -315,13 +314,12 @@ final class CallViewModel_Tests: StreamVideoTestCase {
         eventNotificationCenter.process(.coordinatorEvent(.typeCallRingEvent(event)))
         
         await fulfillment {
-            if case .incoming(_) = callViewModel.callingState {
+            if case .incoming = callViewModel.callingState {
                 return true
             } else {
                 return false
             }
         }
-
 
         // Then
         guard case let .incoming(call) = callViewModel.callingState else {
@@ -367,7 +365,7 @@ final class CallViewModel_Tests: StreamVideoTestCase {
             members: participants
         )
         await fulfillment {
-            if case .lobby(_) = callViewModel.callingState {
+            if case .lobby = callViewModel.callingState {
                 return true
             } else {
                 return false
@@ -408,7 +406,7 @@ final class CallViewModel_Tests: StreamVideoTestCase {
             members: participants
         )
         await fulfillment {
-            if case .lobby(_) = callViewModel.callingState {
+            if case .lobby = callViewModel.callingState {
                 return true
             } else {
                 return false
@@ -625,51 +623,213 @@ final class CallViewModel_Tests: StreamVideoTestCase {
     @MainActor
     func test_participants_layoutIsGrid_validateAllVariants() async throws {
         try await assertParticipantScenarios([
-            .init(callParticipantsCount: 2, participantsLayout: .grid, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 1),
-            .init(callParticipantsCount: 2, participantsLayout: .grid, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 1),
-            .init(callParticipantsCount: 2, participantsLayout: .grid, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 1),
-
-            .init(callParticipantsCount: 3, participantsLayout: .grid, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 2),
-            .init(callParticipantsCount: 3, participantsLayout: .grid, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 2),
-            .init(callParticipantsCount: 3, participantsLayout: .grid, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 2),
-
-            .init(callParticipantsCount: 4, participantsLayout: .grid, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 4),
-            .init(callParticipantsCount: 4, participantsLayout: .grid, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 4),
-            .init(callParticipantsCount: 4, participantsLayout: .grid, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 4),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .grid,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 1
+            ),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .grid,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 1
+            ),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .grid,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 1
+            ),
+            
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .grid,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 2
+            ),
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .grid,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 2
+            ),
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .grid,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 2
+            ),
+            
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .grid,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 4
+            ),
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .grid,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 4
+            ),
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .grid,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 4
+            )
         ])
     }
 
     @MainActor
     func test_participants_layoutIsSpotlight_validateAllVariants() async throws {
         try await assertParticipantScenarios([
-            .init(callParticipantsCount: 2, participantsLayout: .spotlight, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 2),
-            .init(callParticipantsCount: 2, participantsLayout: .spotlight, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 2),
-            .init(callParticipantsCount: 2, participantsLayout: .spotlight, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 2),
-
-            .init(callParticipantsCount: 3, participantsLayout: .spotlight, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 3),
-            .init(callParticipantsCount: 3, participantsLayout: .spotlight, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 3),
-            .init(callParticipantsCount: 3, participantsLayout: .spotlight, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 3),
-
-            .init(callParticipantsCount: 4, participantsLayout: .spotlight, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 4),
-            .init(callParticipantsCount: 4, participantsLayout: .spotlight, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 4),
-            .init(callParticipantsCount: 4, participantsLayout: .spotlight, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 4),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 2
+            ),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 2
+            ),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 2
+            ),
+            
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 3
+            ),
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 3
+            ),
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 3
+            ),
+            
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 4
+            ),
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 4
+            ),
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .spotlight,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 4
+            )
         ])
     }
 
     @MainActor
     func test_participants_layoutIsFullscreen_validateAllVariants() async throws {
         try await assertParticipantScenarios([
-            .init(callParticipantsCount: 2, participantsLayout: .fullScreen, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 2),
-            .init(callParticipantsCount: 2, participantsLayout: .fullScreen, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 2),
-            .init(callParticipantsCount: 2, participantsLayout: .fullScreen, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 2),
-
-            .init(callParticipantsCount: 3, participantsLayout: .fullScreen, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 3),
-            .init(callParticipantsCount: 3, participantsLayout: .fullScreen, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 3),
-            .init(callParticipantsCount: 3, participantsLayout: .fullScreen, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 3),
-
-            .init(callParticipantsCount: 4, participantsLayout: .fullScreen, isLocalScreenSharing: false, isRemoteScreenSharing: false, expectedCount: 4),
-            .init(callParticipantsCount: 4, participantsLayout: .fullScreen, isLocalScreenSharing: true, isRemoteScreenSharing: false, expectedCount: 4),
-            .init(callParticipantsCount: 4, participantsLayout: .fullScreen, isLocalScreenSharing: false, isRemoteScreenSharing: true, expectedCount: 4),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 2
+            ),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 2
+            ),
+            .init(
+                callParticipantsCount: 2,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 2
+            ),
+            
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 3
+            ),
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 3
+            ),
+            .init(
+                callParticipantsCount: 3,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 3
+            ),
+            
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: false,
+                expectedCount: 4
+            ),
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: true,
+                isRemoteScreenSharing: false,
+                expectedCount: 4
+            ),
+            .init(
+                callParticipantsCount: 4,
+                participantsLayout: .fullScreen,
+                isLocalScreenSharing: false,
+                isRemoteScreenSharing: true,
+                expectedCount: 4
+            )
         ])
     }
 
@@ -691,7 +851,7 @@ final class CallViewModel_Tests: StreamVideoTestCase {
             try await assertParticipants(
                 callParticipantsCount: scenario.callParticipantsCount,
                 participantsLayout: scenario.participantsLayout,
-                isLocalScreenSharing:scenario.isLocalScreenSharing,
+                isLocalScreenSharing: scenario.isLocalScreenSharing,
                 isRemoteScreenSharing: scenario.isRemoteScreenSharing,
                 expectedCount: scenario.expectedCount,
                 file: file,
@@ -747,7 +907,7 @@ final class CallViewModel_Tests: StreamVideoTestCase {
         XCTAssertEqual(callViewModel.participants.count, expectedCount, file: file, line: line)
     }
 
-    //MARK: - private
+    // MARK: - private
     
     @MainActor
     private func callViewModelWithRingingCall(participants: [Member]) -> CallViewModel {

--- a/StreamVideoSwiftUITests/CallingViews/CallConnectingView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/CallConnectingView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/CallingViews/CallingGroupView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/CallingGroupView_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 import SnapshotTesting
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
 import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 final class CallingGroupView_Tests: StreamVideoUITestCase {

--- a/StreamVideoSwiftUITests/CallingViews/CallingParticipantView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/CallingParticipantView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/CallingViews/IncomingCallView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/IncomingCallView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor
@@ -23,8 +23,8 @@ final class IncomingCallView_Tests: StreamVideoUITestCase {
             )
             let view = IncomingCallView(
                 callInfo: callInfo,
-                onCallAccepted: {_ in },
-                onCallRejected: {_ in }
+                onCallAccepted: { _ in },
+                onCallRejected: { _ in }
             )
             AssertSnapshot(view, variants: snapshotVariants, suffix: "with_\(count)_participants")
         }

--- a/StreamVideoSwiftUITests/CallingViews/JoiningCallView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/JoiningCallView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/CallingViews/LobbyView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/LobbyView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor
@@ -14,7 +14,7 @@ final class LobbyView_Tests: StreamVideoUITestCase {
     func test_lobbyView_snapshot() throws {
         for count in 0...2 {
             let viewModel = LobbyViewModel(callType: callId, callId: callType)
-            let users = UserFactory.get(count).map { $0.user }
+            let users = UserFactory.get(count).map(\.user)
             viewModel.participants = users
             let view = LobbyView(
                 viewModel: viewModel,

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneCheckView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneCheckView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor
@@ -16,7 +16,7 @@ final class MicrophoneCheckView_Tests: StreamVideoUITestCase {
             let view = MicrophoneCheckView(
                 audioLevels: (0..<count).map { 0.2 * Float($0) },
                 microphoneOn: true,
-                isSilent: false, 
+                isSilent: false,
                 isPinned: false
             )
             .frame(width: 100, height: 50)

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -2,12 +2,12 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
-import XCTest
-@testable import StreamVideoSwiftUI
 import AVFoundation
-import StreamVideo
 import Combine
+import Foundation
+import StreamVideo
+@testable import StreamVideoSwiftUI
+import XCTest
 
 final class MicrophoneChecker_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/CallingViews/OutgoingCallView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/OutgoingCallView_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 @MainActor

--- a/StreamVideoSwiftUITests/Livestreaming/LivestreamPlayer_Tests.swift
+++ b/StreamVideoSwiftUITests/Livestreaming/LivestreamPlayer_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import SnapshotTesting
+import StreamSwiftTestHelpers
 @testable import StreamVideo
 @testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
-import SnapshotTesting
 import XCTest
 
 final class LivestreamPlayer_Tests: StreamVideoTestCase {
@@ -115,7 +115,7 @@ final class LivestreamPlayer_Tests: StreamVideoTestCase {
     @MainActor
     func test_livestreamPlayerVM_pauseStream() {
         // Given
-        let viewModel = LivestreamPlayerViewModel(type: callType, id: callId)        
+        let viewModel = LivestreamPlayerViewModel(type: callType, id: callId)
         
         // When
         viewModel.update(streamPaused: true)

--- a/StreamVideoSwiftUITests/StreamVideoUITestCase.swift
+++ b/StreamVideoSwiftUITests/StreamVideoUITestCase.swift
@@ -2,9 +2,9 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-@testable import StreamVideoSwiftUI
-@testable import StreamVideo
 import StreamSwiftTestHelpers
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
 import XCTest
 
 class StreamVideoUITestCase: XCTestCase {

--- a/StreamVideoSwiftUITests/Utils/AudioValuePercentageNormaliser_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/AudioValuePercentageNormaliser_Tests.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import XCTest
 @testable import StreamVideoSwiftUI
+import XCTest
 
 final class AudioValuePercentageNormaliser_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/Utils/CallEventsHandler_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/CallEventsHandler_Tests.swift
@@ -3,9 +3,9 @@
 //
 
 import Foundation
-import XCTest
 @testable import StreamVideo
 @testable import StreamVideoSwiftUI
+import XCTest
 
 final class CallEventsHandler_Tests: XCTestCase {
     
@@ -26,7 +26,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .userBlocked(let info) = callEvent {
+        if case let .userBlocked(info) = callEvent {
             XCTAssert(info.callCid == callCid)
         } else {
             XCTFail("Wrong event type")
@@ -47,7 +47,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .accepted(let info) = callEvent {
+        if case let .accepted(info) = callEvent {
             XCTAssert(info.callCid == callCid)
         } else {
             XCTFail("Wrong event type")
@@ -68,7 +68,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .ended(let info) = callEvent {
+        if case let .ended(info) = callEvent {
             XCTAssert(info.callCid == callCid)
         } else {
             XCTFail("Wrong event type")
@@ -89,7 +89,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .rejected(let info) = callEvent {
+        if case let .rejected(info) = callEvent {
             XCTAssert(info.callCid == callCid)
         } else {
             XCTFail("Wrong event type")
@@ -113,7 +113,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .incoming(let info) = callEvent {
+        if case let .incoming(info) = callEvent {
             XCTAssert(info.id == "123")
         } else {
             XCTFail("Wrong event type")
@@ -135,7 +135,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .sessionStarted(let info) = callEvent {
+        if case let .sessionStarted(info) = callEvent {
             XCTAssert(info.id == callCid)
         } else {
             XCTFail("Wrong event type")
@@ -154,7 +154,7 @@ final class CallEventsHandler_Tests: XCTestCase {
         let callEvent = callEventsHandler.checkForCallEvents(from: event)
         
         // Then
-        if case .userUnblocked(let info) = callEvent {
+        if case let .userUnblocked(info) = callEvent {
             XCTAssert(info.callCid == callCid)
         } else {
             XCTFail("Wrong event type")
@@ -232,5 +232,4 @@ final class CallEventsHandler_Tests: XCTestCase {
         // Then
         XCTAssert(callEvent == nil)
     }
-
 }

--- a/StreamVideoSwiftUITests/Utils/CornerClipper_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/CornerClipper_Tests.swift
@@ -2,10 +2,10 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import SwiftUI
-@testable import StreamVideoSwiftUI
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
+@testable import StreamVideoSwiftUI
+import SwiftUI
 import XCTest
 
 final class CornerClipper_Tests: StreamVideoUITestCase {
@@ -71,10 +71,10 @@ final class CornerClipper_Tests: StreamVideoUITestCase {
             Text("Hello World!")
                 .frame(width: 100, height: 100)
                 .cornerRadius(
-                   radius,
-                   corners: corners,
-                   backgroundColor: .red
-               ),
+                    radius,
+                    corners: corners,
+                    backgroundColor: .red
+                ),
             variants: snapshotVariants,
             size: .init(width: 100, height: 100),
             line: line,

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/Mocks/MockStreamAVPictureInPictureViewControlling.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/Mocks/MockStreamAVPictureInPictureViewControlling.swift
@@ -1,13 +1,10 @@
 //
-//  MockStreamAVPictureInPictureViewControlling.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 15/7/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
-import StreamWebRTC
 @testable import StreamVideoSwiftUI
+import StreamWebRTC
 
 final class MockStreamAVPictureInPictureViewControlling: StreamAVPictureInPictureViewControlling {
     var onSizeUpdate: ((CGSize) -> Void)?
@@ -15,4 +12,3 @@ final class MockStreamAVPictureInPictureViewControlling: StreamAVPictureInPictur
     var preferredContentSize: CGSize = .zero
     var displayLayer: CALayer = .init()
 }
-

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/Mocks/MockStreamAVPictureInPictureViewControlling.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/Mocks/MockStreamAVPictureInPictureViewControlling.swift
@@ -1,0 +1,18 @@
+//
+//  MockStreamAVPictureInPictureViewControlling.swift
+//  StreamVideoSwiftUITests
+//
+//  Created by Ilias Pavlidakis on 15/7/24.
+//
+
+import Foundation
+import StreamWebRTC
+@testable import StreamVideoSwiftUI
+
+final class MockStreamAVPictureInPictureViewControlling: StreamAVPictureInPictureViewControlling {
+    var onSizeUpdate: ((CGSize) -> Void)?
+    var track: RTCVideoTrack?
+    var preferredContentSize: CGSize = .zero
+    var displayLayer: CALayer = .init()
+}
+

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
@@ -25,7 +25,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 100, height: 100)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -44,7 +44,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 50, height: 50)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -63,7 +63,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 150, height: 75)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -85,7 +85,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 100, height: 100)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -105,7 +105,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 50, height: 50)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -125,7 +125,7 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 150, height: 75)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.imageBuffer)
+        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamBufferTransformerTests.swift
@@ -2,12 +2,12 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-import XCTest
 import CoreGraphics
-import StreamWebRTC
-import StreamSwiftTestHelpers
 import SnapshotTesting
+import StreamSwiftTestHelpers
 @testable import StreamVideoSwiftUI
+import StreamWebRTC
+import XCTest
 
 final class StreamBufferTransformerTests: XCTestCase {
 
@@ -25,7 +25,10 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 100, height: 100)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
+        let resultBuffer = try XCTUnwrap(
+            transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?
+                .pixelBuffer
+        )
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -44,7 +47,10 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 50, height: 50)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
+        let resultBuffer = try XCTUnwrap(
+            transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?
+                .pixelBuffer
+        )
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -63,7 +69,10 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 150, height: 75)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
+        let resultBuffer = try XCTUnwrap(
+            transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?
+                .pixelBuffer
+        )
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -78,14 +87,17 @@ final class StreamBufferTransformerTests: XCTestCase {
         let sourceBuffer = RTCCVPixelBuffer(
             pixelBuffer: try XCTUnwrap(
                 CVPixelBuffer.make(
-                    with: .init(width: 100,height: 100),
+                    with: .init(width: 100, height: 100),
                     pixelFormat: kCVPixelFormatType_32ARGB
                 )
             )
         )
         let targetSize = CGSize(width: 100, height: 100)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
+        let resultBuffer = try XCTUnwrap(
+            transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?
+                .pixelBuffer
+        )
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -105,7 +117,10 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 50, height: 50)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
+        let resultBuffer = try XCTUnwrap(
+            transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?
+                .pixelBuffer
+        )
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -125,7 +140,10 @@ final class StreamBufferTransformerTests: XCTestCase {
         )
         let targetSize = CGSize(width: 150, height: 75)
 
-        let resultBuffer = try XCTUnwrap(transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?.pixelBuffer)
+        let resultBuffer = try XCTUnwrap(
+            transformer.transformAndResizeIfRequired(sourceBuffer, targetSize: targetSize)?
+                .pixelBuffer
+        )
 
         // Assert that no resize occurred, and the output size matches the target size.
         XCTAssertEqual(CVPixelBufferGetWidth(resultBuffer), Int(targetSize.width))
@@ -140,7 +158,7 @@ final class StreamBufferTransformerTests: XCTestCase {
             kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue
         ] as CFDictionary
 
-        var pixelBuffer : CVPixelBuffer?
+        var pixelBuffer: CVPixelBuffer?
         let status = CVPixelBufferCreate(
             kCFAllocatorDefault, Int(image.size.width),
             Int(image.size.height),

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapterTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureTrackStateAdapterTests.swift
@@ -3,10 +3,10 @@
 //
 
 import Foundation
-import XCTest
-import StreamWebRTC
 @testable import StreamVideo
 @testable import StreamVideoSwiftUI
+import StreamWebRTC
+import XCTest
 
 final class StreamPictureInPictureTrackStateAdapterTests: XCTestCase, @unchecked Sendable {
 

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureVideoRendererTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureVideoRendererTests.swift
@@ -1,13 +1,10 @@
 //
-//  StreamPictureInPictureVideoRendererTests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 15/7/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
-import XCTest
 @testable import StreamVideoSwiftUI
+import XCTest
 
 final class StreamPictureInPictureVideoRenderer_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureVideoRendererTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureVideoRendererTests.swift
@@ -1,0 +1,32 @@
+//
+//  StreamPictureInPictureVideoRendererTests.swift
+//  StreamVideoSwiftUITests
+//
+//  Created by Ilias Pavlidakis on 15/7/24.
+//
+
+import Foundation
+import XCTest
+@testable import StreamVideoSwiftUI
+
+final class StreamPictureInPictureVideoRenderer_Tests: XCTestCase {
+
+    func test_didUpdateTrackSize_windowSizePolicyWasUpdated() {
+        let spyPolicy = StreamTestSpyPictureInPictureWindowSizePolicy()
+        let subject = StreamPictureInPictureVideoRenderer(windowSizePolicy: spyPolicy)
+        let targetSize = CGSize(width: 100, height: 150)
+        subject.frame = .init(origin: .zero, size: .init(width: 300, height: 400))
+        subject.layoutSubviews()
+
+        subject.setSize(targetSize)
+
+        XCTAssertEqual(targetSize, spyPolicy.trackSize)
+    }
+}
+
+// MARK: - Spies
+
+private final class StreamTestSpyPictureInPictureWindowSizePolicy: PictureInPictureWindowSizePolicy {
+    var trackSize: CGSize = .zero
+    var controller: (any StreamVideoSwiftUI.StreamAVPictureInPictureViewControlling)?
+}

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift
@@ -1,13 +1,10 @@
 //
-//  StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 15/7/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
-import XCTest
 @testable import StreamVideoSwiftUI
+import XCTest
 
 final class StreamPictureInPictureAdaptiveWindowSizePolicy_Tests: XCTestCase {
 
@@ -31,4 +28,3 @@ final class StreamPictureInPictureAdaptiveWindowSizePolicy_Tests: XCTestCase {
         XCTAssertEqual(controller.preferredContentSize, targetSize)
     }
 }
-

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift
@@ -1,0 +1,34 @@
+//
+//  StreamPictureInPictureAdaptiveWindowSizePolicy_Tests.swift
+//  StreamVideoSwiftUITests
+//
+//  Created by Ilias Pavlidakis on 15/7/24.
+//
+
+import Foundation
+import XCTest
+@testable import StreamVideoSwiftUI
+
+final class StreamPictureInPictureAdaptiveWindowSizePolicy_Tests: XCTestCase {
+
+    private lazy var targetSize: CGSize! = .init(width: 100, height: 280)
+    private lazy var subject: StreamPictureInPictureAdaptiveWindowSizePolicy! = .init()
+
+    override func tearDown() {
+        targetSize = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - didSetTrackSize
+
+    func test_didSetTrackSize_setsPreferredContentSizeOnController() {
+        let controller = MockStreamAVPictureInPictureViewControlling()
+        subject.controller = controller
+
+        subject.trackSize = targetSize
+
+        XCTAssertEqual(controller.preferredContentSize, targetSize)
+    }
+}
+

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureFixedWindowSizePolicy_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureFixedWindowSizePolicy_Tests.swift
@@ -1,0 +1,31 @@
+//
+//  StreamPictureInPictureFixedWindowSizePolicy_Tests.swift
+//  StreamVideoSwiftUITests
+//
+//  Created by Ilias Pavlidakis on 15/7/24.
+//
+
+import Foundation
+import XCTest
+@testable import StreamVideoSwiftUI
+
+final class StreamPictureInPictureFixedWindowSizePolicy_Tests: XCTestCase {
+
+    private lazy var targetSize: CGSize! = .init(width: 100, height: 280)
+    private lazy var subject: StreamPictureInPictureFixedWindowSizePolicy! = .init(targetSize)
+
+    override func tearDown() {
+        targetSize = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - didSetController
+
+    func test_didSetController_setsPreferredContentSizeOnController() {
+        let controller = MockStreamAVPictureInPictureViewControlling()
+        subject.controller = controller
+
+        XCTAssertEqual(controller.preferredContentSize, targetSize)
+    }
+}

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureFixedWindowSizePolicy_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/WindowSizePolicy/StreamPictureInPictureFixedWindowSizePolicy_Tests.swift
@@ -1,13 +1,10 @@
 //
-//  StreamPictureInPictureFixedWindowSizePolicy_Tests.swift
-//  StreamVideoSwiftUITests
-//
-//  Created by Ilias Pavlidakis on 15/7/24.
+// Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
-import XCTest
 @testable import StreamVideoSwiftUI
+import XCTest
 
 final class StreamPictureInPictureFixedWindowSizePolicy_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/Utils/ReusePool_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/ReusePool_Tests.swift
@@ -142,4 +142,3 @@ final class ReusePoolTests: XCTestCase {
         XCTAssertNotNil(object)
     }
 }
-

--- a/StreamVideoSwiftUITests/Utils/StreamMediaDurationFormatter_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/StreamMediaDurationFormatter_Tests.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-import XCTest
 @testable import StreamVideoSwiftUI
+import XCTest
 
 final class StreamMediaDurationFormatter_Tests: XCTestCase {
 

--- a/StreamVideoSwiftUITests/Utils/ToastView_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/ToastView_Tests.swift
@@ -3,8 +3,8 @@
 //
 
 import SnapshotTesting
-@testable import StreamVideoSwiftUI
 import StreamSwiftTestHelpers
+@testable import StreamVideoSwiftUI
 import SwiftUI
 import XCTest
 
@@ -20,7 +20,6 @@ final class ToastView_Tests: StreamVideoUITestCase {
             )
             .toastView(toast: .constant(toast))
 
-        
         // Then
         AssertSnapshot(view, variants: snapshotVariants)
     }
@@ -35,7 +34,6 @@ final class ToastView_Tests: StreamVideoUITestCase {
             )
             .toastView(toast: .constant(toast))
 
-        
         // Then
         AssertSnapshot(view, variants: snapshotVariants)
     }
@@ -50,7 +48,6 @@ final class ToastView_Tests: StreamVideoUITestCase {
             )
             .toastView(toast: .constant(toast))
 
-        
         // Then
         AssertSnapshot(view, variants: snapshotVariants)
     }
@@ -65,7 +62,6 @@ final class ToastView_Tests: StreamVideoUITestCase {
             )
             .toastView(toast: .constant(toast))
 
-        
         // Then
         AssertSnapshot(view, variants: snapshotVariants)
     }
@@ -80,9 +76,7 @@ final class ToastView_Tests: StreamVideoUITestCase {
             )
             .toastView(toast: .constant(toast))
 
-        
         // Then
         AssertSnapshot(view, variants: snapshotVariants)
     }
-
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ reversed_gci = gci.split('.').reverse.join('.')
 is_localhost = !is_ci
 @force_check = false
 swiftformat_excluded_paths = ["**/Generated", "**/generated", "**/protobuf", "**/OpenApi"]
-swiftformat_source_paths = ["Sources", "DemoApp", "DemoAppUIKit", "StreamVideoTests", "StreamVideoUIKitTests"]
+swiftformat_source_paths = ["Sources", "DemoApp", "DemoAppUIKit", "StreamVideoTests", "StreamVideoSwiftUITests", "StreamVideoUIKitTests"]
 
 before_all do |lane|
   if is_ci


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/PBE-5203

### 📝 Summary

Picture in Picture window can be resized to match the size of the rendering track size (scaled down). This is very useful as it maintains content ratio without cutting out anything.

### 🛠 Implementation

This revision introduces a `PictureInPictureWindowSizePolicy` that can be provided to the `StreamPictureInPictureVideoRenderer`. Every time a new frame is being rendered the policy will be updated for the frame's size. It is the policy's responsibility to update the controller (if needed) to a new content size. Two policies have been added:
- `StreamPictureInPictureFixedWindowSizePolicy`: resizes the Picture in Picture window to a fixed size that doesn't adapt to the rendering frame's size.
- `StreamPictureInPictureAdaptiveWindowSizePolicy`: resizes the Picture in Picture window to a size that fits to the rendering frame's size.

For now `PictureInPictureWindowSizePolicy` is internal and not configurable by integrators. We default our implementation to `StreamPictureInPictureAdaptiveWindowSizePolicy` as we think is the best for most cases. The decision to have the policies internal can be re-evaluated in the future based on integrators' requests.

### 🧪 Manual Testing Notes

- Join a call where a web user share their screen
- Move the call to Picture in Picture
- From the web, resize the presenting window
- The size of the Picture in Picture window should be changed to match the frame's size

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)