### PR TITLE
[Enhancement]CallKit handling mute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - You can now provide the incoming video quality setting for some or all participants [#571](https://github.com/GetStream/stream-video-swift/pull/571)
 - You can now set the time a user can remain in the call - after their connection disrupted - while waiting for their network connection to recover [#573](https://github.com/GetStream/stream-video-swift/pull/573)
 - You can now provide the preferred Video stream codec to use [#583](https://github.com/GetStream/stream-video-swift/pull/583)
+- Sync microphone mute state between the SDK and CallKit [#590](https://github.com/GetStream/stream-video-swift/pull/590)
 
 ### 🐞 Fixed
 - In some cases when joining a call setup wasn't completed correctly which lead in issues during the call (e.g. missing video tracks or mute state not updating). [#586](https://github.com/GetStream/stream-video-swift/pull/586)

--- a/Sources/StreamVideoSwiftUI/Utils/ToastView.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/ToastView.swift
@@ -59,8 +59,8 @@ public struct ToastView: View {
 public struct ToastModifier: ViewModifier {
     
     @Binding var toast: Toast?
-    @State private var workItem: DispatchWorkItem?
-    
+    @State private var workItem: Task<Void, Never>?
+
     public init(toast: Binding<Toast?>) {
         _toast = toast
     }
@@ -107,13 +107,11 @@ public struct ToastModifier: ViewModifier {
         
         if toast.duration > 0 {
             workItem?.cancel()
-            
-            let task = DispatchWorkItem {
+
+            workItem = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: UInt64(toast.duration * Double(1_000_000_000)))
                 dismissToast()
             }
-            
-            workItem = task
-            DispatchQueue.main.asyncAfter(deadline: .now() + toast.duration, execute: task)
         }
     }
     


### PR DESCRIPTION
### 🎯 Goal

CallKit integration provided from the SDK now supports syncing of the microphone mute state between CallKit and the SDK.

### 🧪 Manual Testing Notes

- Lock your device and have another user call you.
- Answer the phone from the lock screen
- Mute/Unmute from the lockscreen
- Tap the bottom left icon to navigate to the app
- Verify that the in-app muted state matches the one from CallKit.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)