### PR TITLE
Stop SFU event observation during reconnection

### DIFF
--- a/Sources/StreamVideo/Utils/DisposableBag/DisposableBag.swift
+++ b/Sources/StreamVideo/Utils/DisposableBag/DisposableBag.swift
@@ -25,19 +25,21 @@ public final class DisposableBag: @unchecked Sendable {
             }
         }
 
-        public func remove(_ key: String) {
+        func remove(_ key: String) {
             queue.sync {
                 storage[key]?.cancel()
                 storage[key] = nil
             }
         }
 
-        public func removeAll() {
+        func removeAll() {
             queue.sync {
                 storage.values.forEach { $0.cancel() }
                 storage = [:]
             }
         }
+
+        var isEmpty: Bool { queue.sync { storage.isEmpty } }
     }
 
     private let storage: Storage = .init()
@@ -58,6 +60,8 @@ public final class DisposableBag: @unchecked Sendable {
     public func removeAll() {
         storage.removeAll()
     }
+
+    public var isEmpty: Bool { storage.isEmpty }
 }
 
 extension AnyCancellable {

--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUEventAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUEventAdapter.swift
@@ -22,6 +22,8 @@ final class SFUEventAdapter {
     /// The threshold of participants above which certain behaviors change.
     private let participantsThreshold = 10
 
+    var isActive: Bool { !disposableBag.isEmpty }
+
     /// Initializes a new instance of SFUEventAdapter.
     ///
     /// - Parameters:
@@ -34,6 +36,11 @@ final class SFUEventAdapter {
         self.sfuAdapter = sfuAdapter
         self.stateAdapter = stateAdapter
         observeEvents()
+    }
+
+    /// Stop event observation. Useful when reconnection, to avoid any unnecessary updates on the UI.
+    func stopObserving() {
+        disposableBag.removeAll()
     }
 
     /// Observes various SFU events and sets up handlers for each.

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrating.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrating.swift
@@ -74,6 +74,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                             .stateAdapter
                             .sfuAdapter
 
+                        context.sfuEventObserver?.stopObserving()
                         context.sfuEventObserver = nil
                         context.migratingFromSFU = context.currentSFU
                         context.currentSFU = ""

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Rejoining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Rejoining.swift
@@ -101,6 +101,10 @@ extension WebRTCCoordinator.StateMachine.Stage {
 
                     try Task.checkCancellation()
 
+                    context.sfuEventObserver?.stopObserving()
+
+                    try Task.checkCancellation()
+
                     await coordinator
                         .stateAdapter
                         .cleanUpForReconnection()


### PR DESCRIPTION
### 🎯 Goal

Reduce the amount of unnecessary UI updates during a reconnection.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)