### PR TITLE
[Fix]CallSettings propagation to call

### DIFF
--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -52,17 +52,17 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         self.callController = callController
         microphone = MicrophoneManager(
             callController: callController,
-            initialStatus: .enabled
+            initialStatus: callSettings?.audioOn == false ? .disabled : .enabled
         )
         camera = CameraManager(
             callController: callController,
-            initialStatus: .enabled,
+            initialStatus: callSettings?.videoOn == false ? .disabled : .enabled,
             initialDirection: .front
         )
         speaker = SpeakerManager(
             callController: callController,
-            initialSpeakerStatus: .enabled,
-            initialAudioOutputStatus: .enabled
+            initialSpeakerStatus: callSettings?.speakerOn == false ? .disabled : .enabled,
+            initialAudioOutputStatus: callSettings?.audioOutputOn == false ? .disabled : .enabled
         )
 
         /// If we received a non-nil initial callSettings, we updated them here.


### PR DESCRIPTION
### 📝 Summary

This revision allows configuring a Call's initial mic, camera and speaker settings by respecting the provided CallSettings.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)