### PR TITLE
[Improve]Default participants ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Updated the default sorting for Participants during a call to minimize the movement of already visible tiles [#515](https://github.com/GetStream/stream-video-swift/pull/515)
 
 # [1.10.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.10.0)
 _August 29, 2024_

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -17,11 +17,13 @@ public typealias StreamSortComparator<Value> = (Value, Value) -> ComparisonResul
 public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
     pinned,
     screensharing,
-    dominantSpeaker,
-    ifInvisible(isSpeaking),
-    ifInvisible(publishingVideo),
-    ifInvisible(publishingAudio),
-    ifInvisible(userId)
+    ifInvisible(combineComparators([
+        dominantSpeaker,
+        isSpeaking,
+        isSpeaking,
+        publishingVideo,
+        publishingAudio
+    ]))
 ]
 
 /// The set of comparators used for sorting `CallParticipant` objects during livestreams.

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -23,7 +23,8 @@ public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
         isSpeaking,
         publishingVideo,
         publishingAudio
-    ]))
+    ])),
+    ifInvisible(userId)
 ]
 
 /// The set of comparators used for sorting `CallParticipant` objects during livestreams.

--- a/StreamVideoTests/Utils/Sorting_Tests.swift
+++ b/StreamVideoTests/Utils/Sorting_Tests.swift
@@ -702,6 +702,76 @@ final class Sorting_Tests: XCTestCase {
         )
     }
 
+    func test_defaultComparators_someSpeakingWhileDominantSpeakerIsVisible_orderDoesNotChange() {
+        let combined = combineComparators(defaultComparators)
+
+        assertSort(
+            [
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: false
+                ),
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: false
+                ),
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: false
+                ),
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: true
+                )
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[0], $0[1], $0[2], $0[3]] }
+        )
+    }
+
+    func test_defaultComparators_someSpeakingWhileDominantSpeakerIsInisible_orderChanges() {
+        let combined = combineComparators(defaultComparators)
+
+        assertSort(
+            [
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: false
+                ),
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: false
+                ),
+                .dummy(
+                    hasAudio: true,
+                    showTrack: true,
+                    isSpeaking: true,
+                    isDominantSpeaker: false
+                ),
+                .dummy(
+                    hasAudio: true,
+                    showTrack: false,
+                    isSpeaking: true,
+                    isDominantSpeaker: true
+                )
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[3], $0[0], $0[1], $0[2]] }
+        )
+    }
+
     // MARK: - Private Helpers
 
     private func assertSort(


### PR DESCRIPTION
### 🎯 Goal

Align participants ordering with [React](https://github.com/GetStream/stream-video-js/blob/fea00ff0ff3984e3ab29706355f98804151734a7/packages/client/src/sorting/presets.ts#L43).

### 📝 Summary

Combine participant comparators to provide a more stable (less jumpy) sorting.

### 🧪 Manual Testing Notes

- Join a call with 4 participants
- Have all of them talking while the dominanSpeaker is the one on the fourth position
- When the dominantSpeaker starts speaking (and become dominant) their tile shouldn't move to the first position. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)