### PR TITLE
[Fix]Update deviceToken to empty once unregister void notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- By observing the `CallKitPushNotificationAdapter.deviceToken` you will be notified with an empty `deviceToken` value, once the object unregister push notifications. [#608](https://github.com/GetStream/stream-video-swift/pull/608)
 
 # [1.14.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.14.1)
 _November 12, 2024_

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -86,11 +86,17 @@ fileprivate func content() {
 
         voIPTokenObservationCancellable = callKitPushNotificationAdapter.$deviceToken.sink { [streamVideo] updatedDeviceToken in
             Task {
-                if let lastVoIPToken {
-                    try await streamVideo.deleteDevice(id: updatedDeviceToken)
+                do {
+                    if let lastVoIPToken, !lastVoIPToken.isEmpty {
+                        try await streamVideo.deleteDevice(id: lastVoIPToken)
+                    }
+                    if !updatedDeviceToken.isEmpty {
+                        try await streamVideo.setVoipDevice(id: updatedDeviceToken)
+                    }
+                    lastVoIPToken = updatedDeviceToken
+                } catch {
+                    print(error)
                 }
-                try await streamVideo.setVoipDevice(id: updatedDeviceToken)
-                lastVoIPToken = updatedDeviceToken
             }
         }
     }

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -62,6 +62,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         #else
         registry.delegate = nil
         registry.desiredPushTypes = []
+        deviceToken = ""
         #endif
     }
 


### PR DESCRIPTION
### 📝 Summary

Provide a consistent mechanism for consumers of `CallKitAdapter` to remove devices for a user account.

Docs update PR: [here](https://github.com/GetStream/docs-content/pull/44)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)