### PR TITLE
[Fix]Sorting comparators for fullscreen layout and PiP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - By observing the `CallKitPushNotificationAdapter.deviceToken` you will be notified with an empty `deviceToken` value, once the object unregister push notifications. [#608](https://github.com/GetStream/stream-video-swift/pull/608)
 - When a call you receive a ringing while the app isn't running (and the screen is locked), websocket connection wasn't recovered. [#600](https://github.com/GetStream/stream-video-swift/pull/600)
+- Sorting order on Fullscreen Layout and Picture-in-Picture wasn't respecting dominant speaker change. [#613](https://github.com/GetStream/stream-video-swift/pull/613)
 
 # [1.14.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.14.1)
 _November 12, 2024_

--- a/Sources/StreamVideo/Utils/Sorting.swift
+++ b/Sources/StreamVideo/Utils/Sorting.swift
@@ -17,13 +17,12 @@ public typealias StreamSortComparator<Value> = (Value, Value) -> ComparisonResul
 public let defaultComparators: [StreamSortComparator<CallParticipant>] = [
     pinned,
     screensharing,
-    ifInvisible(combineComparators([
+    combineComparators([
         dominantSpeaker,
-        isSpeaking,
         isSpeaking,
         publishingVideo,
         publishingAudio
-    ])),
+    ]),
     ifInvisible(userId)
 ]
 

--- a/StreamVideoTests/Utils/Sorting_Tests.swift
+++ b/StreamVideoTests/Utils/Sorting_Tests.swift
@@ -702,7 +702,8 @@ final class Sorting_Tests: XCTestCase {
         )
     }
 
-    func test_defaultComparators_someSpeakingWhileDominantSpeakerIsVisible_orderDoesNotChange() {
+    func test_defaultComparators_someSpeakingWhileDominantSpeakerIsVisible_orderSetsToShowDominanFirstAndTheOthersSortedBasedOnOtherCriteria(
+    ) {
         let combined = combineComparators(defaultComparators)
 
         assertSort(
@@ -733,7 +734,7 @@ final class Sorting_Tests: XCTestCase {
                 )
             ],
             comparator: combined,
-            expectedTransformer: { [$0[0], $0[1], $0[2], $0[3]] }
+            expectedTransformer: { [$0[3], $0[0], $0[1], $0[2]] }
         )
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves IOS-499

### 📝 Summary

The revision fixes an issue where the dominant speaker doesn't become the visible track when changing, in fullscreen layout and PictureInPicture.

### 🧪 Manual Testing Notes

- Join a call with 2 other participants
- Either change the layout to fullscreen or move to the background (in order to active PiP)
- Make the other users talk in order to change the dominant speaker
- The dominant participant should be visible (and changing) in every case

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)