### PR TITLE
[Fix]CallKitService storage access

### DIFF
--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -387,7 +387,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
         await waitExpectation()
 
-        XCTAssertEqual(subject.storage.count, 1)
+        XCTAssertEqual(subject.callCount, 1)
 
         // Stub with the new call
         let secondCallUUID = UUID()
@@ -408,7 +408,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             callerId: callerId
         ) { _ in }
 
-        XCTAssertEqual(subject.storage.count, 2)
+        XCTAssertEqual(subject.callCount, 2)
 
         subject.provider(
             callProvider,
@@ -417,9 +417,9 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             )
         )
 
-        await fulfillment { [weak subject] in subject?.storage.count == 1 }
+        await fulfillment { [weak subject] in subject?.callCount == 1 }
 
-        XCTAssertEqual(subject.storage.count, 1)
+        XCTAssertEqual(subject.callCount, 1)
     }
 
     // MARK: - callEnded


### PR DESCRIPTION
### 🔗 Issue Links

https://getstream.zendesk.com/agent/tickets/56365

### 📝 Summary

When performing the EndCall action provider in CallKit, there is an access issue occurring, because at the same time we receive and process a callEnded event from the Stream backend.

### 🛠 Implementation

We now ensure that access to the internal callEntry storage is thread-safe.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)