### PR TITLE
[Feature]Report join call telemetry

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
@@ -297,18 +297,18 @@ final class SFUAdapter: ConnectionStateDelegate, CustomStringConvertible, @unche
     func sendStats(
         _ report: CallStatsReport?,
         for sessionId: String,
-        thermalState: ProcessInfo.ThermalState? = nil
+        thermalState: ProcessInfo.ThermalState? = nil,
+        telemetry: Stream_Video_Sfu_Signal_Telemetry? = nil
     ) async throws {
-        statusCheck()
-        guard let report else { return }
         var statsRequest = Stream_Video_Sfu_Signal_SendStatsRequest()
         statsRequest.sessionID = sessionId
         statsRequest.sdk = "stream-ios"
         statsRequest.sdkVersion = SystemEnvironment.version
         statsRequest.webrtcVersion = SystemEnvironment.webRTCVersion
-        statsRequest.publisherStats = report.publisherRawStats?.jsonString ?? ""
-        statsRequest.subscriberStats = report.subscriberRawStats?.jsonString ?? ""
+        statsRequest.publisherStats = report?.publisherRawStats?.jsonString ?? ""
+        statsRequest.subscriberStats = report?.subscriberRawStats?.jsonString ?? ""
         statsRequest.deviceState = .init(thermalState)
+        statsRequest.telemetry = telemetry ?? .init()
 
         let task = Task { [statsRequest, signalService] in
             try Task.checkCancellation()

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -367,21 +367,22 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             from: .connected,
             expectedTarget: .joined,
             subject: subject
-        ) { [mockCoordinatorStack] _ in
-            let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
-            let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
-
-            switch telemetry.data {
-            case .connectionTimeSeconds:
-                XCTAssertTrue(true)
-            case .reconnection:
-                XCTFail()
-            case .none:
-                XCTFail()
-            }
-        }
+        ) { _ in }
 
         cancellable.cancel()
+
+        let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
+        await fulfillment { mockSignalService.sendStatsWasCalledWithRequest?.telemetry != nil }
+        let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
+
+        switch telemetry.data {
+        case .connectionTimeSeconds:
+            XCTAssertTrue(true)
+        case .reconnection:
+            XCTFail()
+        case .none:
+            XCTFail()
+        }
     }
 
     // MARK: - transition from connected with isRejoiningFromSessionID != nil
@@ -744,21 +745,22 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             from: .connected,
             expectedTarget: .joined,
             subject: subject
-        ) { [mockCoordinatorStack] _ in
-            let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
-            let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
-
-            switch telemetry.data {
-            case .connectionTimeSeconds:
-                XCTFail()
-            case let .reconnection(reconnection):
-                XCTAssertEqual(reconnection.strategy, .rejoin)
-            case .none:
-                XCTFail()
-            }
-        }
+        ) { _ in }
 
         cancellable.cancel()
+
+        let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
+        await fulfillment { mockSignalService.sendStatsWasCalledWithRequest?.telemetry != nil }
+        let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
+
+        switch telemetry.data {
+        case .connectionTimeSeconds:
+            XCTFail()
+        case let .reconnection(reconnection):
+            XCTAssertEqual(reconnection.strategy, .rejoin)
+        case .none:
+            XCTFail()
+        }
     }
 
     // MARK: - transition from fastReconnected
@@ -942,21 +944,22 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             from: .fastReconnected,
             expectedTarget: .joined,
             subject: subject
-        ) { [mockCoordinatorStack] _ in
-            let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
-            let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
-
-            switch telemetry.data {
-            case .connectionTimeSeconds:
-                XCTFail()
-            case let .reconnection(reconnection):
-                XCTAssertEqual(reconnection.strategy, .fast)
-            case .none:
-                XCTFail()
-            }
-        }
+        ) { _ in }
 
         cancellable.cancel()
+
+        let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
+        await fulfillment { mockSignalService.sendStatsWasCalledWithRequest?.telemetry != nil }
+        let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
+
+        switch telemetry.data {
+        case .connectionTimeSeconds:
+            XCTFail()
+        case let .reconnection(reconnection):
+            XCTAssertEqual(reconnection.strategy, .fast)
+        case .none:
+            XCTFail()
+        }
     }
 
     // MARK: - transition from migrated
@@ -1319,21 +1322,22 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             from: .migrated,
             expectedTarget: .joined,
             subject: subject
-        ) { [mockCoordinatorStack] _ in
-            let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
-            let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
-
-            switch telemetry.data {
-            case .connectionTimeSeconds:
-                XCTFail()
-            case let .reconnection(reconnection):
-                XCTAssertEqual(reconnection.strategy, .migrate)
-            case .none:
-                XCTFail()
-            }
-        }
+        ) { _ in }
 
         cancellable.cancel()
+
+        let mockSignalService = try XCTUnwrap(mockCoordinatorStack?.sfuStack.service)
+        await fulfillment { mockSignalService.sendStatsWasCalledWithRequest?.telemetry != nil }
+        let telemetry = try XCTUnwrap(mockSignalService.sendStatsWasCalledWithRequest?.telemetry)
+
+        switch telemetry.data {
+        case .connectionTimeSeconds:
+            XCTFail()
+        case let .reconnection(reconnection):
+            XCTAssertEqual(reconnection.strategy, .migrate)
+        case .none:
+            XCTFail()
+        }
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-585/report-connection-times-to-the-sfu

### 🎯 Goal

Report join call telemetry including join strategy and duration. (React reference [PR](https://github.com/GetStream/stream-video-js/pull/1574/files))

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)