### PR TITLE
[Enhancement]Handle participantsCount event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- Participants (regular and anonymous) count, can be accessed - before or after joining a call - from the `Call.state.participantCount` & `Call.state.anonymousParticipantCount` respectively. [#496](https://github.com/GetStream/stream-video-swift/pull/496)
 
 # [1.0.9](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.9)
 _July 19, 2024_

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -117,6 +117,7 @@ public class CallState: ObservableObject {
     }
 
     @Published public internal(set) var reconnectionStatus = ReconnectionStatus.connected
+    @Published public internal(set) var anonymousParticipantCount: UInt32 = 0
     @Published public internal(set) var participantCount: UInt32 = 0
     @Published public internal(set) var isInitialized: Bool = false
     @Published public internal(set) var callSettings = CallSettings()
@@ -235,8 +236,12 @@ public class CallState: ObservableObject {
             break
         case .typeCallRtmpBroadcastFailedEvent:
             break
-        case .typeCallSessionParticipantCountsUpdatedEvent:
-            break
+        case let .typeCallSessionParticipantCountsUpdatedEvent(event):
+            participantCount = event.participantsCountByRole
+                .values
+                .map(UInt32.init)
+                .reduce(0) { $0 + $1 }
+            anonymousParticipantCount = UInt32(event.anonymousParticipantCount)
         }
     }
 

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -236,12 +236,8 @@ public class CallState: ObservableObject {
             break
         case .typeCallRtmpBroadcastFailedEvent:
             break
-        case let .typeCallSessionParticipantCountsUpdatedEvent(event):
-            participantCount = event.participantsCountByRole
-                .values
-                .map(UInt32.init)
-                .reduce(0) { $0 + $1 }
-            anonymousParticipantCount = UInt32(event.anonymousParticipantCount)
+        case .typeCallSessionParticipantCountsUpdatedEvent:
+            break
         }
     }
 

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -13,6 +13,7 @@ class CallController: @unchecked Sendable {
         didSet {
             handleParticipantsUpdated()
             handleParticipantCountUpdated()
+            handleAnonymousParticipantCountUpdated()
         }
     }
 
@@ -478,7 +479,15 @@ class CallController: @unchecked Sendable {
             }
         }
     }
