### PR TITLE
[Fix]MissingPermission error thrown when connectUser shouldn't be called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Updated the default sorting for Participants during a call to minimize the movement of already visible tiles [#515](https://github.com/GetStream/stream-video-swift/pull/515)
 
+### 🐞 Fixed
+- An `MissingPermissions` error was thrown when creating a `StreamVideo` with anonymous user type. [#525](https://github.com/GetStream/stream-video-swift/pull/525)
+
 # [1.10.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.10.0)
 _August 29, 2024_
 

--- a/DemoApp/Sources/Components/Router.swift
+++ b/DemoApp/Sources/Components/Router.swift
@@ -231,7 +231,11 @@ final class Router: ObservableObject {
         utils.userListProvider = appState
         streamVideoUI = StreamVideoUI(streamVideo: streamVideo, utils: utils)
 
-        appState.connectUser()
+        if user?.type != .anonymous {
+            appState.connectUser()
+        } else {
+            appState.loading = false
+        }
     }
 
     private func refreshToken(

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -189,7 +189,7 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
                 } catch {
                     log.error("Error connecting as guest", error: error)
                 }
-            } else {
+            } else if user.type != .anonymous {
                 do {
                     try Task.checkCancellation()
                     try await self.connectUser(isInitial: true)


### PR DESCRIPTION
### 📝 Summary

Even though `connectUser` isn't supposed to be called for `anonymous`, it seems that we are calling it anyway (but ignoring the error). This revision checks user type and avoids calling connectUser for `anonymous`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)