### PR TITLE
[Fix]Legacy URL parsing pointing to Pronto

### DIFF
--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -156,7 +156,8 @@ struct SimpleCallingView: View {
             return
         }
 
-        if deeplinkInfo.baseURL == AppEnvironment.baseURL {
+        if deeplinkInfo.baseURL == AppEnvironment
+            .baseURL || (deeplinkInfo.baseURL == .legacy && AppEnvironment.baseURL == .pronto) {
             if !Set(AppEnvironment.availableCallTypes).contains(deeplinkInfo.callType) {
                 AppEnvironment.availableCallTypes.append(deeplinkInfo.callType)
             }


### PR DESCRIPTION
### 📝 Summary

When parsing Legacy URLs while the current DemoApp Environment is Pronto, rather than triggering an environment switch, proceed in Pronto.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)