### PR TITLE
[Fix]Frame scaled to fill without respecting content mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- When joining one call after another, the last frame of the previous call was flashing for a split second in the new call [#596](https://github.com/GetStream/stream-video-swift/pull/596)
 
 # [1.14.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.14.0)
 _November 06, 2024_

--- a/Sources/StreamVideoSwiftUI/Utils/ReusePool.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/ReusePool.swift
@@ -62,14 +62,13 @@ final class ReusePool<Element: AnyObject & Hashable> {
     ///
     /// - Parameters:
     ///   - element: The element to release.
-    ///   - replaceAvailableElementWithNew: If set to `true` rather than moving the item to
     ///   available, it will throw it away and instead place a newly created element in `available` storage.
     ///   Defaults to `false`.
-    func release(_ element: Element, replaceAvailableElementWithNew: Bool = false) {
+    func release(_ element: Element) {
         queue.sync {
             if inUse.contains(element), available.endIndex < initialCapacity {
                 inUse.remove(element)
-                available.append(replaceAvailableElementWithNew ? factory() : element)
+                available.append(element)
                 log.debug("Will make available \(type(of: element)):\(String(describing: element)).")
             } else {
                 inUse.remove(element)

--- a/Sources/StreamVideoSwiftUI/Utils/VideoRendererPool/VideoRendererPool.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/VideoRendererPool/VideoRendererPool.swift
@@ -16,7 +16,7 @@ final class VideoRendererPool {
     /// Initializes the `VideoRendererPool` with a specified initial capacity.
     ///
     /// - Parameter initialCapacity: The initial capacity of the pool (default is 2).
-    init(initialCapacity: Int = 2) {
+    init(initialCapacity: Int = 0) {
         // Initialize the pool with a capacity and a factory closure to create `VideoRenderer` instances
         pool = ReusePool(initialCapacity: initialCapacity) {
             VideoRenderer(frame: CGRect(origin: .zero, size: .zero))
@@ -43,7 +43,7 @@ final class VideoRendererPool {
     ///
     /// - Parameter renderer: The `VideoRenderer` instance to release.
     func releaseRenderer(_ renderer: VideoRenderer) {
-        pool.release(renderer, replaceAvailableElementWithNew: true)
+        pool.release(renderer)
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/Utils/VideoRendererPool/VideoRendererPool.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/VideoRendererPool/VideoRendererPool.swift
@@ -15,7 +15,7 @@ final class VideoRendererPool {
 
     /// Initializes the `VideoRendererPool` with a specified initial capacity.
     ///
-    /// - Parameter initialCapacity: The initial capacity of the pool (default is 2).
+    /// - Parameter initialCapacity: The initial capacity of the pool (default is 0).
     init(initialCapacity: Int = 0) {
         // Initialize the pool with a capacity and a factory closure to create `VideoRenderer` instances
         pool = ReusePool(initialCapacity: initialCapacity) {

--- a/StreamVideoSwiftUITests/Utils/ReusePool_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/ReusePool_Tests.swift
@@ -74,8 +74,8 @@ final class ReusePoolTests: XCTestCase {
         XCTAssertNotNil(object2)
         XCTAssertNotEqual(object1, object2)
 
-        subject.release(object2, replaceAvailableElementWithNew: true)
-        subject.release(object1, replaceAvailableElementWithNew: true)
+        subject.release(object2)
+        subject.release(object1)
 
         // After releasing, these objects should be available for reuse
         let object3 = subject.acquire()
@@ -83,8 +83,8 @@ final class ReusePoolTests: XCTestCase {
 
         XCTAssertNotNil(object3)
         XCTAssertNotNil(object4)
-        XCTAssertFalse(object1 === object3) // Reused object
-        XCTAssertFalse(object2 === object4) // Reused object
+        XCTAssertTrue(object1 === object3) // Reused object
+        XCTAssertTrue(object2 === object4) // Reused object
 
         // Now, the pool should be at initial capacity
         let object5 = subject.acquire()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-494/[alfagift]video-track-appears-stretched-when-the-first-join-livestream

### 📝 Summary

In some cases it appears that the VideoRenderer doesn't respect the provided contentMode and prefers `scaleToFill`.

### 🛠 Implementation

This revision disables the VideoRendererReusePool until further investigation to understand why it causes this weird behaviour.

### 🎨 Showcase

|  Before  |  After   |
| -------- | -------- |
| <video src="https://github.com/user-attachments/assets/39a0e056-3287-4d44-85ef-176fc97b982f"/> | <video src="https://github.com/user-attachments/assets/db040611-0411-42fe-8805-6b1205fbf824"/> |

### 🧪 Manual Testing Notes

Join multiple livestreams one after another. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)