### PR TITLE
Fix/failing test current route returns correct route

### DIFF
--- a/StreamVideoTests/Utils/AudioSession/StreamRTCAudioSession_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/StreamRTCAudioSession_Tests.swift
@@ -40,7 +40,8 @@ final class StreamRTCAudioSession_Tests: XCTestCase {
     // MARK: - currentRoute
 
     func test_currentRoute_returnsCorrectRoute() {
-        XCTAssertEqual(subject.currentRoute, rtcAudioSession.currentRoute)
+        XCTAssertEqual(subject.currentRoute.inputs.map(\.portType), rtcAudioSession.currentRoute.inputs.map(\.portType))
+        XCTAssertEqual(subject.currentRoute.outputs.map(\.portType), rtcAudioSession.currentRoute.outputs.map(\.portType))
     }
 
     // MARK: - category


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-550/fix-failing-test-streamrtcaudiosession-teststest-currentroute

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (Docusaurus, tutorial, CMS)