### PR TITLE
[Fix]SetPublisher track setUp race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - You can now set the time a user can remain in the call - after their connection disrupted - while waiting for their network connection to recover [#573](https://github.com/GetStream/stream-video-swift/pull/573)
 - You can now provide the preferred Video stream codec to use [#583](https://github.com/GetStream/stream-video-swift/pull/583)
 
+### 🐞 Fixed
+- In some cases when joining a call setup wasn't completed correctly which lead in issues during the call (e.g. missing video tracks or mute state not updating). [#586](https://github.com/GetStream/stream-video-swift/pull/586)
+
 # [1.13.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.13.0)
 _October 08, 2024_
 

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -531,9 +531,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
         if supportsHolding {
             log.warning("CallKit hold isn't supported.")
-//            update.supportsGrouping = true
-//            update.supportsHolding = true
-//            update.supportsUngrouping = true
         } else {
             update.supportsGrouping = false
             update.supportsHolding = false

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -264,8 +264,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 let subscriber = await coordinator.stateAdapter.subscriber {
                 let offer = try await subscriber.createOffer()
                 subscriberSessionDescription = offer.sdp
-
             } else {
+                try await publisher?.ensureSetUpHasBeenCompleted()
                 subscriberSessionDescription = try await RTCTemporaryPeerConnection(
                     sessionID: coordinator.stateAdapter.sessionID,
                     peerConnectionFactory: coordinator.stateAdapter.peerConnectionFactory,

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCConfiguration.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCConfiguration.swift
@@ -12,13 +12,15 @@ enum WebRTCConfiguration {
         var connect: TimeInterval
         var join: TimeInterval
         var migrationCompletion: TimeInterval
+        var publisherSetUpBeforeNegotiation: TimeInterval
 
         /// Timeout for authentication in production environment.
         static let production = Timeout(
             authenticate: 10,
             connect: 10,
             join: 10,
-            migrationCompletion: 10
+            migrationCompletion: 10,
+            publisherSetUpBeforeNegotiation: 2
         )
 
         #if STREAM_TESTS
@@ -27,7 +29,8 @@ enum WebRTCConfiguration {
             authenticate: 1,
             connect: 1,
             join: 1,
-            migrationCompletion: 1
+            migrationCompletion: 1,
+            publisherSetUpBeforeNegotiation: 2
         )
         #endif
     }

--- a/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinator.swift
+++ b/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinator.swift
@@ -24,6 +24,7 @@ final class MockRTCPeerConnectionCoordinator:
         case restartICE
         case close
         case setVideoFilter
+        case ensureSetUpHasBeenCompleted
         case setUp
         case beginScreenSharing
         case didUpdateCameraPosition
@@ -45,6 +46,7 @@ final class MockRTCPeerConnectionCoordinator:
         case restartICE
         case close
         case setVideoFilter(videoFilter: VideoFilter?)
+        case ensureSetUpHasBeenCompleted
         case setUp(settings: CallSettings, ownCapabilities: [OwnCapability])
         case beginScreenSharing(type: ScreensharingType, ownCapabilities: [OwnCapability])
         case stopScreenSharing
@@ -73,6 +75,8 @@ final class MockRTCPeerConnectionCoordinator:
                 return ()
             case let .setVideoFilter(videoFilter):
                 return videoFilter
+            case .ensureSetUpHasBeenCompleted:
+                return ()
             case let .setUp(settings, ownCapabilities):
                 return (settings, ownCapabilities)
             case let .beginScreenSharing(type, ownCapabilities):
@@ -217,6 +221,15 @@ final class MockRTCPeerConnectionCoordinator:
                 videoFilter: videoFilter
             )
         )
+    }
+
+    override func ensureSetUpHasBeenCompleted() async throws {
+        stubbedFunctionInput[.ensureSetUpHasBeenCompleted]?
+            .append(.ensureSetUpHasBeenCompleted)
+
+        if let result = stubbedFunction[.ensureSetUpHasBeenCompleted] as? Error {
+            throw result
+        }
     }
 
     override func setUp(

--- a/StreamVideoTests/WebRTC/v2/IntegrationTests/WebRTCIntegrationTests.swift
+++ b/StreamVideoTests/WebRTC/v2/IntegrationTests/WebRTCIntegrationTests.swift
@@ -4,7 +4,7 @@
 
 import Combine
 @testable import StreamVideo
-import XCTest
+@preconcurrency import XCTest
 
 final class WebRTCIntegrationTests: XCTestCase, @unchecked Sendable {
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCConfiguration_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCConfiguration_Tests.swift
@@ -14,5 +14,6 @@ final class WebRTCConfigurationTests: XCTestCase {
         XCTAssertEqual(timeout.connect, 10)
         XCTAssertEqual(timeout.join, 10)
         XCTAssertEqual(timeout.migrationCompletion, 10)
+        XCTAssertEqual(timeout.publisherSetUpBeforeNegotiation, 2)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://stream-io.atlassian.net/browse/PBE-6301

### 📝 Summary

In some cases, a race condition was hit, where Publisher setUp hasn't completed when the negotiation was executing. That resulted in SetPublisherRequest tracks being empty.

### 🛠 Implementation

Before negotiation, we add a small expectation (setUp must complete before proceeding) and allowing a 2 seconds waiting time for it.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)