### PR TITLE
[Fix]Replace `#file` to `#fileID`

### DIFF
--- a/Sources/StreamVideo/Errors/Errors.swift
+++ b/Sources/StreamVideo/Errors/Errors.swift
@@ -56,7 +56,7 @@ public class ClientError: Error, CustomStringConvertible {
     ///   - error: an external error.
     ///   - file: a file name source of an error.
     ///   - line: a line source of an error.
-    public init(with error: Error? = nil, _ file: StaticString = #file, _ line: UInt = #line) {
+    public init(with error: Error? = nil, _ file: StaticString = #fileID, _ line: UInt = #line) {
         underlyingError = error
         location = .init(file: "\(file)", line: Int(line))
         if let aErr = error as? APIError {
@@ -71,7 +71,7 @@ public class ClientError: Error, CustomStringConvertible {
     ///   - message: an error message.
     ///   - file: a file name source of an error.
     ///   - line: a line source of an error.
-    public init(_ message: String, _ file: StaticString = #file, _ line: UInt = #line) {
+    public init(_ message: String, _ file: StaticString = #fileID, _ line: UInt = #line) {
         self.message = message
         location = .init(file: "\(file)", line: Int(line))
         underlyingError = nil

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSessionAdapter.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSessionAdapter.swift
@@ -48,7 +48,7 @@ final class StreamAudioSessionAdapter: NSObject, RTCAudioSessionDelegate, @unche
         let configuration = RTCAudioSessionConfiguration.default
         audioSession.updateConfiguration(
             functionName: #function,
-            file: #file,
+            file: #fileID,
             line: #line
         ) {
             try $0.setConfiguration(.default)
@@ -242,7 +242,7 @@ final class StreamAudioSessionAdapter: NSObject, RTCAudioSessionDelegate, @unche
 
                 audioSession.updateConfiguration(
                     functionName: #function,
-                    file: #file,
+                    file: #fileID,
                     line: #line
                 ) {
                     try $0.setMode(mode.rawValue)
@@ -271,7 +271,7 @@ final class StreamAudioSessionAdapter: NSObject, RTCAudioSessionDelegate, @unche
         )
         audioSession.updateConfiguration(
             functionName: #function,
-            file: #file,
+            file: #fileID,
             line: #line
         ) { try $0.setActive(isActive) }
     }

--- a/Sources/StreamVideo/Utils/Logger/Array+Logger.swift
+++ b/Sources/StreamVideo/Utils/Logger/Array+Logger.swift
@@ -9,7 +9,7 @@ extension Array {
         _ level: LogLevel,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line,
         messageBuilder: ((Self) -> String)? = nil
     ) -> Self {

--- a/Sources/StreamVideo/Utils/Logger/Logger.swift
+++ b/Sources/StreamVideo/Utils/Logger/Logger.swift
@@ -303,7 +303,7 @@ public class Logger {
     public func callAsFunction(
         _ level: LogLevel,
         functionName: StaticString = #function,
-        fileName: StaticString = #filePath,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line,
         message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
@@ -332,7 +332,7 @@ public class Logger {
     public func log(
         _ level: LogLevel,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line,
         message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
@@ -371,7 +371,7 @@ public class Logger {
         _ message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         log(
@@ -396,7 +396,7 @@ public class Logger {
         _ message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         log(
@@ -421,7 +421,7 @@ public class Logger {
         _ message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         log(
@@ -447,7 +447,7 @@ public class Logger {
         subsystems: LogSubsystem = .other,
         error: Error? = nil,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         log(
@@ -472,7 +472,7 @@ public class Logger {
         _ message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         guard !condition() else { return }
@@ -499,7 +499,7 @@ public class Logger {
         _ message: @autoclosure () -> Any,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         if StreamRuntimeCheck.assertionsEnabled {

--- a/Sources/StreamVideo/Utils/Logger/Publisher+Logger.swift
+++ b/Sources/StreamVideo/Utils/Logger/Publisher+Logger.swift
@@ -132,7 +132,7 @@ extension Publisher {
         _ level: LogLevel,
         subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line,
         messageBuilder: ((Self.Output) -> String)? = nil
     ) -> Publishers.Log<Self> {

--- a/Sources/StreamVideo/Utils/StateMachine/Publisher+NextValue.swift
+++ b/Sources/StreamVideo/Utils/StateMachine/Publisher+NextValue.swift
@@ -15,7 +15,7 @@ extension Publisher {
     func nextValue(
         dropFirst: Int = 0,
         timeout: TimeInterval? = nil,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) async throws -> Output {

--- a/Sources/StreamVideo/Utils/Unwrap/Unwrap.swift
+++ b/Sources/StreamVideo/Utils/Unwrap/Unwrap.swift
@@ -14,7 +14,7 @@ import Foundation
 ///   - errorMessage: A custom error message that will be used in the thrown
 ///                   `ClientError` if the value is `nil`. The default is
 ///                   `"Unavailable value"`.
-///   - file: The file from which the function was called, using the `#file`
+///   - file: The file from which the function was called, using the `#fileID`
 ///           directive to capture the source location. Default is the
 ///           calling file.
 ///   - line: The line number from which the function was called, using the
@@ -35,7 +35,7 @@ import Foundation
 func unwrap<T>(
     _ value: T?,
     errorMessage: String = "Unavailable value",
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line
 ) throws -> T {
     guard let value else {

--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
@@ -137,7 +137,7 @@ final class SFUAdapter: ConnectionStateDelegate, CustomStringConvertible, @unche
     ///   - line: The line from which we are requesting the publisher. Used for logging.
     func publisher<T>(
         eventType: T.Type,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) -> AnyPublisher<T, Never> {
@@ -575,7 +575,7 @@ final class SFUAdapter: ConnectionStateDelegate, CustomStringConvertible, @unche
 
     private func statusCheck(
         functionName: StaticString = #function,
-        filename: StaticString = #file,
+        filename: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         guard !isConnected else { return }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCJoinRequestFactory.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCJoinRequestFactory.swift
@@ -42,7 +42,7 @@ struct WebRTCJoinRequestFactory {
         subscriberSdp: String,
         reconnectAttempt: UInt32,
         publisher: RTCPeerConnectionCoordinator?,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) async -> Stream_Video_Sfu_Event_JoinRequest {
@@ -82,7 +82,7 @@ struct WebRTCJoinRequestFactory {
         coordinator: WebRTCCoordinator,
         reconnectAttempt: UInt32,
         publisher: RTCPeerConnectionCoordinator?,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) async -> Stream_Video_Sfu_Event_ReconnectDetails? {
@@ -172,7 +172,7 @@ struct WebRTCJoinRequestFactory {
     func buildAnnouncedTracks(
         _ publisher: RTCPeerConnectionCoordinator?,
         videoOptions: VideoOptions,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) -> [Stream_Video_Sfu_Models_TrackInfo] {
@@ -227,7 +227,7 @@ struct WebRTCJoinRequestFactory {
         _ previousSessionID: String?,
         coordinator: WebRTCCoordinator,
         incomingVideoQualitySettings: IncomingVideoQualitySettings,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) async -> [Stream_Video_Sfu_Signal_TrackSubscriptionDetails] {

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -445,7 +445,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
     func enqueue(
         _ operation: @escaping ParticipantOperation,
         functionName: StaticString = #function,
-        fileName: StaticString = #file,
+        fileName: StaticString = #fileID,
         lineNumber: UInt = #line
     ) {
         /// Creates a new asynchronous task for the operation.

--- a/Sources/StreamVideo/WebSockets/Events/JsonEventDecoder.swift
+++ b/Sources/StreamVideo/WebSockets/Events/JsonEventDecoder.swift
@@ -31,11 +31,11 @@ extension ClientError {
     }
     
     public class EventDecoding: ClientError {
-        override init(_ message: String, _ file: StaticString = #file, _ line: UInt = #line) {
+        override init(_ message: String, _ file: StaticString = #fileID, _ line: UInt = #line) {
             super.init(message, file, line)
         }
         
-        init<T>(missingValue: String, for type: T.Type, _ file: StaticString = #file, _ line: UInt = #line) {
+        init<T>(missingValue: String, for type: T.Type, _ file: StaticString = #fileID, _ line: UInt = #line) {
             super.init("`\(missingValue)` field can't be `nil` for the `\(type)` event.", file, line)
         }
     }


### PR DESCRIPTION
### 🎯 Goal

By reducing logs size we attempt to reduce the SDK size.

### 📝 Summary

`#file` in Swift 5 embeds `#filePath` while in Swift 6 it embeds `#fileID`. From Apple's [documentation](https://developer.apple.com/documentation/swift/filepath()#overview) for `#filePath` we get this:

```
Because #fileID doesn’t embed the full path to the source file, unlike #filePath, it gives you better privacy and reduces the size of the compiled binary. Avoid using #filePath outside of tests, build scripts, or other code that doesn’t become part of the shipping program.
```

Other users also report same behaviour [here](https://x.com/KyleSwifter/status/1868562829932150839)

### 🛠 Implementation

Update all references in Source, to `#fileID`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)