### PR TITLE
[Fix]Screensharing track disappearing when shared second time

### DIFF
--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -50,6 +50,12 @@ public class CallState: ObservableObject {
     @Published public internal(set) var screenSharingSession: ScreenSharingSession? = nil {
         didSet {
             let isCurrentUserSharing = screenSharingSession?.participant.id == sessionId
+            /// When screensharingSession is non-nil we need to ensure that the track is also enabled.
+            /// Otherwise, we can get in a situation where a track which was shared previously,
+            /// was disabled (due to PiP) and that will cause the track not showing on UI.
+            /// Forcing it here to be enabled, should mitigate this issue and ensure that the track is always
+            /// visible whenever screensharingSession is non-nil.
+            screenSharingSession?.track?.isEnabled = true
             if isCurrentUserSharing != isCurrentUserScreensharing {
                 isCurrentUserScreensharing = isCurrentUserSharing
             }


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/PBE-5237

### 🛠 Implementation

Whenever screensharingSession is non-nil, we ensure that the screenshareTrack is enabled

### 🧪 Manual Testing Notes

- Enter - from an iPad - a call with a web user
- Start sharing screen from web
- Move iOS to PiP
- Stop sharing screen from web
- Move iOS to foreground
- Start sharing screen from web
- Screenshare track should be visible

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)