### PR TITLE
[Fix]Ensure Call.state.startedAt is non-nil when session is valid

### DIFF
--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -427,10 +427,17 @@ public class CallState: ObservableObject {
     }
     
     private func didUpdate(_ session: CallSessionResponse?) {
-        if startedAt != session?.liveStartedAt {
-            startedAt = session?.liveStartedAt
+        guard let session else { return }
+        if let startedAt = session.startedAt {
+            self.startedAt = startedAt
+        } else if let liveStartedAt = session.liveStartedAt {
+            startedAt = liveStartedAt
+        } else if startedAt == nil {
+            /// If we don't receive a value from the SFU we start the timer on the current date.
+            startedAt = Date()
         }
-        if session?.liveEndedAt != nil {
+
+        if session.liveEndedAt != nil {
             resetTimer()
         }
     }


### PR DESCRIPTION
### 📝 Summary

This revision aims to resolve an issue where callDuration may not be populated from the SFU.

### 🧪 Manual Testing Notes

Join and leave multiple calls. The call duration on top of the call should always be visible after joining a call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)