-    
+
+    private func handleAnonymousParticipantCountUpdated() {
+        webRTCClient?.onAnonymousParticipantCountUpdated = { [weak self] participantCount in
+            Task { @MainActor [weak self] in
+                self?.call?.state.anonymousParticipantCount = participantCount
+            }
+        }
+    }
+
     private func handleSignalChannelConnectionStateChange(_ state: WebSocketConnectionState) {
         switch state {
         case let .disconnected(source):

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -17,7 +17,16 @@ class CallController: @unchecked Sendable {
         }
     }
 
-    weak var call: Call?
+    weak var call: Call? {
+        didSet {
+            participantsCountUpdatesTask?.cancel()
+            participantsCountUpdatesTask = nil
+            if let call {
+                participantsCountUpdatesTask = subscribeToParticipantsCountUpdatesEvent(call)
+            }
+        }
+    }
+
     private let user: User
     private let callId: String
     private let callType: String
@@ -31,7 +40,8 @@ class CallController: @unchecked Sendable {
     private var currentSFU: String?
     private var statsInterval: TimeInterval = 5
     private var statsCancellable: AnyCancellable?
-    
+    private var participantsCountUpdatesTask: Task<Void, Never>?
+
     init(
         defaultAPI: DefaultAPI,
         user: User,
@@ -496,6 +506,10 @@ class CallController: @unchecked Sendable {
                 self?.handleSignalChannelDisconnect(source: source)
             }
         case .connected(healthCheckInfo: _):
+            /// Once connected we should stop listening for CallSessionParticipantCountsUpdatedEvent
+            /// updates and only rely on the healthCheck event.
+            participantsCountUpdatesTask?.cancel()
+            participantsCountUpdatesTask = nil
             log.debug("Signal channel connected")
             if reconnectionDate != nil {
                 reconnectionDate = nil
@@ -697,6 +711,20 @@ class CallController: @unchecked Sendable {
                 try await webRTCClient?.sendStats(report: stats)
             } catch {
                 log.error(error)
+            }
+        }
+    }
+
+    private func subscribeToParticipantsCountUpdatesEvent(_ call: Call) -> Task<Void, Never> {
+        Task {
+            for await event in call.subscribe(for: CallSessionParticipantCountsUpdatedEvent.self) {
+                Task { @MainActor in
+                    call.state.participantCount = event.participantsCountByRole
+                        .values
+                        .map(UInt32.init)
+                        .reduce(0) { $0 + $1 }
+                    call.state.anonymousParticipantCount = UInt32(event.anonymousParticipantCount)
+                }
             }
         }
     }

--- a/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
+++ b/Sources/StreamVideo/WebRTC/SfuMiddleware.swift
@@ -16,6 +16,7 @@ class SfuMiddleware: EventMiddleware {
     private var publisher: PeerConnection?
     var onSocketConnected: ((Bool) -> Void)?
     var onParticipantCountUpdated: ((UInt32) -> Void)?
+    var onAnonymousParticipantCountUpdated: ((UInt32) -> Void)?
     var onSessionMigrationEvent: (() -> Void)?
     var onPinsChanged: (([Stream_Video_Sfu_Models_Pin]) -> Void)?
     
@@ -76,6 +77,7 @@ class SfuMiddleware: EventMiddleware {
                     await loadParticipants(from: event)
                 case let .healthCheckResponse(event):
                     onParticipantCountUpdated?(event.participantCount.total)
+                    onAnonymousParticipantCountUpdated?(event.participantCount.anonymous)
                 case let .trackPublished(event):
                     await handleTrackPublishedEvent(event)
                 case let .trackUnpublished(event):

--- a/Sources/StreamVideo/WebRTC/WebRTCClient.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCClient.swift
@@ -189,6 +189,7 @@ class WebRTCClient: NSObject, @unchecked Sendable {
     var onParticipantsUpdated: (([String: CallParticipant]) -> Void)?
     var onSignalConnectionStateChange: ((WebSocketConnectionState) -> Void)?
     var onParticipantCountUpdated: ((UInt32) -> Void)?
+    var onAnonymousParticipantCountUpdated: ((UInt32) -> Void)?
     var onSessionMigrationEvent: (() -> Void)? {
         didSet {
             sfuMiddleware.onSessionMigrationEvent = onSessionMigrationEvent
@@ -313,6 +314,10 @@ class WebRTCClient: NSObject, @unchecked Sendable {
         sfuMiddleware.onParticipantCountUpdated = { [weak self] participantCount in
             self?.onParticipantCountUpdated?(participantCount)
         }
+        sfuMiddleware.onAnonymousParticipantCountUpdated = { [weak self] in
+            self?.onAnonymousParticipantCountUpdated?($0)
+        }
+
         sfuMiddleware.onPinsChanged = { [weak self] pins in
             self?.handlePinsChanged(pins)
         }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		404C27CC2BF2552900DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		404CAEE72B8F48F6007087BC /* DemoBackgroundEffectSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
+		405EFF112C7F120700AC5CE6 /* SFUMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405EFF102C7F120700AC5CE6 /* SFUMiddlewareTests.swift */; };
 		4063033F2AD847EC0091AE77 /* CallState_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4063033E2AD847EC0091AE77 /* CallState_Tests.swift */; };
 		406303422AD848000091AE77 /* CallParticipant_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406303412AD848000091AE77 /* CallParticipant_Mock.swift */; };
 		406303462AD9432D0091AE77 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 406303442AD942ED0091AE77 /* GoogleSignInSwift */; };
@@ -1304,6 +1305,7 @@
 		4049CE832BBBF8EF003D07D2 /* StreamAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAsyncImage.swift; sourceTree = "<group>"; };
 		404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatModifier.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
+		405EFF102C7F120700AC5CE6 /* SFUMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFUMiddlewareTests.swift; sourceTree = "<group>"; };
 		4063033E2AD847EC0091AE77 /* CallState_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallState_Tests.swift; sourceTree = "<group>"; };
 		406303412AD848000091AE77 /* CallParticipant_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipant_Mock.swift; sourceTree = "<group>"; };
 		406583852B87694B00B4F979 /* BlurBackgroundVideoFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurBackgroundVideoFilter.swift; sourceTree = "<group>"; };
@@ -4081,6 +4083,7 @@
 				8414081229F28B5600FF2D7C /* RTCConfiguration_Tests.swift */,
 				8446AF902A4D84F4002AB07B /* Retries_Tests.swift */,
 				841FF5042A5D815700809BBB /* VideoCapturerUtils_Tests.swift */,
+				405EFF102C7F120700AC5CE6 /* SFUMiddlewareTests.swift */,
 			);
 			path = WebRTC;
 			sourceTree = "<group>";
@@ -5763,6 +5766,7 @@
 				8251E62B2A17BEB400E7257A /* StreamVideoTestResources.swift in Sources */,
 				403FB14C2BFE14760047A696 /* Publisher_NextTests.swift in Sources */,
 				84A4DCBB2A41DC6E00B1D1BF /* AsyncAssert.swift in Sources */,
+				405EFF112C7F120700AC5CE6 /* SFUMiddlewareTests.swift in Sources */,
 				84CBBE0B29228BA900D0DA61 /* StreamVideoTestCase.swift in Sources */,
 				40F017512BBEF00500E89FD1 /* ScreensharingSettings+Dummy.swift in Sources */,
 				403FB14E2BFE18D10047A696 /* StreamStateMachine_Tests.swift in Sources */,

--- a/StreamVideoTests/WebRTC/SFUMiddlewareTests.swift
+++ b/StreamVideoTests/WebRTC/SFUMiddlewareTests.swift
@@ -1,0 +1,62 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class SFUMiddlewareTests: XCTestCase {
+
+    private lazy var sessionID: String! = .unique
+    private lazy var user: User! = .init(id: .unique)
+    private lazy var state: WebRTCClient.State! = .init()
+    private lazy var signalService: Stream_Video_Sfu_Signal_SignalServer! = .init(
+        httpClient: HTTPClient_Mock(),
+        apiKey: .unique,
+        hostname: .unique,
+        token: .unique
+    )
+    private lazy var participantThreshold: Int! = 10
+
+    private lazy var subject: SfuMiddleware! = .init(
+        sessionID: sessionID,
+        user: user,
+        state: state,
+        signalService: signalService,
+        participantThreshold: participantThreshold
+    )
+
+    override func tearDown() {
+        subject = nil
+        user = nil
+        state = nil
+        signalService = nil
+        participantThreshold = nil
+        super.tearDown()
+    }
+
+    // MARK: - handle(event:)
+
+    func test_handle_healthCheck_passesCorrectValuesForParticipantsAndAnonymous() async throws {
+        var participantCount = Stream_Video_Sfu_Models_ParticipantCount()
+        participantCount.total = 10
+        participantCount.anonymous = 3
+        var healthCheckInfo = Stream_Video_Sfu_Event_HealthCheckResponse()
+        healthCheckInfo.participantCount = participantCount
+        let participantsCountExpectation = expectation(description: "onParticipantCountUpdated was called")
+        let anonymousCountExpectation = expectation(description: "onAnonymousParticipantCountUpdated was called")
+        subject.onParticipantCountUpdated = {
+            XCTAssertEqual($0, participantCount.total)
+            participantsCountExpectation.fulfill()
+        }
+        subject.onAnonymousParticipantCountUpdated = {
+            XCTAssertEqual($0, participantCount.anonymous)
+            anonymousCountExpectation.fulfill()
+        }
+
+        _ = subject.handle(event: .sfuEvent(.healthCheckResponse(healthCheckInfo)))
+
+        await fulfillment(of: [participantsCountExpectation, anonymousCountExpectation])
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://stream-io.atlassian.net/jira/software/c/projects/PBE/boards/151?selectedIssue=PBE-5756

### 🎯 Goal

Provide a consistent way for participants (regular and anonymous) count observation (before/after joining a call).

### 🛠 Implementation

- Listen and react to the new SFU `call.session_participant_count_updated` event.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)