### PR TITLE
[Fix]CleanUp active videoCapturing and screenSharing sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Fix an issue that was causing the video capturer to no be cleaned up when the call was ended, causing the camera access system indicator to remain on while the `CallEnded` screen is visible. [#636](https://github.com/GetStream/stream-video-swift/pull/636)
+
 # [1.15.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.15.0)
 _January 14, 2025_
 

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -291,6 +291,8 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
     /// Cleans up the WebRTC session by closing connections and resetting
     /// states.
     func cleanUp() async {
+        screenShareSessionProvider.activeSession = nil
+        videoCaptureSessionProvider.activeSession = nil
         peerConnectionsDisposableBag.removeAll()
         await publisher?.close()
         await subscriber?.close()


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-651/[video]stop-videocapturer-and-screensharecapturer-when-call-ends-and

### 📝 Summary

On Call cleanUp we should be stopping all video and screenShare capturers. Without doing that, we end up in the `Call ended screen` and the camera access system indicator remain on.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)