### PR TITLE
[Fix]Track orientation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Updated the default sorting for Participants during a call to minimize the movement of already visible tiles [#515](https://github.com/GetStream/stream-video-swift/pull/515)
+- **Breaking** The `StreamDeviceOrientation` values now are `.portrait(isUpsideDown: Bool)` & `.landscape(isLeft: Bool)`. [#534](https://github.com/GetStream/stream-video-swift/pull/534)
 
 ### 🐞 Fixed
 - An `MissingPermissions` error was thrown when creating a `StreamVideo` with anonymous user type. [#525](https://github.com/GetStream/stream-video-swift/pull/525)

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 		402F04A92B70ED8600CA1986 /* StreamCallStatisticsReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F04A62B70ED8600CA1986 /* StreamCallStatisticsReporter.swift */; };
 		402F04AA2B70ED8600CA1986 /* Statistics+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F04A72B70ED8600CA1986 /* Statistics+Convenience.swift */; };
 		402F04AB2B70ED8600CA1986 /* StreamCallStatisticsFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F04A82B70ED8600CA1986 /* StreamCallStatisticsFormatter.swift */; };
-		402F04AE2B714E9B00CA1986 /* StreamDeviceOrientationAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F04AD2B714E9B00CA1986 /* StreamDeviceOrientationAdapter.swift */; };
 		402F04AF2B7245F800CA1986 /* DemoCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F446012A9E2C23004BE3DA /* DemoCallView.swift */; };
 		402F04B12B724EE500CA1986 /* CallViewModel+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F04B02B724EE500CA1986 /* CallViewModel+Snapshot.swift */; };
 		4030E5A02A9DF5BD003E8CBA /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4030E59F2A9DF5BD003E8CBA /* AppEnvironment.swift */; };
@@ -559,6 +558,12 @@
 		40FB15212BF78FA100D5E580 /* Publisher+NextValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FB15202BF78FA100D5E580 /* Publisher+NextValue.swift */; };
 		40FBEF492AC30343007CFF17 /* Safari.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF482AC30343007CFF17 /* Safari.swift */; };
 		40FBEF4B2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */; };
+		40FE5EB32C9C73E0006B0881 /* StreamDeviceOrientationAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F04AD2B714E9B00CA1986 /* StreamDeviceOrientationAdapter.swift */; };
+		40FE5EBB2C9C7D40006B0881 /* StreamVideoCaptureHandler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBA2C9C7D40006B0881 /* StreamVideoCaptureHandler_Tests.swift */; };
+		40FE5EBD2C9C82A6006B0881 /* MockRTCVideoCapturerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBC2C9C82A6006B0881 /* MockRTCVideoCapturerDelegate.swift */; };
+		40FE5EBF2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
+		40FE5EC02C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
+		40FE5EC12C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
 		43217A0C2A44A28B002B5857 /* ConnectionErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43217A0B2A44A28B002B5857 /* ConnectionErrorEvent.swift */; };
 		4351AEAD2A40588D00D32D0D /* IntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4351AEAC2A40588D00D32D0D /* IntegrationTest.swift */; };
 		4351AEAF2A40591800D32D0D /* CallCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4351AEAE2A40591800D32D0D /* CallCRUDTests.swift */; };
@@ -1795,6 +1800,9 @@
 		40FB15202BF78FA100D5E580 /* Publisher+NextValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+NextValue.swift"; sourceTree = "<group>"; };
 		40FBEF482AC30343007CFF17 /* Safari.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Safari.swift; sourceTree = "<group>"; };
 		40FBEF4A2AC30371007CFF17 /* XCUIApplication+KeyboardIntroduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+KeyboardIntroduction.swift"; sourceTree = "<group>"; };
+		40FE5EBA2C9C7D40006B0881 /* StreamVideoCaptureHandler_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamVideoCaptureHandler_Tests.swift; sourceTree = "<group>"; };
+		40FE5EBC2C9C82A6006B0881 /* MockRTCVideoCapturerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRTCVideoCapturerDelegate.swift; sourceTree = "<group>"; };
+		40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+Convenience.swift"; sourceTree = "<group>"; };
 		43217A0B2A44A28B002B5857 /* ConnectionErrorEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionErrorEvent.swift; sourceTree = "<group>"; };
 		4351AEAC2A40588D00D32D0D /* IntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTest.swift; sourceTree = "<group>"; };
 		4351AEAE2A40591800D32D0D /* CallCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCRUDTests.swift; sourceTree = "<group>"; };
@@ -3291,6 +3299,7 @@
 		409CA7972BEE21660045F7AA /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */,
 				40382F412C89CF9300C2D00F /* Stream_Video_Sfu_Models_ConnectionQuality+Convenience.swift */,
 				40382F442C89D00200C2D00F /* Stream_Video_Sfu_Models_Participant+Convenience.swift */,
 				409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */,
