### PR TITLE
[Fix]Allow callSettings propagation to CallState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Participants (regular and anonymous) count, can be accessed - before or after joining a call - from the `Call.state.participantCount` & `Call.state.anonymousParticipantCount` respectively. [#496](https://github.com/GetStream/stream-video-swift/pull/496)
+- You can now provide the `CallSettings` when you start a ringing call [#497](https://github.com/GetStream/stream-video-swift/pull/497)
 
 # [1.0.9](https://github.com/GetStream/stream-video-swift/releases/tag/1.0.9)
 _July 19, 2024_

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -43,7 +43,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         callType: String,
         callId: String,
         coordinatorClient: DefaultAPI,
-        callController: CallController
+        callController: CallController,
+        callSettings: CallSettings? = nil
     ) {
         self.callId = callId
         self.callType = callType
@@ -63,6 +64,14 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
             initialSpeakerStatus: .enabled,
             initialAudioOutputStatus: .enabled
         )
+
+        /// If we received a non-nil initial callSettings, we updated them here.
+        if let callSettings {
+            Task { @MainActor [weak self] in
+                self?.state.update(callSettings: callSettings)
+            }
+        }
+
         self.callController.call = self
         // It's important to instantiate the stateMachine as soon as possible
         // to ensure it's uniqueness.

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -215,10 +215,13 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     /// - Parameters:
     ///  - callType: the type of the call.
     ///  - callId: the id of the all.
+    ///  - callSettings: the initial CallSettings to use. If `nil` is provided, the default CallSettings
+    ///  will be used.
     /// - Returns: `Call` object.
     public func call(
         callType: String,
-        callId: String
+        callId: String,
+        callSettings: CallSettings? = nil
     ) -> Call {
         callCache.call(for: callCid(from: callId, callType: callType)) {
             let callController = makeCallController(callType: callType, callId: callId)
@@ -226,7 +229,8 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
                 callType: callType,
                 callId: callId,
                 coordinatorClient: coordinatorClient,
-                callController: callController
+                callController: callController,
+                callSettings: callSettings
             )
             eventsMiddleware.add(subscriber: call)
             return call

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -356,6 +356,7 @@ open class CallViewModel: ObservableObject {
                 callId: callId,
                 callSettings: callSettings
             )
+            self.call = call
             Task {
                 do {
                     let callData = try await call.create(

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -351,8 +351,11 @@ open class CallViewModel: ObservableObject {
                 backstage: backstage
             )
         } else {
-            let call = streamVideo.call(callType: callType, callId: callId)
-            self.call = call
+            let call = streamVideo.call(
+                callType: callType,
+                callId: callId,
+                callSettings: callSettings
+            )
             Task {
                 do {
                     let callData = try await call.create(
@@ -572,7 +575,11 @@ open class CallViewModel: ObservableObject {
         enteringCallTask = Task {
             do {
                 log.debug("Starting call")
-                let call = call ?? streamVideo.call(callType: callType, callId: callId)
+                let call = call ?? streamVideo.call(
+                    callType: callType,
+                    callId: callId,
+                    callSettings: callSettings
+                )
                 var settingsRequest: CallSettingsRequest?
                 var limits: LimitsSettingsRequest?
                 if maxDuration != nil || maxParticipants != nil {

--- a/StreamVideoTests/Mock/MockStreamVideo.swift
+++ b/StreamVideoTests/Mock/MockStreamVideo.swift
@@ -60,7 +60,11 @@ final class MockStreamVideo: StreamVideo, Mockable {
         stubbedFunction[function] = value
     }
 
-    override func call(callType: String, callId: String) -> Call {
+    override func call(
+        callType: String,
+        callId: String,
+        callSettings: CallSettings? = nil
+    ) -> Call {
         stubbedFunction[.call] as! Call
     }
 


### PR DESCRIPTION
### 🎯 Goal

Allow providing initial callSettings when starting a call (and skipping joining).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)