### PR TITLE
Remove StreamVideo module's shadow at xcframeworks' swiftinterfaces

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -323,7 +323,7 @@ end
 
 lane :build_xcframeworks do
   match_me
-  output_directory = "#{Dir.pwd}/../Products"
+  output_directory = File.absolute_path("#{Dir.pwd}/../Products")
   team_id = File.read('Matchfile').match(/team_id\("(.*)"\)/)[1]
   codesign = ["codesign --timestamp -v --sign 'Apple Distribution: Stream.io Inc (#{team_id})'"]
   sdk_names.each do |sdk|
@@ -340,7 +340,19 @@ lane :build_xcframeworks do
     sh('../Scripts/removeUnneededSymbols.sh', sdk, output_directory)
     codesign << lane_context[SharedValues::XCFRAMEWORK_OUTPUT_PATH]
   end
+
+  remove_stream_video_module_shadow(output_directory: output_directory)
   sh(codesign.join(' ')) # We need to sign all frameworks at once
+end
+
+# Swift emits an invalid module interface when a public type has the same name as a module, see https://github.com/swiftlang/swift/issues/56573
+private_lane :remove_stream_video_module_shadow do |options|
+  Dir.glob("#{options[:output_directory]}/**/*.swiftinterface") do |file|
+    if File.file?(file)
+      UI.important("Removing the StreamVideo module's shadow at: #{file}...")
+      File.write(file, File.read(file).gsub('StreamVideo.', ''))
+    end
+  end
 end
 
 desc 'Runs e2e ui tests'


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://stream-io.atlassian.net/browse/PBE-5183

### 🎯 Goal

Make xcframeworks great again!

### 🧪 Manual Testing Notes

- Import `StreamVideo` xcframeworks from `https://github.com/GetStream/stream-video-swift-spm` using branch `test-resolved-spm-issue`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)

### 🎁 Meme
![giphy-downsized-large](https://github.com/user-attachments/assets/59dd1565-f2cc-44ad-9976-90faa6692b9e)