@@ -3991,6 +4000,14 @@
 			path = UITests;
 			sourceTree = "<group>";
 		};
+		40FE5EB92C9C7D35006B0881 /* VideoCapturing */ = {
+			isa = PBXGroup;
+			children = (
+				40FE5EBA2C9C7D40006B0881 /* StreamVideoCaptureHandler_Tests.swift */,
+			);
+			path = VideoCapturing;
+			sourceTree = "<group>";
+		};
 		4351AEAB2A40586B00D32D0D /* IntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -4550,6 +4567,7 @@
 		8492B87629081CE700006649 /* Mock */ = {
 			isa = PBXGroup;
 			children = (
+				40FE5EBC2C9C82A6006B0881 /* MockRTCVideoCapturerDelegate.swift */,
 				40483CB92C9B1E6000B4FCA8 /* MockWebRTCCoordinatorFactory.swift */,
 				40AF6A3A2C93469000BA2935 /* MockWebSocketClientFactory.swift */,
 				406B3C5C2C92E37500FC93A1 /* MockInternetConnection.swift */,
@@ -4718,6 +4736,7 @@
 				40A0E9612B88D3DC0089E8D3 /* UIInterfaceOrientation+CGOrientation.swift */,
 				40C4DF432C1C261D0035DBC2 /* Publisher+WeakAssign.swift */,
 				408CE0F22BD905920052EC3A /* Models+Sendable.swift */,
+				402F04AC2B714E9B00CA1986 /* DeviceOrientation */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4789,6 +4808,7 @@
 		84D6494529E9F2B7002CA428 /* WebRTC */ = {
 			isa = PBXGroup;
 			children = (
+				40FE5EB92C9C7D35006B0881 /* VideoCapturing */,
 				406B3C072C8F602D00FC93A1 /* v2 */,
 				40AB34BD2C5D33C800B5B6B3 /* SFU */,
 				40AB34B72C5D2F4D00B5B6B3 /* Extensions */,
@@ -5034,7 +5054,6 @@
 				4049CE802BBBF73A003D07D2 /* AsyncImage */,
 				403FF3E22BA1D2270092CE8A /* StreamPixelBufferRepository */,
 				40FA12EE2B76AC4B00CE3EC9 /* Extensions */,
-				402F04AC2B714E9B00CA1986 /* DeviceOrientation */,
 				40E1104A2B5A9F5B007DF492 /* Formatters */,
 				40A9416C2B4D958A006D6965 /* PictureInPicture */,
 				40AA2EE02AE00179000DCA5C /* ClipCorners.swift */,
@@ -6405,6 +6424,7 @@
 				8206D8532A5FF3260099F5EC /* SystemEnvironment+Version.swift in Sources */,
 				84CD12202C73831000056640 /* CallMissedEvent.swift in Sources */,
 				842B8E1C2A2DFED900863A87 /* AcceptCallResponse.swift in Sources */,
+				40FE5EB32C9C73E0006B0881 /* StreamDeviceOrientationAdapter.swift in Sources */,
 				40C9E45B2C9987CE00802B28 /* Publisher+Sendable.swift in Sources */,
 				40F18B8E2BEBB65100ADF76E /* View+OptionalPublisher.swift in Sources */,
 				40C9E4512C9880DB00802B28 /* Unwrap.swift in Sources */,
@@ -6523,6 +6543,7 @@
 				842747F129EED88800E063AD /* InternetConnection_Tests.swift in Sources */,
 				40C9E4552C988CE100802B28 /* WebRTCJoinRequestFactory_Tests.swift in Sources */,
 				84F58B9329EEB53E00010C4C /* EventMiddleware_Mock.swift in Sources */,
+				40FE5EBF2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */,
 				842747EC29EED59000E063AD /* JSONDecoder_Tests.swift in Sources */,
 				406B3C142C8F870400FC93A1 /* MockActiveCallProvider.swift in Sources */,
 				841FF5052A5D815700809BBB /* VideoCapturerUtils_Tests.swift in Sources */,
@@ -6559,6 +6580,7 @@
 				40382F472C89D00200C2D00F /* Stream_Video_Sfu_Models_Participant+Convenience.swift in Sources */,
 				84DC44982BA3ACC70050290C /* CallStatsReporting_Tests.swift in Sources */,
 				84F58B7229EE922700010C4C /* WebSocketConnectionState_Tests.swift in Sources */,
+				40FE5EBD2C9C82A6006B0881 /* MockRTCVideoCapturerDelegate.swift in Sources */,
 				40382F3D2C89C11D00C2D00F /* MockRTCPeerConnectionCoordinatorFactory.swift in Sources */,
 				40AB31262A49838000C270E1 /* EventTests.swift in Sources */,
 				84F58B7C29EE979F00010C4C /* VirtualTime.swift in Sources */,
@@ -6590,6 +6612,7 @@
 				8492B87A29081E6600006649 /* StreamVideo_Mock.swift in Sources */,
 				84D6494729E9F2D0002CA428 /* WebRTCClient_Tests.swift in Sources */,
 				4013387A2BF248CC007318BD /* MockCall.swift in Sources */,
+				40FE5EBB2C9C7D40006B0881 /* StreamVideoCaptureHandler_Tests.swift in Sources */,
 				40AB34BF2C5D33CF00B5B6B3 /* SFUAdapter_Tests.swift in Sources */,
 				40F017532BBEF01F00E89FD1 /* RingSettings+Dummy.swift in Sources */,
 				40F017732BBEF28600E89FD1 /* CallAcceptedEvent+Dummy.swift in Sources */,
@@ -6759,7 +6782,6 @@
 				8469593E29BF214700134EA0 /* ViewExtensions.swift in Sources */,
 				4049CE822BBBF74C003D07D2 /* LegacyAsyncImage.swift in Sources */,
 				40F0C3A72BC7FAA400AB75AD /* VideoRendererPool.swift in Sources */,
-				402F04AE2B714E9B00CA1986 /* StreamDeviceOrientationAdapter.swift in Sources */,
 				4049CE842BBBF8EF003D07D2 /* StreamAsyncImage.swift in Sources */,
 				40C7B82C2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift in Sources */,
 				40245F322BE269E300FCF075 /* StatelessVideoIconView.swift in Sources */,
@@ -6812,6 +6834,7 @@
 				40245F452BE2746300FCF075 /* CallIngressResponse+Dummy.swift in Sources */,
 				40245F462BE2746300FCF075 /* GeofenceSettings+Dummy.swift in Sources */,
 				40245F472BE2746300FCF075 /* CallRejectedEvent+Dummy.swift in Sources */,
+				40FE5EC12C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */,
 				40245F482BE2746300FCF075 /* CallParticipantResponse+Dummy.swift in Sources */,
 				40245F492BE2746300FCF075 /* EgressHLSResponse+Dummy.swift in Sources */,
 				40245F4A2BE2746300FCF075 /* CallSessionParticipantLeftEvent+Dummy.swift in Sources */,
@@ -6913,6 +6936,7 @@
 				40382F482C89D03700C2D00F /* Stream_Video_Sfu_Models_ConnectionQuality+Convenience.swift in Sources */,
 				408CE0F92BD95F1B0052EC3A /* VideoConfig+Dummy.swift in Sources */,
 				40382F462C89D00200C2D00F /* Stream_Video_Sfu_Models_Participant+Convenience.swift in Sources */,
+				40FE5EC02C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */,
 				82E3BA432A0BAE0A001AB93E /* EventBatcher_Mock.swift in Sources */,
 				8493227E29093A420013C029 /* StreamVideo_Mock.swift in Sources */,
 				82E3BA4F2A0BAE4E001AB93E /* VirtualTimer.swift in Sources */,

--- a/StreamVideoSwiftUITests/CallView/ParticipantsGridLayout_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/ParticipantsGridLayout_Tests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
     
-    private var mockedOrientation: StreamDeviceOrientation! = .portrait
+    private var mockedOrientation: StreamDeviceOrientation! = .portrait(isUpsideDown: false)
     private lazy var orientationAdapter: StreamDeviceOrientationAdapter! = .init { self.mockedOrientation }
 
     private lazy var callController: CallController_Mock! = CallController_Mock(
@@ -45,7 +45,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
     
     @MainActor
     func test_grid_participantWithAudio_snapshot() {
-        mockedOrientation = .portrait
+        mockedOrientation = .portrait(isUpsideDown: false)
 
         for count in gridParticipants {
             let layout = ParticipantsGridLayout(
@@ -61,7 +61,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
     
     @MainActor
     func test_grid_participantWithoutAudio_snapshot() {
-        mockedOrientation = .portrait
+        mockedOrientation = .portrait(isUpsideDown: false)
 
         for count in gridParticipants {
             let layout = ParticipantsGridLayout(
@@ -77,7 +77,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
     
     @MainActor
     func test_grid_participantsConnectionQuality_snapshot() throws {
-        mockedOrientation = .portrait
+        mockedOrientation = .portrait(isUpsideDown: false)
 
         for quality in connectionQuality {
             let count = gridParticipants.last!
@@ -94,7 +94,7 @@ final class ParticipantsGridLayout_Tests: StreamVideoUITestCase {
     
     @MainActor
     func test_grid_participantsSpeaking_snapshot() {
-        mockedOrientation = .portrait
+        mockedOrientation = .portrait(isUpsideDown: false)
 
         for count in gridParticipants {
             let participants = ParticipantFactory.get(count, speaking: true)

--- a/StreamVideoTests/Mock/MockRTCVideoCapturerDelegate.swift
+++ b/StreamVideoTests/Mock/MockRTCVideoCapturerDelegate.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+//
+//  MockRTCVideoCapturerDelegate.swift
+//  StreamVideo
+//
+//  Created by Ilias Pavlidakis on 19/9/24.
+//
+import StreamWebRTC
+
+final class MockRTCVideoCapturerDelegate: NSObject, RTCVideoCapturerDelegate {
+    private(set) var didCaptureWasCalledWith: (capturer: RTCVideoCapturer, frame: RTCVideoFrame)?
+
+    func capturer(
+        _ capturer: RTCVideoCapturer,
+        didCapture frame: RTCVideoFrame
+    ) {
+        didCaptureWasCalledWith = (capturer, frame)
+    }
+}

--- a/StreamVideoTests/Utilities/Extensions/CVPixelBuffer+Convenience.swift
+++ b/StreamVideoTests/Utilities/Extensions/CVPixelBuffer+Convenience.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreVideo
+import Foundation
+import StreamVideo
+
+extension CVPixelBuffer {
+    static func make(bufferSize: CGSize = .init(width: 100, height: 100)) throws -> CVPixelBuffer {
+        var cvPool: CVPixelBufferPool?
+        let poolAttributes: [String: Any] = [
+            kCVPixelBufferPoolMinimumBufferCountKey as String: 5
+        ]
+        let pixelBufferAttributes: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+            kCVPixelBufferWidthKey as String: Int(bufferSize.width),
+            kCVPixelBufferHeightKey as String: Int(bufferSize.height),
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+        ]
+        CVPixelBufferPoolCreate(
+            nil,
+            poolAttributes as CFDictionary,
+            pixelBufferAttributes as CFDictionary,
+            &cvPool
+        )
+        guard let pool = cvPool else {
+            throw ClientError()
+        }
+
+        var pixelBuffer: CVPixelBuffer?
+        let error = CVPixelBufferPoolCreatePixelBuffer(
+            nil,
+            pool,
+            &pixelBuffer
+        )
+
+        if error == kCVReturnWouldExceedAllocationThreshold {
+            throw ClientError("\(kCVReturnWouldExceedAllocationThreshold)")
+        } else if let pixelBuffer {
+            return pixelBuffer
+        } else {
+            throw ClientError()
+        }
+    }
+}

--- a/StreamVideoTests/WebRTC/VideoCapturing/StreamVideoCaptureHandler_Tests.swift
+++ b/StreamVideoTests/WebRTC/VideoCapturing/StreamVideoCaptureHandler_Tests.swift
@@ -1,0 +1,131 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import StreamWebRTC
+import XCTest
+
+final class StreamVideoCaptureHandler_Tests: XCTestCase {
+
+    private lazy var source: MockRTCVideoCapturerDelegate! = .init()
+    private lazy var subject: StreamVideoCaptureHandler! = .init(
+        source: source,
+        filters: []
+    )
+
+    // MARK: - Lifecycle
+
+    override func tearDown() {
+        subject = nil
+        source = nil
+        super.tearDown()
+    }
+
+    // MARK: - capturer(_:didCapture:)
+
+    // MARK: camera: front
+
+    func test_didCapture_orientationPortraitCameraFront_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .portrait(isUpsideDown: false),
+            cameraPosition: .front,
+            expected: ._90
+        )
+    }
+
+    func test_didCapture_orientationPortraitUpsideDownCameraFront_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .portrait(isUpsideDown: true),
+            cameraPosition: .front,
+            expected: ._270
+        )
+    }
+
+    func test_didCapture_orientationLandscapeLeftCameraFront_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .landscape(isLeft: true),
+            cameraPosition: .front,
+            expected: ._180
+        )
+    }
+
+    func test_didCapture_orientationLandscapeRightCameraFront_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .landscape(isLeft: false),
+            cameraPosition: .front,
+            expected: ._0
+        )
+    }
+
+    // MARK: camera: back
+
+    func test_didCapture_orientationPortraitCameraBack_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .portrait(isUpsideDown: false),
+            cameraPosition: .back,
+            expected: ._90
+        )
+    }
+
+    func test_didCapture_orientationPortraitUpsideDownCameraBack_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .portrait(isUpsideDown: true),
+            cameraPosition: .back,
+            expected: ._270
+        )
+    }
+
+    func test_didCapture_orientationLandscapeLeftCameraBack_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .landscape(isLeft: true),
+            cameraPosition: .back,
+            expected: ._0
+        )
+    }
+
+    func test_didCapture_orientationLandscapeRightCameraBack_frameHasExpectedOrientation() async throws {
+        try await assertFrameOrientation(
+            deviceOrientation: .landscape(isLeft: false),
+            cameraPosition: .back,
+            expected: ._180
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    func assertFrameOrientation(
+        deviceOrientation: StreamDeviceOrientation,
+        cameraPosition: AVCaptureDevice.Position,
+        expected: RTCVideoRotation,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws {
+        let orientationAdapter = StreamDeviceOrientationAdapter() { deviceOrientation }
+        InjectedValues[\.orientationAdapter] = orientationAdapter
+        let capturer: RTCVideoCapturer! = .init()
+        _ = subject
+        subject.currentCameraPosition = cameraPosition
+        let frame = RTCVideoFrame(
+            buffer: RTCCVPixelBuffer(pixelBuffer: try .make()),
+            rotation: ._270,
+            timeStampNs: 0
+        )
+
+        subject.capturer(capturer, didCapture: frame)
+
+        await fulfillment(file: file, line: line) { self.source.didCaptureWasCalledWith != nil }
+        XCTAssertTrue(
+            source.didCaptureWasCalledWith?.capturer === capturer,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            source.didCaptureWasCalledWith?.frame.rotation.rawValue,
+            expected.rawValue,
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://stream-io.atlassian.net/browse/PBE-6062

### 📝 Summary

Probably, due to the re-creation of the capturer after a reconnection, orientation changes don't propagate correctly, causing the local track to appear disoriented.

### 🛠 Implementation

We are moving to `StreamVideo`, the `StreamDeviceOrientationAdapter` and update the `StreamDeviceOrientation` cases to be more informative. We then update the `StreamVideoCaptureHandler` to rely on the `StreamDeviceOrientationAdapter` rather than on notifications. In that way we maintain a centralised storage for orientation between `StreamVideo` & `StreamVideoSwiftUI`.

⚠️ Breaking Changes ⚠️ 
- The `StreamDeviceOrientation` values now are `.portrait(isUpsideDown: Bool)` & `.landscape(isLeft: Bool)`.

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)