### PR TITLE
[Fix]Debug menu call expiration not working as expected

### DIFF
--- a/DemoApp/Sources/Views/Login/DebugMenu.swift
+++ b/DemoApp/Sources/Views/Login/DebugMenu.swift
@@ -129,7 +129,7 @@ struct DebugMenu: View {
                 currentValue: callExpiration,
                 additionalItems: { customCallExpirationView },
                 label: "Call Expiration"
-            ) { _ in self.callExpiration = .custom(10) }
+            ) { self.callExpiration = $0 }
 
             makeMenu(
                 for: [.enabled, .disabled],


### PR DESCRIPTION
### 📝 Summary

For now our Debug menu doesn't set correctly the call expiration value as it always default to the `.custom(10)`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)