### PR TITLE
[Fix]Cron checks failing on iOS 15

### DIFF
--- a/StreamVideoTests/Mock/MockRTCRtpCodecCapability.swift
+++ b/StreamVideoTests/Mock/MockRTCRtpCodecCapability.swift
@@ -5,8 +5,9 @@
 @testable import StreamVideo
 import StreamWebRTC
 
-final class MockRTCRtpCodecCapability: RTCRtpCodecCapabilityProtocol, Mockable {
+final class MockRTCRtpCodecCapability: NSObject, RTCRtpCodecCapabilityProtocol, Mockable {
     enum MockFunctionKey: Hashable, CaseIterable { case none }
+    enum MockPropertyKey: String, Hashable { case name, fmtp, clockRate, preferredPayloadType }
     typealias FunctionKey = MockFunctionKey
     typealias FunctionInputKey = EmptyPayloadable
     var stubbedProperty: [String: Any] = [:]
@@ -18,6 +19,21 @@ final class MockRTCRtpCodecCapability: RTCRtpCodecCapabilityProtocol, Mockable {
 
     func stub<T>(for function: FunctionKey, with value: T) {
         stubbedFunction[function] = value
+    }
+
+    func propertyKey<T>(for keyPath: KeyPath<MockRTCRtpCodecCapability, T>) -> String {
+        switch keyPath {
+        case \.name:
+            return MockPropertyKey.name.rawValue
+        case \.fmtp:
+            return MockPropertyKey.fmtp.rawValue
+        case \.clockRate:
+            return MockPropertyKey.clockRate.rawValue
+        case \.preferredPayloadType:
+            return MockPropertyKey.preferredPayloadType.rawValue
+        default:
+            fatalError()
+        }
     }
 
     var name: String { self[dynamicMember: \.name] }

--- a/StreamVideoTests/Mock/MockRTCRtpEncodingParameters.swift
+++ b/StreamVideoTests/Mock/MockRTCRtpEncodingParameters.swift
@@ -7,6 +7,7 @@ import StreamWebRTC
 
 final class MockRTCRtpEncodingParameters: RTCRtpEncodingParametersProtocol, Mockable {
     enum MockFunctionKey: Hashable, CaseIterable { case none }
+    enum MockPropertyKey: String, Hashable { case rid, maxBitrateBps, maxFramerate }
     typealias FunctionKey = MockFunctionKey
     typealias FunctionInputKey = EmptyPayloadable
     var stubbedProperty: [String: Any] = [:]
@@ -18,6 +19,19 @@ final class MockRTCRtpEncodingParameters: RTCRtpEncodingParametersProtocol, Mock
 
     func stub<T>(for function: FunctionKey, with value: T) {
         stubbedFunction[function] = value
+    }
+
+    func propertyKey<T>(for keyPath: KeyPath<MockRTCRtpEncodingParameters, T>) -> String {
+        switch keyPath {
+        case \.rid:
+            return MockPropertyKey.rid.rawValue
+        case \.maxBitrateBps:
+            return MockPropertyKey.maxBitrateBps.rawValue
+        case \.maxFramerate:
+            return MockPropertyKey.maxFramerate.rawValue
+        default:
+            fatalError()
+        }
     }
 
     var rid: String? { self[dynamicMember: \.rid] }


### PR DESCRIPTION
### 📝 Summary

Keypaths on iOS 15 seems to be unable to convert to String values, making our `Mockable` implementation fail. For those cases where this will be happening we can simply override the `propertyKey` function on our `Mockable` instance in order to provide correct mapping for each keyPath.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)