### PR TITLE
[Fix]Spacing between horizontal participants in gridLayout

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridLayout.swift
@@ -215,6 +215,7 @@ struct TwoRowParticipantsView<Factory: ViewFactory>: View {
     var firstRowParticipants: [CallParticipant]
     var secondRowParticipants: [CallParticipant]
     var availableFrame: CGRect
+    var innerItemSpacing: CGFloat = 8
     var onChangeTrackVisibility: @MainActor(CallParticipant, Bool) -> Void
     
     var body: some View {
@@ -311,10 +312,11 @@ struct HorizontalParticipantsView<Factory: ViewFactory>: View {
     var call: Call?
     var participants: [CallParticipant]
     var availableFrame: CGRect
+    var innerItemSpacing: CGFloat = 8
     var onChangeTrackVisibility: @MainActor(CallParticipant, Bool) -> Void
-    
+
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: innerItemSpacing) {
             ForEach(participants) { participant in
                 viewFactory.makeVideoParticipantView(
                     participant: participant,
@@ -352,6 +354,10 @@ struct HorizontalParticipantsView<Factory: ViewFactory>: View {
     }
     
     private var availableWidth: CGFloat {
-        availableFrame.width / CGFloat(participants.count)
+        (availableFrame.width - totalInnerItemSpacing) / CGFloat(participants.count)
+    }
+
+    private var totalInnerItemSpacing: CGFloat {
+        CGFloat(participants.endIndex - 1) * innerItemSpacing
     }
 }


### PR DESCRIPTION
### 🛠 Implementation

Our `HorizontalParticipantsView` sizes the items inside it without taking under consideration the innerItem spacing that the HStack puts between the items. 

This revision fixes that issue by including the total innerItem spacing in the calculation for each item's size.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) (16GB) - 2024-07-15 at 18 34 10](https://github.com/user-attachments/assets/71857aa6-74a3-4620-8469-8f1e523f2d74) | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) (16GB) - 2024-07-15 at 18 33 25](https://github.com/user-attachments/assets/39619511-1f80-4fd9-9fa3-fc1e814f0746) |

### 🧪 Manual Testing Notes

- Join a call with 5 users on iPad
- Ensure that spacing from the screen edges and in between participants is as expected

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)