### PR TITLE
[Fix]Empty session ids during livestream

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
@@ -218,6 +218,9 @@ final class SFUAdapter: ConnectionStateDelegate, CustomStringConvertible, @unche
     func sendJoinRequest(
         _ payload: Stream_Video_Sfu_Event_JoinRequest
     ) {
+        if payload.sessionID.isEmpty {
+            log.warning("JoinRequests should contain a sessionId.", subsystems: .sfu)
+        }
         var event = Stream_Video_Sfu_Event_SfuRequest()
         event.requestPayload = .joinRequest(payload)
         send(message: event)

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -44,7 +44,7 @@ actor WebRTCStateAdapter: ObservableObject {
     let screenShareSessionProvider: ScreenShareSessionProvider
 
     /// Published properties that represent different parts of the WebRTC state.
-    @Published private(set) var sessionID: String = ""
+    @Published private(set) var sessionID: String = UUID().uuidString
     @Published private(set) var token: String = ""
     @Published private(set) var callSettings: CallSettings = .init()
     @Published private(set) var audioSettings: AudioSettings = .init()
@@ -112,11 +112,6 @@ actor WebRTCStateAdapter: ObservableObject {
         self.rtcPeerConnectionCoordinatorFactory = rtcPeerConnectionCoordinatorFactory
         self.videoCaptureSessionProvider = videoCaptureSessionProvider
         self.screenShareSessionProvider = screenShareSessionProvider
-        let sessionID = UUID().uuidString
-
-        Task {
-            await set(sessionID: sessionID)
-        }
     }
 
     /// Sets the session ID.

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -38,6 +38,10 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
 
     // MARK: - setSessionID
 
+    func test_sessionID_shouldNotBeEmptyOnInit() async throws {
+        await assertEqualAsync(await subject.sessionID.isEmpty, false)
+    }
+
     func test_setSessionID_shouldUpdateSessionID() async throws {
         _ = subject
         _ = try await subject


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://stream-io.atlassian.net/browse/PBE-6305

### 📝 Summary

In some cases we noticed in backend logs that iOS devices connect with empty sessionIds. Even though we haven't been able to reproduce it, this revision attempts to eliminate most code paths that set the sessionId to an empty string.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)