### PR TITLE
[Fix]Compiler warning on StreamVideo

### DIFF
--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -657,8 +657,7 @@ extension StreamVideo: ConnectionStateDelegate {
         switch state {
         case let .disconnected(source):
             if let serverError = source.serverError {
-                if serverError.isInvalidTokenError
-                    || (serverError as? APIError)?.isTokenExpiredError == true {
+                if serverError.isInvalidTokenError {
                     Task {
                         do {
                             guard let apiTransport = apiTransport as? URLSessionTransport else { return }


### PR DESCRIPTION
### 📝 Summary

The path that produces the warning isn't in use as it's covered on the first if statement.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)