### PR TITLE
[Improvement]Locking mechanisms and Atomic property wrapper

### DIFF
--- a/Sources/StreamVideo/Utils/Atomic.swift
+++ b/Sources/StreamVideo/Utils/Atomic.swift
@@ -28,7 +28,7 @@ final class Atomic<T> {
         case unfair
         case recursive
 
-        var queue: LockQueing {
+        var queue: LockQueuing {
             switch self {
             case .unfair:
                 return UnfairQueue()
@@ -38,7 +38,7 @@ final class Atomic<T> {
         }
     }
 
-    private let queue: LockQueing
+    private let queue: LockQueuing
     private var _value: T
 
     var wrappedValue: T {

--- a/Sources/StreamVideo/Utils/Atomic.swift
+++ b/Sources/StreamVideo/Utils/Atomic.swift
@@ -24,36 +24,40 @@ import Foundation
 
 @propertyWrapper
 final class Atomic<T> {
-    var wrappedValue: T {
-        get {
-            var currentValue: T!
-            mutate { currentValue = $0 }
-            return currentValue
-        }
+    enum Mode {
+        case unfair
+        case recursive
 
-        set {
-            mutate { $0 = newValue }
+        var queue: LockQueing {
+            switch self {
+            case .unfair:
+                return UnfairQueue()
+            case .recursive:
+                return RecursiveQueue()
+            }
         }
     }
-    
-    private let lock = NSRecursiveLock()
-    private var _wrappedValue: T
+
+    private let queue: LockQueing
+    private var _value: T
+
+    var wrappedValue: T {
+        get { queue.sync { _value } }
+        set { queue.sync { _value = newValue } }
+    }
+
+    init(wrappedValue: T, mode: Mode = .unfair) {
+        _value = wrappedValue
+        queue = mode.queue
+    }
+
+    /// Update the value safely.
+    /// - Parameter changes: a block with changes. It should return a new value.
+    func mutate(_ changes: (_ value: T) -> T) {
+        queue.sync { _value = changes(_value) }
+    }
     
     /// Update the value safely.
     /// - Parameter changes: a block with changes. It should return a new value.
-    func mutate(_ changes: (_ value: inout T) -> Void) {
-        lock.lock()
-        changes(&_wrappedValue)
-        lock.unlock()
-    }
-    
-    /// Update the value safely.
-    /// - Parameter changes: a block with changes. It should return a new value.
-    func callAsFunction(_ changes: (_ value: inout T) -> Void) {
-        mutate(changes)
-    }
-    
-    init(wrappedValue: T) {
-        _wrappedValue = wrappedValue
-    }
+    func callAsFunction(_ changes: (_ value: T) -> T) { mutate(changes) }
 }

--- a/Sources/StreamVideo/Utils/Queues/LockQueuing.swift
+++ b/Sources/StreamVideo/Utils/Queues/LockQueuing.swift
@@ -6,9 +6,9 @@ import Foundation
 
 /// A protocol defining a lock-based synchronization interface.
 ///
-/// Types conforming to `LockQueing` provide thread-safe access to resources
+/// Types conforming to `LockQueuing` provide thread-safe access to resources
 /// by executing blocks of code within a lock, ensuring mutual exclusion.
-protocol LockQueing {
+protocol LockQueuing {
 
     /// Executes a block within a lock, ensuring exclusive access.
     ///

--- a/Sources/StreamVideo/Utils/Queues/LockQueuing.swift
+++ b/Sources/StreamVideo/Utils/Queues/LockQueuing.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A protocol defining a lock-based synchronization interface.
+///
+/// Types conforming to `LockQueing` provide thread-safe access to resources
+/// by executing blocks of code within a lock, ensuring mutual exclusion.
+protocol LockQueing {
+
+    /// Executes a block within a lock, ensuring exclusive access.
+    ///
+    /// This method should guarantee that only one thread can execute the
+    /// provided block at a time, using the underlying lock mechanism.
+    ///
+    /// - Parameter block: The block of code to execute safely within the lock.
+    /// - Returns: The value returned by the block, if any.
+    /// - Throws: Rethrows any errors thrown by the block.
+    func sync<T>(_ block: () throws -> T) rethrows -> T
+}

--- a/Sources/StreamVideo/Utils/Queues/RecursiveQueue.swift
+++ b/Sources/StreamVideo/Utils/Queues/RecursiveQueue.swift
@@ -19,7 +19,7 @@ import Foundation
 /// While `NSRecursiveLock` has more overhead than `os_unfair_lock`, it is ideal for more complex code flows
 /// where reentrancy or recursive method calls require safe locking. This makes it a better fit than
 /// `os_unfair_lock` when you need the flexibility to enter the lock multiple times on the same thread.
-public final class RecursiveQueue: LockQueing, @unchecked Sendable {
+public final class RecursiveQueue: LockQueuing, @unchecked Sendable {
 
     /// The recursive lock instance.
     private let lock = NSRecursiveLock()

--- a/Sources/StreamVideo/Utils/Queues/RecursiveQueue.swift
+++ b/Sources/StreamVideo/Utils/Queues/RecursiveQueue.swift
@@ -1,0 +1,40 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A synchronization utility implementing a recursive locking mechanism.
+///
+/// This class provides a way to synchronize access to resources using `NSRecursiveLock`,
+/// which allows the same thread to acquire the lock multiple times without deadlocking.
+/// This is useful in recursive or reentrant code where multiple methods that may call each other
+/// need to access a shared resource.
+///
+/// `NSRecursiveLock` is an Objective-C-based recursive lock that provides thread safety in situations
+/// where the same thread needs to acquire the lock more than once. Unlike `os_unfair_lock`, which is non-recursive
+/// and prioritizes performance, `NSRecursiveLock` ensures that the same thread can enter critical sections
+/// repeatedly, avoiding deadlock in reentrant code scenarios.
+///
+/// While `NSRecursiveLock` has more overhead than `os_unfair_lock`, it is ideal for more complex code flows
+/// where reentrancy or recursive method calls require safe locking. This makes it a better fit than
+/// `os_unfair_lock` when you need the flexibility to enter the lock multiple times on the same thread.
+public final class RecursiveQueue: LockQueing, @unchecked Sendable {
+
+    /// The recursive lock instance.
+    private let lock = NSRecursiveLock()
+
+    /// Initializes a new instance of `RecursiveQueue`.
+    public init() {}
+
+    /// Executes a block with mutual exclusion via a recursive lock.
+    ///
+    /// - Parameter block: The block of code to execute safely under the lock.
+    /// - Returns: The value returned by the block, if any.
+    /// - Throws: Rethrows any errors thrown by the block.
+    public func sync<T>(_ block: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try block()
+    }
+}

--- a/Sources/StreamVideo/Utils/Queues/UnfairQueue.swift
+++ b/Sources/StreamVideo/Utils/Queues/UnfairQueue.swift
@@ -23,7 +23,7 @@ import Foundation
 /// additional overhead of dispatching tasks and managing thread execution in a DispatchQueue could result
 /// in unnecessary latency, making `os_unfair_lock` the superior choice for scenarios where rapid, lightweight
 /// synchronization is paramount.
-public final class UnfairQueue: @unchecked Sendable {
+public final class UnfairQueue: LockQueing, @unchecked Sendable {
 
     /// The unfair lock variable, managed as an unsafe mutable pointer to `os_unfair_lock`.
     private let lock: os_unfair_lock_t

--- a/Sources/StreamVideo/Utils/Queues/UnfairQueue.swift
+++ b/Sources/StreamVideo/Utils/Queues/UnfairQueue.swift
@@ -23,7 +23,7 @@ import Foundation
 /// additional overhead of dispatching tasks and managing thread execution in a DispatchQueue could result
 /// in unnecessary latency, making `os_unfair_lock` the superior choice for scenarios where rapid, lightweight
 /// synchronization is paramount.
-public final class UnfairQueue: LockQueing, @unchecked Sendable {
+public final class UnfairQueue: LockQueuing, @unchecked Sendable {
 
     /// The unfair lock variable, managed as an unsafe mutable pointer to `os_unfair_lock`.
     private let lock: os_unfair_lock_t

--- a/Sources/StreamVideo/WebSockets/Client/RetryStrategy.swift
+++ b/Sources/StreamVideo/WebSockets/Client/RetryStrategy.swift
@@ -43,28 +43,25 @@ struct DefaultRetryStrategy: RetryStrategy {
     @Atomic private(set) var consecutiveFailuresCount = 0
     
     mutating func incrementConsecutiveFailures() {
-        _consecutiveFailuresCount.mutate { $0 += 1 }
+        _consecutiveFailuresCount.mutate { $0 + 1 }
     }
     
     mutating func resetConsecutiveFailures() {
-        _consecutiveFailuresCount.mutate { $0 = 0 }
+        consecutiveFailuresCount = 0
     }
     
     func nextRetryDelay() -> TimeInterval {
         var delay: TimeInterval = 0
 
-        _consecutiveFailuresCount.mutate {
-            /// The first time we get to retry, we do it without any delay. Any subsequent time will
-            /// be delayed by a random interval.
-            guard $0 > 0 else {
-                return
-            }
+        let consecutiveFailuresCount = self.consecutiveFailuresCount
+        /// The first time we get to retry, we do it without any delay. Any subsequent time will
+        /// be delayed by a random interval.
+        guard consecutiveFailuresCount > 0 else { return delay }
 
-            let maxDelay: TimeInterval = min(0.5 + Double($0 * 2), Self.maximumReconnectionDelay)
-            let minDelay: TimeInterval = min(max(0.25, (Double($0) - 1) * 2), Self.maximumReconnectionDelay)
-            
-            delay = TimeInterval.random(in: minDelay...maxDelay)
-        }
+        let maxDelay: TimeInterval = min(0.5 + Double(consecutiveFailuresCount * 2), Self.maximumReconnectionDelay)
+        let minDelay: TimeInterval = min(max(0.25, (Double(consecutiveFailuresCount) - 1) * 2), Self.maximumReconnectionDelay)
+
+        delay = TimeInterval.random(in: minDelay...maxDelay)
 
         return delay
     }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -498,6 +498,10 @@
 		40E110472B5A9DF4007DF492 /* CallDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E110462B5A9DF4007DF492 /* CallDurationView.swift */; };
 		40E110492B5A9F03007DF492 /* Formatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E110482B5A9F03007DF492 /* Formatters.swift */; };
 		40E1104C2B5A9F6D007DF492 /* MediaDurationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E1104B2B5A9F6D007DF492 /* MediaDurationFormatter.swift */; };
+		40E18AAD2CD51E5900A65C9F /* RecursiveQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E18AAC2CD51E5900A65C9F /* RecursiveQueue.swift */; };
+		40E18AAF2CD51E9400A65C9F /* LockQueuing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E18AAE2CD51E8E00A65C9F /* LockQueuing.swift */; };
+		40E18AB22CD51FC100A65C9F /* UnfairQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E18AB12CD51FC100A65C9F /* UnfairQueueTests.swift */; };
+		40E18AB42CD522F700A65C9F /* RecursiveQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E18AB32CD522F700A65C9F /* RecursiveQueueTests.swift */; };
 		40E9B3B12BCD755F00ACF18F /* MemberResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E9B3B02BCD755F00ACF18F /* MemberResponse+Dummy.swift */; };
 		40E9B3B32BCD93AE00ACF18F /* JoinCallResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E9B3B22BCD93AE00ACF18F /* JoinCallResponse+Dummy.swift */; };
 		40E9B3B52BCD93F500ACF18F /* Credentials+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E9B3B42BCD93F500ACF18F /* Credentials+Dummy.swift */; };
@@ -1772,6 +1776,10 @@
 		40E110462B5A9DF4007DF492 /* CallDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallDurationView.swift; sourceTree = "<group>"; };
 		40E110482B5A9F03007DF492 /* Formatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatters.swift; sourceTree = "<group>"; };
 		40E1104B2B5A9F6D007DF492 /* MediaDurationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDurationFormatter.swift; sourceTree = "<group>"; };
+		40E18AAC2CD51E5900A65C9F /* RecursiveQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveQueue.swift; sourceTree = "<group>"; };
+		40E18AAE2CD51E8E00A65C9F /* LockQueuing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockQueuing.swift; sourceTree = "<group>"; };
+		40E18AB12CD51FC100A65C9F /* UnfairQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfairQueueTests.swift; sourceTree = "<group>"; };
+		40E18AB32CD522F700A65C9F /* RecursiveQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveQueueTests.swift; sourceTree = "<group>"; };
 		40E9B3B02BCD755F00ACF18F /* MemberResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberResponse+Dummy.swift"; sourceTree = "<group>"; };
 		40E9B3B22BCD93AE00ACF18F /* JoinCallResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JoinCallResponse+Dummy.swift"; sourceTree = "<group>"; };
 		40E9B3B42BCD93F500ACF18F /* Credentials+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Credentials+Dummy.swift"; sourceTree = "<group>"; };
@@ -2993,12 +3001,14 @@
 			path = Stages;
 			sourceTree = "<group>";
 		};
-		403FF3DF2BA1D20E0092CE8A /* UnfairQueue */ = {
+		403FF3DF2BA1D20E0092CE8A /* Queues */ = {
 			isa = PBXGroup;
 			children = (
+				40E18AAE2CD51E8E00A65C9F /* LockQueuing.swift */,
+				40E18AAC2CD51E5900A65C9F /* RecursiveQueue.swift */,
 				403FF3E02BA1D21E0092CE8A /* UnfairQueue.swift */,
 			);
-			path = UnfairQueue;
+			path = Queues;
 			sourceTree = "<group>";
 		};
 		403FF3E22BA1D2270092CE8A /* StreamPixelBufferRepository */ = {
@@ -3854,6 +3864,15 @@
 			path = Formatters;
 			sourceTree = "<group>";
 		};
+		40E18AB02CD51FB900A65C9F /* Queues */ = {
+			isa = PBXGroup;
+			children = (
+				40E18AB32CD522F700A65C9F /* RecursiveQueueTests.swift */,
+				40E18AB12CD51FC100A65C9F /* UnfairQueueTests.swift */,
+			);
+			path = Queues;
+			sourceTree = "<group>";
+		};
 		40F0173C2BBEB85F00E89FD1 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -4359,6 +4378,7 @@
 		842747F429EEDACB00E063AD /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40E18AB02CD51FB900A65C9F /* Queues */,
 				4029E9562CB943E800E1D571 /* CollectionDelayedUpdateObserver_Tests.swift */,
 				40C2B5C42C2D7ADE00EC2C2D /* RejectionReasonProvider */,
 				40C4DF4E2C1C41470035DBC2 /* ParticipantAutoLeavePolicy */,
@@ -4845,7 +4865,7 @@
 				40C2B5B42C2B604800EC2C2D /* DisposableBag */,
 				40C4DF402C1C21360035DBC2 /* ParticipantAutoLeavePolicy */,
 				408937892C062B0B000EEB69 /* UUIDProviding */,
-				403FF3DF2BA1D20E0092CE8A /* UnfairQueue */,
+				403FF3DF2BA1D20E0092CE8A /* Queues */,
 				40FB150D2BF77CA200D5E580 /* StateMachine */,
 				40FB15082BF74C0A00D5E580 /* CallCache */,
 				40149DCA2B7E813500473176 /* AudioRecorder */,
@@ -6311,6 +6331,7 @@
 				84DC38B729ADFCFD00946713 /* CallRecordingStartedEvent.swift in Sources */,
 				40F161AB2A4C6B5C00846E3E /* ScreenSharingSession.swift in Sources */,
 				40BBC4CF2C639054002AEF92 /* WebRTCCoordinator+Stage.swift in Sources */,
+				40E18AAF2CD51E9400A65C9F /* LockQueuing.swift in Sources */,
 				842B8E1F2A2DFED900863A87 /* StartRecordingResponse.swift in Sources */,
 				84DC389529ADFCFD00946713 /* QueryMembersRequest.swift in Sources */,
 				84DC38AB29ADFCFD00946713 /* RecordSettingsRequest.swift in Sources */,
@@ -6410,6 +6431,7 @@
 				402F04AB2B70ED8600CA1986 /* StreamCallStatisticsFormatter.swift in Sources */,
 				40382F502C8B3DAE00C2D00F /* StreamRTCPeerConnection.swift in Sources */,
 				8487D8B02A697E9A00536ED4 /* VideoCapturing.swift in Sources */,
+				40E18AAD2CD51E5900A65C9F /* RecursiveQueue.swift in Sources */,
 				842B8E242A2DFED900863A87 /* CallSessionParticipantJoinedEvent.swift in Sources */,
 				40BBC4D42C639371002AEF92 /* WebRTCCoordinator+Connected.swift in Sources */,
 				848CCCE62AB8ED8F002E83A2 /* BroadcastSettingsResponse.swift in Sources */,
@@ -6710,6 +6732,7 @@
 				8414081329F28B5700FF2D7C /* RTCConfiguration_Tests.swift in Sources */,
 				40F017712BBEF24E00E89FD1 /* CallSettingsResponse+Dummy.swift in Sources */,
 				403FB1562BFE1FC00047A696 /* StreamCallStateMachineStageErrorStage_Tests.swift in Sources */,
+				40E18AB42CD522F700A65C9F /* RecursiveQueueTests.swift in Sources */,
 				40AF6A4B2C9369A900BA2935 /* WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift in Sources */,
 				842747F129EED88800E063AD /* InternetConnection_Tests.swift in Sources */,
 				40C9E4552C988CE100802B28 /* WebRTCJoinRequestFactory_Tests.swift in Sources */,
@@ -6761,6 +6784,7 @@
 				40F0173E2BBEB86800E89FD1 /* TestsAuthenticationProvider.swift in Sources */,
 				401338762BF2489C007318BD /* MockCXCallController.swift in Sources */,
 				842747FC29EEECBA00E063AD /* AssertTestQueue.swift in Sources */,
+				40E18AB22CD51FC100A65C9F /* UnfairQueueTests.swift in Sources */,
 				40F017652BBEF1A200E89FD1 /* RTMPIngress+Dummy.swift in Sources */,
 				406B3C5D2C92E37600FC93A1 /* MockInternetConnection.swift in Sources */,
 				84DCA2112A389160000C3411 /* AssertDelay.swift in Sources */,

--- a/StreamVideoTests/Utils/Queues/RecursiveQueueTests.swift
+++ b/StreamVideoTests/Utils/Queues/RecursiveQueueTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+import XCTest
+
+final class RecursiveQueueTests: XCTestCase {
+
+    private lazy var taskWaitIntervalRange: ClosedRange<TimeInterval>! = 0.2...0.5
+    private lazy var subject: RecursiveQueue! = .init()
+
+    // MARK: - Lifecycle
+
+    override func tearDown() {
+        subject = nil
+        taskWaitIntervalRange = nil
+        super.tearDown()
+    }
+
+    // MARK: - sync(_:)
+
+    func test_sync_exclusiveAccess() async {
+        var sharedResource = 0
+        let iterations = 10
+        let expectation = XCTestExpectation(description: "Concurrent access")
+        expectation.expectedFulfillmentCount = iterations
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<iterations {
+                group.addTask {
+                    await self.wait(for: Double.random(in: self.taskWaitIntervalRange))
+                    self.subject.sync {
+                        let currentValue = sharedResource
+                        sharedResource = currentValue + 1
+                    }
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        await fulfillment(
+            of: [expectation],
+            timeout: TimeInterval(iterations) * taskWaitIntervalRange.upperBound
+        )
+        XCTAssertEqual(sharedResource, iterations)
+    }
+
+    // MARK: - Recursive Lock Testing
+
+    func test_sync_recursiveAccess() async {
+        var sharedResource = 0
+        let recursionDepth = 5
+        let expectation = XCTestExpectation(description: "Recursive access")
+        expectation.expectedFulfillmentCount = recursionDepth
+
+        func recursiveIncrement(depth: Int) {
+            guard depth > 0 else { return }
+            subject.sync {
+                sharedResource += 1
+                expectation.fulfill()
+                recursiveIncrement(depth: depth - 1)
+            }
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await self.wait(for: Double.random(in: self.taskWaitIntervalRange))
+                recursiveIncrement(depth: recursionDepth)
+            }
+        }
+
+        await fulfillment(
+            of: [expectation],
+            timeout: TimeInterval(recursionDepth) * taskWaitIntervalRange.upperBound
+        )
+        XCTAssertEqual(sharedResource, recursionDepth)
+    }
+}

--- a/StreamVideoTests/Utils/Queues/UnfairQueueTests.swift
+++ b/StreamVideoTests/Utils/Queues/UnfairQueueTests.swift
@@ -9,19 +9,20 @@ final class UnfairQueueTests: XCTestCase {
 
     private lazy var taskWaitIntervalRange: ClosedRange<TimeInterval>! = 0.2...0.5
     private lazy var subject: UnfairQueue! = .init()
+    private var sharedResource: Int! = 0
 
     // MARK: - Lifecycle
 
     override func tearDown() {
         subject = nil
         taskWaitIntervalRange = nil
+        sharedResource = nil
         super.tearDown()
     }
 
     // MARK: - sync(_:)
 
     func test_sync_exclusiveAccess() async {
-        var sharedResource = 0
         let iterations = 10
         let expectation = XCTestExpectation(description: "Concurrent access")
         expectation.expectedFulfillmentCount = iterations
@@ -31,8 +32,8 @@ final class UnfairQueueTests: XCTestCase {
                 group.addTask {
                     await self.wait(for: Double.random(in: self.taskWaitIntervalRange))
                     self.subject.sync {
-                        let currentValue = sharedResource
-                        sharedResource = currentValue + 1
+                        let currentValue = self.sharedResource!
+                        self.sharedResource = currentValue + 1
                     }
                     expectation.fulfill()
                 }

--- a/StreamVideoTests/Utils/Queues/UnfairQueueTests.swift
+++ b/StreamVideoTests/Utils/Queues/UnfairQueueTests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+import XCTest
+
+final class UnfairQueueTests: XCTestCase {
+
+    private lazy var taskWaitIntervalRange: ClosedRange<TimeInterval>! = 0.2...0.5
+    private lazy var subject: UnfairQueue! = .init()
+
+    // MARK: - Lifecycle
+
+    override func tearDown() {
+        subject = nil
+        taskWaitIntervalRange = nil
+        super.tearDown()
+    }
+
+    // MARK: - sync(_:)
+
+    func test_sync_exclusiveAccess() async {
+        var sharedResource = 0
+        let iterations = 10
+        let expectation = XCTestExpectation(description: "Concurrent access")
+        expectation.expectedFulfillmentCount = iterations
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<iterations {
+                group.addTask {
+                    await self.wait(for: Double.random(in: self.taskWaitIntervalRange))
+                    self.subject.sync {
+                        let currentValue = sharedResource
+                        sharedResource = currentValue + 1
+                    }
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        await fulfillment(
+            of: [expectation],
+            timeout: TimeInterval(iterations) * taskWaitIntervalRange.upperBound
+        )
+        XCTAssertEqual(sharedResource, iterations)
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Improve our locking mechanisms (used to ensure thread-safe access) and add tests to verify stability.

### 📝 Summary

This revision is attempting to align our locking mechanisms (under a single interface) while extending the Atomic property wrapper to be configured with the desired mechanism based on the requirements.

### 🛠 Implementation

- A `LockQueueing` protocol that will be used as the identifying interface between our locking mechanisms.
- The existing `UnfairQueue` conforms to the new `LockQueueing` protocol.
- A new `RecursiveQueue` that uses a `NSRecursiveLock` underneath and conforms to `LockQueueing`.
- An update on the `Atomic` property wrapper that can now be configured with the desired mechanism.
- Added tests that ensure concurrentAccess and deadlock impossibility.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)