### PR TITLE
[Fix]Capture quality adaptive policy criteria

### DIFF
--- a/Sources/StreamVideo/Utils/ThermalStateObserver.swift
+++ b/Sources/StreamVideo/Utils/ThermalStateObserver.swift
@@ -108,6 +108,15 @@ final class ThermalStateObserver: ObservableObject, ThermalStateObserving {
     }
 }
 
+extension ProcessInfo.ThermalState: Comparable {
+    public static func < (
+        lhs: ProcessInfo.ThermalState,
+        rhs: ProcessInfo.ThermalState
+    ) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
 /// Provides the default value of the `Appearance` class.
 enum ThermalStateObserverKey: InjectionKey {
     static var currentValue: any ThermalStateObserving = ThermalStateObserver.shared

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -446,6 +446,9 @@
 		40C4DF572C1C61BD0035DBC2 /* URL+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401A64B22A9DF86200534ED1 /* URL+Convenience.swift */; };
 		40C689182C64DDC70054528A /* Publisher+TaskSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C689172C64DDC70054528A /* Publisher+TaskSink.swift */; };
 		40C6891C2C657F280054528A /* Publisher+AsyncStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C6891B2C657F280054528A /* Publisher+AsyncStream.swift */; };
+		40C75BB72CB4044600C167C3 /* MockThermalStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C75BB62CB4044600C167C3 /* MockThermalStateObserver.swift */; };
+		40C75BB82CB4045100C167C3 /* MockThermalStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C75BB62CB4044600C167C3 /* MockThermalStateObserver.swift */; };
+		40C75BB92CB40D8700C167C3 /* Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013387B2BF248E9007318BD /* Mockable.swift */; };
 		40C7B82C2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B82B2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift */; };
 		40C7B8322B61325500FB9DB2 /* ModalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B8312B61325500FB9DB2 /* ModalButton.swift */; };
 		40C7B8342B613A8200FB9DB2 /* ControlBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7B8332B613A8200FB9DB2 /* ControlBadgeView.swift */; };
