### PR TITLE
[Fix]Error propagation on new WebRTC Stack

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
@@ -84,7 +84,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     ring: ring,
                     notify: notify,
                     options: options,
-                    updateSession: false
+                    updateSession: false,
+                    onErrorDisconnect: false
                 )
                 return self
             case .rejoining:
@@ -98,7 +99,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     ring: false,
                     notify: false,
                     options: nil,
-                    updateSession: true
+                    updateSession: true,
+                    onErrorDisconnect: true
                 )
                 return self
             default:
@@ -120,7 +122,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
             ring: Bool,
             notify: Bool,
             options: CreateCallOptions?,
-            updateSession: Bool
+            updateSession: Bool,
+            onErrorDisconnect: Bool
         ) {
             Task { [weak self] in
                 guard let self else { return }
@@ -178,9 +181,13 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     /// reconnection.
                     transitionOrDisconnect(.connected(context))
                 } catch {
-                    /// In case of an error, we transition to ``.disconnected`` with the error
-                    /// stored in the context, in order to allow for reconnection.
-                    transitionDisconnectOrError(error)
+                    if onErrorDisconnect {
+                        /// In case of an error, we transition to ``.disconnected`` with the error
+                        /// stored in the context, in order to allow for reconnection.
+                        transitionDisconnectOrError(error)
+                    } else {
+                        transitionErrorOrLog(error)
+                    }
                 }
             }
             .store(in: disposableBag)

--- a/SwiftUIDemoAppUITests/Pages/CallDetailsPage.swift
+++ b/SwiftUIDemoAppUITests/Pages/CallDetailsPage.swift
@@ -26,6 +26,6 @@ enum CallDetailsPage {
     }
     static var participants: XCUIElementQuery { participantList.buttons }
     static var connectionErrorAlert: XCUIElement {
-        app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'StreamVideo.ClientError'")).firstMatch
+        app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'StreamVideo.APIError'")).firstMatch
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Fix the error propagation in the new WebRTC stack to provide the same support we did before the reconnection-v2.

### 📝 Summary

When we are connecting to a call, for the first time (not through a reconnection) in the case of an error, we want to escalate the error and cancel joining.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)