### PR TITLE
Disconnect rather than error stage

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connected.swift
@@ -30,7 +30,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
         ) -> Self? {
             switch previousStage.id {
             case .connecting:
-                Task { transitionOrError(.joining(context)) }
+                Task { transitionOrDisconnect(.joining(context)) }
                 return self
             default:
                 return nil

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
@@ -76,9 +76,9 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     await coordinator.stateAdapter.set(sfuAdapter: sfuAdapter)
                     context.currentSFU = response.credentials.server.edgeName
 
-                    transitionOrError(.connected(context))
+                    transitionOrDisconnect(.connected(context))
                 } catch {
-                    transitionErrorOrLog(error)
+                    transitionDisconnectOrError(error)
                 }
             }
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
@@ -116,13 +116,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 if context.reconnectionStrategy == .disconnected {
                     transitionErrorOrLog(blockError)
                 } else {
-                    do {
-                        try transition?(
-                            .disconnected(context)
-                        )
-                    } catch {
-                        transitionErrorOrLog(blockError)
-                    }
+                    transitionOrDisconnect(.disconnected(context))
                 }
             }
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+FastReconnected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+FastReconnected.swift
@@ -30,7 +30,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
         ) -> Self? {
             switch previousStage.id {
             case .fastReconnecting:
-                Task { transitionOrError(.joining(context)) }
+                Task { transitionOrDisconnect(.joining(context)) }
                 return self
             default:
                 return nil

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+FastReconnecting.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+FastReconnecting.swift
@@ -80,8 +80,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     )
                 } catch {
                     context.reconnectionStrategy = context.nextReconnectionStrategy()
-                    context.flowError = error
-                    transitionOrError(.disconnected(context))
+                    transitionDisconnectOrError(error)
                 }
             }
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -102,8 +102,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     context.reconnectionStrategy = context
                         .reconnectionStrategy
                         .next
-                    context.flowError = error
-                    transitionOrError(.disconnected(context))
+                    transitionDisconnectOrError(error)
                 }
             }
         }
@@ -161,9 +160,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     if let clientError = error as? ClientError {
                         log.error(clientError)
                     }
-                    context.flowError = error
                     context.reconnectionStrategy = .rejoin
-                    transitionOrError(.disconnected(context))
+                    transitionDisconnectOrError(error)
                 }
             }
         }
@@ -213,8 +211,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         )
                     )
                 } catch {
-                    context.flowError = error
-                    transitionOrError(.disconnected(context))
+                    transitionDisconnectOrError(error)
                 }
             }
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrated.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrated.swift
@@ -76,7 +76,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         )
                     )
                 } catch {
-                    transitionErrorOrLog(error)
+                    transitionDisconnectOrError(error)
                 }
             }
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrating.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrating.swift
@@ -60,7 +60,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                             )
                         )
                     } catch {
-                        transitionErrorOrLog(error)
+                        transitionDisconnectOrError(error)
                     }
                 }
                 return self

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Rejoining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Rejoining.swift
@@ -99,8 +99,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     if error is CancellationError {
                         /* No-op */
                     } else {
-                        context.flowError = error
-                        transitionOrError(.disconnected(context))
+                        transitionDisconnectOrError(error)
                     }
                 }
             }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -84,6 +84,8 @@ extension WebRTCCoordinator.StateMachine {
             nil // No-op
         }
 
+        // MARK: - Helper transitions
+
         func transitionErrorOrLog(_ error: Error) {
             do {
                 try transition?(
@@ -97,11 +99,25 @@ extension WebRTCCoordinator.StateMachine {
             }
         }
 
+        func transitionDisconnectOrError(_ error: Error) {
+            context.flowError = error
+            transitionOrError(.disconnected(context))
+        }
+
         func transitionOrError(_ nextStage: Stage) {
             do {
                 try transition?(nextStage)
             } catch {
                 transitionErrorOrLog(error)
+            }
+        }
+
+        func transitionOrDisconnect(_ nextStage: Stage) {
+            do {
+                try transition?(nextStage)
+            } catch let initialError {
+                nextStage.context.flowError = initialError
+                transitionOrError(.disconnected(nextStage.context))
             }
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://stream-io.atlassian.net/browse/PBE-5901

### 📝 Summary

When connection is lost there where flows that would result in ending the call rather than reconnecting it. This revision fixes those flows and always disconnect rather than leaving the call.

### 🧪 Manual Testing Notes

- Enter a call
- Trigger a migration
- Once migration is done enable airplane mode on your device
- Wait a couple seconds and disable it
- Call should reconnect    

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)