@@ -1701,6 +1704,7 @@
 		40C689192C64F74F0054528A /* SFUSignalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFUSignalService.swift; sourceTree = "<group>"; };
 		40C6891B2C657F280054528A /* Publisher+AsyncStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+AsyncStream.swift"; sourceTree = "<group>"; };
 		40C6891D2C6661990054528A /* SFUEventAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFUEventAdapter.swift; sourceTree = "<group>"; };
+		40C75BB62CB4044600C167C3 /* MockThermalStateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockThermalStateObserver.swift; sourceTree = "<group>"; };
 		40C7B82B2B612D6000FB9DB2 /* ParticipantsListViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsListViewModifier.swift; sourceTree = "<group>"; };
 		40C7B8312B61325500FB9DB2 /* ModalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalButton.swift; sourceTree = "<group>"; };
 		40C7B8332B613A8200FB9DB2 /* ControlBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBadgeView.swift; sourceTree = "<group>"; };
@@ -4620,6 +4624,7 @@
 		8492B87629081CE700006649 /* Mock */ = {
 			isa = PBXGroup;
 			children = (
+				40C75BB62CB4044600C167C3 /* MockThermalStateObserver.swift */,
 				40FE5EBC2C9C82A6006B0881 /* MockRTCVideoCapturerDelegate.swift */,
 				40483CB92C9B1E6000B4FCA8 /* MockWebRTCCoordinatorFactory.swift */,
 				40AF6A3A2C93469000BA2935 /* MockWebSocketClientFactory.swift */,
@@ -6606,6 +6611,7 @@
 				40C9E4552C988CE100802B28 /* WebRTCJoinRequestFactory_Tests.swift in Sources */,
 				84F58B9329EEB53E00010C4C /* EventMiddleware_Mock.swift in Sources */,
 				40FE5EBF2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */,
+				40C75BB72CB4044600C167C3 /* MockThermalStateObserver.swift in Sources */,
 				842747EC29EED59000E063AD /* JSONDecoder_Tests.swift in Sources */,
 				406B3C142C8F870400FC93A1 /* MockActiveCallProvider.swift in Sources */,
 				841FF5052A5D815700809BBB /* VideoCapturerUtils_Tests.swift in Sources */,
@@ -6898,6 +6904,7 @@
 				40245F452BE2746300FCF075 /* CallIngressResponse+Dummy.swift in Sources */,
 				40245F462BE2746300FCF075 /* GeofenceSettings+Dummy.swift in Sources */,
 				40245F472BE2746300FCF075 /* CallRejectedEvent+Dummy.swift in Sources */,
+				40C75BB92CB40D8700C167C3 /* Mockable.swift in Sources */,
 				40FE5EC12C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */,
 				40245F482BE2746300FCF075 /* CallParticipantResponse+Dummy.swift in Sources */,
 				40245F492BE2746300FCF075 /* EgressHLSResponse+Dummy.swift in Sources */,
@@ -6913,6 +6920,7 @@
 				40245F672BE27B8400FCF075 /* StatelessSpeakerIconView_Tests.swift in Sources */,
 				40245F692BE27CCB00FCF075 /* StatelessParticipantsListButton_Tests.swift in Sources */,
 				40245F532BE2746300FCF075 /* TranscriptionSettings+Dummy.swift in Sources */,
+				40C75BB82CB4045100C167C3 /* MockThermalStateObserver.swift in Sources */,
 				40245F542BE2746300FCF075 /* BroadcastSettingsResponse+Dummy.swift in Sources */,
 				40245F552BE2746300FCF075 /* UserResponse+Dummy.swift in Sources */,
 				40245F562BE2746300FCF075 /* ScreensharingSettings+Dummy.swift in Sources */,

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -294,12 +294,13 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
             .coordinator
             .changePinState(isEnabled: false, sessionId: user.id)
 
-        await assertNilAsync(
-            await mockWebRTCCoordinatorFactory
+        await fulfillment {
+            await self
+                .mockWebRTCCoordinatorFactory
                 .mockCoordinatorStack
                 .coordinator
-                .stateAdapter.participants[user.id]?.pin
-        )
+                .stateAdapter.participants[self.user.id]?.pin == nil
+        }
     }
 
     // MARK: - startNoiseCancellation

--- a/StreamVideoTests/Mock/MockThermalStateObserver.swift
+++ b/StreamVideoTests/Mock/MockThermalStateObserver.swift
@@ -1,0 +1,47 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamVideo
+
+final class MockThermalStateObserver: ThermalStateObserving, Mockable {
+
+    // MARK: - Mockable
+
+    typealias FunctionKey = MockFunctionKey
+    typealias FunctionInputKey = EmptyPayloadable
+    var stubbedProperty: [String: Any] = [:]
+    var stubbedFunction: [FunctionKey: Any] = [:]
+    @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = [:]
+    func stub<T>(for keyPath: KeyPath<MockThermalStateObserver, T>, with value: T) {
+        stubbedProperty[propertyKey(for: keyPath)] = value
+    }
+
+    func stub<T>(for function: FunctionKey, with value: T) {}
+
+    enum MockFunctionKey: Hashable, CaseIterable {}
+
+    // MARK: - Properties
+
+    var state: ProcessInfo.ThermalState {
+        get { self[dynamicMember: \.state] }
+        set { _ = newValue }
+    }
+
+    var statePublisher: AnyPublisher<ProcessInfo.ThermalState, Never> {
+        get { self[dynamicMember: \.statePublisher] }
+        set { _ = newValue }
+    }
+
+    var scale: CGFloat {
+        get { self[dynamicMember: \.scale] }
+        set { _ = newValue }
+    }
+
+    init() {
+        InjectedValues[\.thermalStateObserver] = self
+        stub(for: \.state, with: .nominal)
+        stub(for: \.scale, with: 1)
+    }
+}

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/VideoCapturePolicy/AdaptiveVideoCapturePolicy_tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/VideoCapturePolicy/AdaptiveVideoCapturePolicy_tests.swift
@@ -22,12 +22,19 @@ final class AdaptiveVideoCapturePolicy_Tests: XCTestCase {
         localTrack: videoTrack,
         capturer: cameraVideoCapturer
     )
-    private lazy var subject: AdaptiveVideoCapturePolicy! = .init()
+    private lazy var thermalStateObserver: MockThermalStateObserver! = .init()
+    private var subject: AdaptiveVideoCapturePolicy!
 
     // MARK: - Lifecycle
 
+    override func setUp() {
+        super.setUp()
+        _ = thermalStateObserver
+    }
+
     override func tearDown() {
         subject = nil
+        thermalStateObserver = nil
         activeCaptureSession = nil
         cameraVideoCapturer = nil
         videoTrack = nil
@@ -38,37 +45,701 @@ final class AdaptiveVideoCapturePolicy_Tests: XCTestCase {
 
     // MARK: - updateCaptureQuality
 
-    func test_updateCaptureQuality_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec() async throws {
-        try await assertUpdateCaptureQuality(expected: [.full, .half, .quarter])
+    // MARK: ThermalState: .nominal | neuralEngineExists: false
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
     }
 
-    func test_updateCaptureQuality_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec() async throws {
-        try await assertUpdateCaptureQuality(expected: [.half, .quarter])
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
     }
 
-    func test_updateCaptureQuality_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec() async throws {
-        try await assertUpdateCaptureQuality(expected: [.full, .quarter])
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
     }
 
-    func test_updateCaptureQuality_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec() async throws {
-        try await assertUpdateCaptureQuality(expected: [.full])
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
     }
 
-    func test_updateCaptureQuality_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec() async throws {
-        try await assertUpdateCaptureQuality(expected: [.half])
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
     }
 
-    func test_updateCaptureQuality_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec() async throws {
-        try await assertUpdateCaptureQuality(expected: [.quarter])
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineDoesNotExist_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .nominal
+        )
+    }
+
+    // MARK: ThermalState: .nominal | neuralEngineExists: true
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateNominal_neuralEngineExists_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .nominal
+        )
+    }
+
+    // MARK: ThermalState: .fair | neuralEngineExists: false
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineDoesNotExist_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .fair
+        )
+    }
+
+    // MARK: ThermalState: .fair | neuralEngineExists: true
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateFair_neuralEngineExists_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 0,
+            neuralEngineExists: true,
+            thermalState: .fair
+        )
+    }
+
+    // MARK: thermalState: .serious | neuralEngineExists: false
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineDoesNotExist_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .serious
+        )
+    }
+
+    // MARK: thermalState: .serious | neuralEngineExists: true
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateSerious_neuralEngineExists_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .serious
+        )
+    }
+
+    // MARK: thermalState: .critical | neuralEngineExists: false
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineDoesNotExist_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: false,
+            thermalState: .critical
+        )
+    }
+
+    // MARK: thermalState: .critical | neuralEngineExists: true
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_fullHalfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full, .half, .quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_halfAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .half,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_fullAndQuarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [
+                .full,
+                .quarter
+            ],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_fullEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.full],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_halfEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.half],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_quarterEncodingsAreActive_capturerWasCalledWithExpectedVideoCodec(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+    }
+
+    func test_updateCaptureQuality_thermalStateCritical_neuralEngineExists_quarterEncodingsMatchTheCurrentlyActiveOnes_capturerWasNotCalledASecondTime(
+    ) async throws {
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
+
+        try await assertUpdateCaptureQuality(
+            expected: [.quarter],
+            expectedTimesCalled: 1,
+            neuralEngineExists: true,
+            thermalState: .critical
+        )
     }
 
     // MARK: - Private helpers
 
     private func assertUpdateCaptureQuality(
         expected: [VideoCodec],
+        expectedTimesCalled: Int,
+        neuralEngineExists: Bool,
+        thermalState: ProcessInfo.ThermalState,
         file: StaticString = #file,
         line: UInt = #line
     ) async throws {
+        if subject == nil {
+            subject = .init { neuralEngineExists }
+        }
+        thermalStateObserver.stub(for: \.state, with: thermalState)
+
         try await subject.updateCaptureQuality(
             with: .init(
                 expected.map(\.quality)
@@ -78,16 +749,20 @@ final class AdaptiveVideoCapturePolicy_Tests: XCTestCase {
 
         XCTAssertEqual(
             cameraVideoCapturer.timesCalled(.updateCaptureQuality),
-            1,
+            expectedTimesCalled,
             file: file,
             line: line
         )
-        XCTAssertEqual(
-            cameraVideoCapturer.recordedInputPayload(([VideoCodec], AVCaptureDevice?).self, for: .updateCaptureQuality)?.first?.0
-                .map(\.quality).sorted(),
-            expected.map(\.quality).sorted(),
-            file: file,
-            line: line
-        )
+
+        if expectedTimesCalled > 0 {
+            XCTAssertEqual(
+                cameraVideoCapturer.recordedInputPayload(([VideoCodec], AVCaptureDevice?).self, for: .updateCaptureQuality)?.first?
+                    .0
+                    .map(\.quality).sorted(),
+                expected.map(\.quality).sorted(),
+                file: file,
+                line: line
+            )
+        }
     }
 }

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/VideoCapturePolicy/AdaptiveVideoCapturePolicy_tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/VideoCapturePolicy/AdaptiveVideoCapturePolicy_tests.swift
@@ -9,6 +9,8 @@ import XCTest
 
 final class AdaptiveVideoCapturePolicy_Tests: XCTestCase {
 
+    private static var thermalStateObserver: MockThermalStateObserver! = .init()
+
     private lazy var device: AVCaptureDevice! = .init(uniqueID: .unique)
     private lazy var peerConnectionFactory: PeerConnectionFactory! = .mock()
     private lazy var videoTrack: RTCVideoTrack! = (
@@ -22,19 +24,18 @@ final class AdaptiveVideoCapturePolicy_Tests: XCTestCase {
         localTrack: videoTrack,
         capturer: cameraVideoCapturer
     )
-    private lazy var thermalStateObserver: MockThermalStateObserver! = .init()
     private var subject: AdaptiveVideoCapturePolicy!
 
     // MARK: - Lifecycle
 
-    override func setUp() {
-        super.setUp()
-        _ = thermalStateObserver
+    override class func tearDown() {
+        Self.thermalStateObserver = nil
+        InjectedValues[\.thermalStateObserver] = ThermalStateObserver.shared
+        super.tearDown()
     }
 
     override func tearDown() {
         subject = nil
-        thermalStateObserver = nil
         activeCaptureSession = nil
         cameraVideoCapturer = nil
         videoTrack = nil
@@ -738,7 +739,7 @@ final class AdaptiveVideoCapturePolicy_Tests: XCTestCase {
         if subject == nil {
             subject = .init { neuralEngineExists }
         }
-        thermalStateObserver.stub(for: \.state, with: thermalState)
+        Self.thermalStateObserver.stub(for: \.state, with: thermalState)
 
         try await subject.updateCaptureQuality(
             with: .init(

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -353,9 +353,13 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
 
         try await subject.changePinState(isEnabled: false, sessionId: user.id)
 
-        await assertNilAsync(
-            await subject.stateAdapter.participants[user.id]?.pin
-        )
+        await fulfillment {
+            await self
+                .subject
+                .stateAdapter
+                .participants[self.user.id]?
+                .pin == nil
+        }
     }
 
     // MARK: - startNoiseCancellation

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -469,9 +469,13 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
             for: participant.sessionId
         )
 
-        await assertNilAsync(
-            await subject.participants[participant.sessionId]?.track?.trackId
-        )
+        await fulfillment {
+            await self
+                .subject
+                .participants[participant.sessionId]?
+                .track?
+                .trackId == nil
+        }
     }
 
     func test_didRemoveTrack_screenSharingOfExistingParticipant_shouldRemoveTrack() async throws {
@@ -486,9 +490,13 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
             for: participant.sessionId
         )
 
-        await assertNilAsync(
-            await subject.participants[participant.sessionId]?.screenshareTrack?.trackId
-        )
+        await fulfillment {
+            await self
+                .subject
+                .participants[participant.sessionId]?
+                .screenshareTrack?
+                .trackId == nil
+        }
     }
 
     // MARK: - trackFor


### PR DESCRIPTION
### 🎯 Goal

Provide stricter for adapting the video capturing quality.

### 📝 Summary

On low end devices or when a device is under thermal stress, we will be activating the adaptive capture quality policy, which will ensure that the capturing video frames are matching the highest quality that SFU has instruct us to send. 

The reason for the limiting criteria, is to avoid a blinking that occurs every time the quality changes, on devices that don't really need to change capturing quality (as it doesn't heavily affect their performance).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)