### PR TITLE
[Fix]Accepting call on another device will sync state with CallViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix an issue that was causing the video capturer to no be cleaned up when the call was ended, causing the camera access system indicator to remain on while the `CallEnded` screen is visible. [#636](https://github.com/GetStream/stream-video-swift/pull/636)
+- Fix an issue which was not dismissing incoming call screen if the call was accepted on another device. [#640](https://github.com/GetStream/stream-video-swift/pull/640)
 
 # [1.15.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.15.0)
 _January 14, 2025_

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -751,7 +751,7 @@ open class CallViewModel: ObservableObject {
 
         switch callingState {
         case .incoming where event.user?.id == streamVideo.user.id:
-            rejectCall(callType: event.type, callId: event.callId)
+            setActiveCall(call)
         case .outgoing where call?.cId == event.callCid:
             enterCall(
                 call: call,

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -751,7 +751,7 @@ open class CallViewModel: ObservableObject {
 
         switch callingState {
         case .incoming where event.user?.id == streamVideo.user.id:
-            break
+            rejectCall(callType: event.type, callId: event.callId)
         case .outgoing where call?.cId == event.callCid:
             enterCall(
                 call: call,

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -363,6 +363,76 @@ final class CallViewModel_Tests: StreamVideoTestCase {
     }
 
     @MainActor
+    func test_incomingCall_sameUserAcceptedAnotherCall_callingStateShouldRemainIncoming() async throws {
+        // Given
+        let callViewModel = CallViewModel()
+        await fulfillment { callViewModel.isSubscribedToCallEvents }
+
+        // When
+        let event = CallRingEvent(
+            call: mockResponseBuilder.makeCallResponse(cid: cId),
+            callCid: cId,
+            createdAt: Date(),
+            members: [],
+            sessionId: "123",
+            user: UserResponse(
+                blockedUserIds: [],
+                createdAt: Date(),
+                custom: [:],
+                id: secondUser.userId,
+                language: "",
+                role: "user",
+                teams: [],
+                updatedAt: Date()
+            ),
+            video: true
+        )
+
+        let wrapped = WrappedEvent.coordinatorEvent(.typeCallRingEvent(event))
+        let eventNotificationCenter = try XCTUnwrap(eventNotificationCenter)
+        eventNotificationCenter.process(wrapped)
+
+        await fulfillment {
+            if case .incoming = callViewModel.callingState {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        // Then
+        guard case let .incoming(call) = callViewModel.callingState else {
+            XCTFail()
+            return
+        }
+        XCTAssert(call.id == callId)
+
+        // When we receive an accept even it means we accepted somewhere else
+        eventNotificationCenter.process(
+            .coordinatorEvent(
+                .typeCallAcceptedEvent(
+                    .dummy(
+                        callCid: "default:\(String.unique)",
+                        user: firstUser.user.toUserResponse()
+                    )
+                )
+            )
+        )
+
+        // Then
+        try await XCTAssertWithDelay(
+            {
+                switch callViewModel.callingState {
+                case .incoming:
+                    return true
+                default:
+                    return false
+                }
+            }()
+        )
+    }
+
+    @MainActor
     func test_incomingCall_anotherUserAcceptedThisCall_callingStateShouldRemainIncoming() async throws {
         // Given
         let callViewModel = CallViewModel()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-673/[support]user-accepts-ringing-call-in-one-device-in-app-incoming

### 📝 Summary

When a user accepts a ringing call from one device, on all their other devices correctly dismiss CallKit push notification but they do not update CallViewModel's internal state, resulting in the in-app incoming call to remain on screen.

### 🧪 Manual Testing Notes

- Have a user login on two different devices (and keep the app in the foreground)
- Have another user ring the user from the first step
- Both devices should present CallKit push notification and in-app incoming call
- Accept the call on one device
- The other device, should dismiss CallKit push notification and in-app incoming call screen.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)