### PR TITLE
[Enhancement]Handle video property on VoIP push notification

### DIFF
--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -165,7 +165,7 @@ fileprivate func content() {
                                     // hasVideo: A boolean indicating if the call
                                     // will be video or only audio. Still requires
                                     // appropriate setting of ``CallSettings`.`
-                                    hasVideo: true
+                                    video: true
                                 )
                             }
                         }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -160,7 +160,12 @@ fileprivate func content() {
                                     callType: .default,
                                     callId: UUID().uuidString,
                                     members: [.init(userId: name)],
-                                    ring: true
+                                    ring: true,
+                                    
+                                    // hasVideo: A boolean indicating if the call
+                                    // will be video or only audio. Still requires
+                                    // appropriate setting of ``CallSettings`.`
+                                    hasVideo: true
                                 )
                             }
                         }

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -225,7 +225,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     ///   - maxDuration: An optional integer representing the maximum duration of the call in seconds.
     ///   - maxParticipants: An optional integer representing the maximum number of participants allowed in the call.
     ///   - backstage: An optional backstage request.
-    ///   - hasVideo: A boolean indicating if the call will be video or only audio. Still requires appropriate
+    ///   - video: A boolean indicating if the call will be video or only audio. Still requires appropriate
     ///   setting of ``CallSettings`.`
     /// - Returns: A `CallResponse` object representing the created call.
     /// - Throws: An error if the call creation fails.
@@ -241,7 +241,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         maxDuration: Int? = nil,
         maxParticipants: Int? = nil,
         backstage: BackstageSettingsRequest? = nil,
-        hasVideo: Bool? = nil
+        video: Bool? = nil
     ) async throws -> CallResponse {
         var membersRequest = [MemberRequest]()
         memberIds?.forEach {
@@ -272,7 +272,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
                 settingsOverride: settingsOverride,
                 startsAt: startsAt,
                 team: team,
-                video: hasVideo
+                video: video
             ),
             notify: notify,
             ring: ring

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -225,6 +225,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     ///   - maxDuration: An optional integer representing the maximum duration of the call in seconds.
     ///   - maxParticipants: An optional integer representing the maximum number of participants allowed in the call.
     ///   - backstage: An optional backstage request.
+    ///   - hasVideo: A boolean indicating if the call will be video or only audio. Still requires appropriate
+    ///   setting of ``CallSettings`.`
     /// - Returns: A `CallResponse` object representing the created call.
     /// - Throws: An error if the call creation fails.
     @discardableResult
@@ -238,7 +240,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         notify: Bool = false,
         maxDuration: Int? = nil,
         maxParticipants: Int? = nil,
-        backstage: BackstageSettingsRequest? = nil
+        backstage: BackstageSettingsRequest? = nil,
+        hasVideo: Bool? = nil
     ) async throws -> CallResponse {
         var membersRequest = [MemberRequest]()
         memberIds?.forEach {
@@ -268,7 +271,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
                 members: membersRequest,
                 settingsOverride: settingsOverride,
                 startsAt: startsAt,
-                team: team
+                team: team,
+                video: hasVideo
             ),
             notify: notify,
             ring: ring

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -23,13 +23,13 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         var cid: String
         var localizedCallerName: String
         var callerId: String
-        var hasVideo: Bool
+        var hasVideo: Bool?
 
         public init(
             cid: String,
             localizedCallerName: String,
             callerId: String,
-            hasVideo: Bool
+            hasVideo: Bool? = nil
         ) {
             self.cid = cid
             self.localizedCallerName = localizedCallerName
@@ -107,7 +107,6 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
                 "Received VoIP push notification with cid:\(content.cid) callerId:\(content.callerId) callerName:\(content.localizedCallerName)."
             )
 
-        callKitService.supportsVideo = content.hasVideo
         callKitService.reportIncomingCall(
             content.cid,
             localizedCallerName: content.localizedCallerName,
@@ -136,8 +135,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             return .init(
                 cid: "unknown",
                 localizedCallerName: defaultCallText,
-                callerId: defaultCallText,
-                hasVideo: false
+                callerId: defaultCallText
             )
         }
 
@@ -155,7 +153,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             fallback: defaultCallText
         )
 
-        let hasVideo = streamDict[PayloadKey.video.rawValue] as? Bool ?? false
+        let hasVideo = streamDict[PayloadKey.video.rawValue] as? Bool
 
         return .init(
             cid: cid,

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -15,6 +15,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         case displayName = "call_display_name"
         case createdByName = "created_by_display_name"
         case createdById = "created_by_id"
+        case video
     }
 
     /// Represents the content of a VoIP push notification.
@@ -22,15 +23,18 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         var cid: String
         var localizedCallerName: String
         var callerId: String
+        var hasVideo: Bool
 
         public init(
             cid: String,
             localizedCallerName: String,
-            callerId: String
+            callerId: String,
+            hasVideo: Bool
         ) {
             self.cid = cid
             self.localizedCallerName = localizedCallerName
             self.callerId = callerId
+            self.hasVideo = hasVideo
         }
     }
 
@@ -103,10 +107,12 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
                 "Received VoIP push notification with cid:\(content.cid) callerId:\(content.callerId) callerName:\(content.localizedCallerName)."
             )
 
+        callKitService.supportsVideo = content.hasVideo
         callKitService.reportIncomingCall(
             content.cid,
             localizedCallerName: content.localizedCallerName,
             callerId: content.callerId,
+            hasVideo: content.hasVideo,
             completion: { error in
                 if let error {
                     log.error(error)
@@ -130,7 +136,8 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             return .init(
                 cid: "unknown",
                 localizedCallerName: defaultCallText,
-                callerId: defaultCallText
+                callerId: defaultCallText,
+                hasVideo: false
             )
         }
 
@@ -148,10 +155,13 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             fallback: defaultCallText
         )
 
+        let hasVideo = streamDict[PayloadKey.video.rawValue] as? Bool ?? false
+
         return .init(
             cid: cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: hasVideo
         )
     }
 }

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -23,13 +23,13 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         var cid: String
         var localizedCallerName: String
         var callerId: String
-        var hasVideo: Bool?
+        var hasVideo: Bool
 
         public init(
             cid: String,
             localizedCallerName: String,
             callerId: String,
-            hasVideo: Bool? = nil
+            hasVideo: Bool
         ) {
             self.cid = cid
             self.localizedCallerName = localizedCallerName
@@ -135,7 +135,8 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             return .init(
                 cid: "unknown",
                 localizedCallerName: defaultCallText,
-                callerId: defaultCallText
+                callerId: defaultCallText,
+                hasVideo: false
             )
         }
 
@@ -153,7 +154,15 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             fallback: defaultCallText
         )
 
-        let hasVideo = streamDict[PayloadKey.video.rawValue] as? Bool
+        let hasVideo: Bool = {
+            if let booleanValue = streamDict[PayloadKey.video.rawValue] as? Bool {
+                return booleanValue
+            } else if let stringValue = streamDict[PayloadKey.video.rawValue] as? String {
+                return stringValue == "true"
+            } else {
+                return false
+            }
+        }()
 
         return .init(
             cid: cid,

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -109,39 +109,17 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     ///   - cid: The call ID.
     ///   - localizedCallerName: The localized caller name.
     ///   - callerId: The caller's identifier.
+    ///   - hasVideo: Indicator if call is video or audio. If nil we default to the value of `supportsVideo`
     ///   - completion: A closure to be called upon completion.
     @MainActor
     open func reportIncomingCall(
         _ cid: String,
         localizedCallerName: String,
         callerId: String,
+        hasVideo: Bool? = nil,
         completion: @escaping (Error?) -> Void
     ) {
-        reportIncomingCall(
-            cid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: false,
-            completion: completion
-        )
-    }
-
-    /// Reports an incoming call to the CallKit framework.
-    ///
-    /// - Parameters:
-    ///   - cid: The call ID.
-    ///   - localizedCallerName: The localized caller name.
-    ///   - callerId: The caller's identifier.
-    ///   - hasVideo: Indicator if call is video or audio.
-    ///   - completion: A closure to be called upon completion.
-    @MainActor
-    open func reportIncomingCall(
-        _ cid: String,
-        localizedCallerName: String,
-        callerId: String,
-        hasVideo: Bool,
-        completion: @escaping (Error?) -> Void
-    ) {
+        let hasVideo = hasVideo ?? supportsVideo
         let (callUUID, callUpdate) = buildCallUpdate(
             cid: cid,
             localizedCallerName: localizedCallerName,
@@ -162,6 +140,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             cid:\(cid)
             callerId:\(callerId)
             callerName:\(localizedCallerName)
+            hasVideo: \(hasVideo)
             """
         )
 

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -117,10 +117,36 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         callerId: String,
         completion: @escaping (Error?) -> Void
     ) {
+        reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false,
+            completion: completion
+        )
+    }
+
+    /// Reports an incoming call to the CallKit framework.
+    ///
+    /// - Parameters:
+    ///   - cid: The call ID.
+    ///   - localizedCallerName: The localized caller name.
+    ///   - callerId: The caller's identifier.
+    ///   - hasVideo: Indicator if call is video or audio.
+    ///   - completion: A closure to be called upon completion.
+    @MainActor
+    open func reportIncomingCall(
+        _ cid: String,
+        localizedCallerName: String,
+        callerId: String,
+        hasVideo: Bool,
+        completion: @escaping (Error?) -> Void
+    ) {
         let (callUUID, callUpdate) = buildCallUpdate(
             cid: cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: hasVideo
         )
 
         callProvider.reportNewIncomingCall(
@@ -573,7 +599,8 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     private func buildCallUpdate(
         cid: String,
         localizedCallerName: String,
-        callerId: String
+        callerId: String,
+        hasVideo: Bool
     ) -> (UUID, CXCallUpdate) {
         let update = CXCallUpdate()
         let idComponents = cid.components(separatedBy: ":")
@@ -589,7 +616,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
         update.localizedCallerName = localizedCallerName
         update.remoteHandle = CXHandle(type: .generic, value: callerId)
-        update.hasVideo = supportsVideo
+        update.hasVideo = hasVideo
         update.supportsDTMF = false
 
         if supportsHolding {

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -109,17 +109,16 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     ///   - cid: The call ID.
     ///   - localizedCallerName: The localized caller name.
     ///   - callerId: The caller's identifier.
-    ///   - hasVideo: Indicator if call is video or audio. If nil we default to the value of `supportsVideo`
+    ///   - hasVideo: Indicator if call is video or audio.
     ///   - completion: A closure to be called upon completion.
     @MainActor
     open func reportIncomingCall(
         _ cid: String,
         localizedCallerName: String,
         callerId: String,
-        hasVideo: Bool? = nil,
+        hasVideo: Bool = false,
         completion: @escaping (Error?) -> Void
     ) {
-        let hasVideo = hasVideo ?? supportsVideo
         let (callUUID, callUpdate) = buildCallUpdate(
             cid: cid,
             localizedCallerName: localizedCallerName,

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -328,6 +328,8 @@ open class CallViewModel: ObservableObject {
     ///  - maxParticipants: An optional integer representing the maximum number of participants allowed in the call.
     ///  - startsAt: An optional date when the call starts.
     ///  - backstage: An optional request for setting up backstage.
+    ///  - hasVideo: A boolean indicating if the call will be video or only audio. Still requires appropriate
+    ///   setting of ``CallSettings`.`
     public func startCall(
         callType: String,
         callId: String,
@@ -337,7 +339,8 @@ open class CallViewModel: ObservableObject {
         maxParticipants: Int? = nil,
         startsAt: Date? = nil,
         backstage: BackstageSettingsRequest? = nil,
-        customData: [String: RawJSON]? = nil
+        customData: [String: RawJSON]? = nil,
+        hasVideo: Bool? = nil
     ) {
         outgoingCallMembers = members
         callingState = ring ? .outgoing : .joining
@@ -368,7 +371,8 @@ open class CallViewModel: ObservableObject {
                         custom: customData,
                         ring: ring,
                         maxDuration: maxDuration,
-                        maxParticipants: maxParticipants
+                        maxParticipants: maxParticipants,
+                        hasVideo: hasVideo
                     )
                     let timeoutSeconds = TimeInterval(
                         callData.settings.ring.autoCancelTimeoutMs / 1000

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -328,7 +328,7 @@ open class CallViewModel: ObservableObject {
     ///  - maxParticipants: An optional integer representing the maximum number of participants allowed in the call.
     ///  - startsAt: An optional date when the call starts.
     ///  - backstage: An optional request for setting up backstage.
-    ///  - hasVideo: A boolean indicating if the call will be video or only audio. Still requires appropriate
+    ///  - video: A boolean indicating if the call will be video or only audio. Still requires appropriate
     ///   setting of ``CallSettings`.`
     public func startCall(
         callType: String,
@@ -340,7 +340,7 @@ open class CallViewModel: ObservableObject {
         startsAt: Date? = nil,
         backstage: BackstageSettingsRequest? = nil,
         customData: [String: RawJSON]? = nil,
-        hasVideo: Bool? = nil
+        video: Bool? = nil
     ) {
         outgoingCallMembers = members
         callingState = ring ? .outgoing : .joining
@@ -372,7 +372,7 @@ open class CallViewModel: ObservableObject {
                         ring: ring,
                         maxDuration: maxDuration,
                         maxParticipants: maxParticipants,
-                        hasVideo: hasVideo
+                        video: video
                     )
                     let timeoutSeconds = TimeInterval(
                         callData.settings.ring.autoCancelTimeoutMs / 1000

--- a/Sources/StreamVideoSwiftUI/Models/CallEventsHandler.swift
+++ b/Sources/StreamVideoSwiftUI/Models/CallEventsHandler.swift
@@ -55,7 +55,8 @@ public class CallEventsHandler {
                 caller: caller,
                 type: type,
                 members: members,
-                timeout: TimeInterval(ringEvent.call.settings.ring.autoCancelTimeoutMs / 1000)
+                timeout: TimeInterval(ringEvent.call.settings.ring.autoCancelTimeoutMs / 1000),
+                video: ringEvent.video
             )
             return .incoming(incomingCall)
         case let .typeCallSessionStartedEvent(callSessionStartedEvent):

--- a/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
+++ b/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
@@ -17,18 +17,21 @@ public struct IncomingCall: Identifiable, Sendable, Equatable {
     public let type: String
     public let members: [Member]
     public let timeout: TimeInterval
+    public let video: Bool
 
     public init(
         id: String,
         caller: User,
         type: String,
         members: [Member],
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        video: Bool
     ) {
         self.id = id
         self.caller = caller
         self.type = type
         self.members = members
         self.timeout = timeout
+        self.video = video
     }
 }

--- a/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
+++ b/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
@@ -25,7 +25,7 @@ public struct IncomingCall: Identifiable, Sendable, Equatable {
         type: String,
         members: [Member],
         timeout: TimeInterval,
-        video: Bool
+        video: Bool = false
     ) {
         self.id = id
         self.caller = caller

--- a/StreamVideoSwiftUITests/CallingViews/IncomingCallView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/IncomingCallView_Tests.swift
@@ -19,7 +19,8 @@ final class IncomingCallView_Tests: StreamVideoUITestCase {
                 caller: members.first!.user,
                 type: callType,
                 members: members,
-                timeout: 15000
+                timeout: 15000,
+                video: false
             )
             let view = IncomingCallView(
                 callInfo: callInfo,

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -105,18 +105,6 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
     }
 
     @MainActor
-    func test_pushRegistryDidReceiveIncomingPush_typeIsVoIP_hasVideoIsNil_reportIncomingCallWasCalledAsExpected() {
-        assertDidReceivePushNotification(
-            .init(
-                cid: "123",
-                localizedCallerName: "TestUser",
-                callerId: "test_user",
-                hasVideo: nil
-            )
-        )
-    }
-
-    @MainActor
     func test_pushRegistryDidReceiveIncomingPush_typeIsVoIPWithDisplayNameAndCallerName_reportIncomingCallWasCalledAsExpected() {
         assertDidReceivePushNotification(
             .init(

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -98,7 +98,8 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
             .init(
                 cid: "123",
                 localizedCallerName: "TestUser",
-                callerId: "test_user"
+                callerId: "test_user",
+                hasVideo: false
             )
         )
     }
@@ -109,7 +110,8 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
             .init(
                 cid: "123",
                 localizedCallerName: "TestUser",
-                callerId: "test_user"
+                callerId: "test_user",
+                hasVideo: false
             ),
             displayName: "Stream Group Call"
         )
@@ -137,7 +139,8 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
                 "call_cid": $0.cid,
                 "call_display_name": displayName,
                 "created_by_display_name": $0.localizedCallerName,
-                "created_by_id": $0.callerId
+                "created_by_id": $0.callerId,
+                "video": $0.hasVideo
             ]
         ] } ?? [:]
 
@@ -166,6 +169,12 @@ final class CallKitPushNotificationAdapterTests: XCTestCase {
             XCTAssertEqual(
                 callKitService.reportIncomingCallWasCalled?.callerId,
                 content.callerId,
+                file: file,
+                line: line
+            )
+            XCTAssertEqual(
+                callKitService.reportIncomingCallWasCalled?.hasVideo,
+                content.hasVideo,
                 file: file,
                 line: line
             )

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -57,13 +57,12 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     // MARK: - reportIncomingCall
 
     @MainActor
-    func test_reportIncomingCall_supportsVideo_callUpdateWasConfiguredCorrectly() throws {
-        subject.supportsVideo = true
-
+    func test_reportIncomingCall_hasVideo_callUpdateWasConfiguredCorrectly() throws {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: true
         ) { _ in }
 
         let invocation = try XCTUnwrap(callProvider.invocations.first)
@@ -78,12 +77,11 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
     @MainActor
     func test_reportIncomingCall_doesNotSupportVideo_callUpdateWasConfiguredCorrectly() throws {
-        subject.supportsVideo = false
-
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         let invocation = try XCTUnwrap(callProvider.invocations.first)
@@ -105,7 +103,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         XCTAssertEqual(subject.callProvider.configuration.iconTemplateImageData, expectedData)
@@ -118,7 +117,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         XCTAssertNil(subject.callProvider.configuration.iconTemplateImageData)
@@ -134,7 +134,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { error in
             completionError = error
             expectation.fulfill()
@@ -157,7 +158,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
         }
     }
@@ -174,7 +176,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
         }
     }
@@ -236,7 +239,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
 
             let waitExpectation = self.expectation(description: "Wait expectation")
@@ -267,7 +271,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
         }
     }
@@ -288,7 +293,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
 
             let waitExpectationA = self.expectation(description: "a")
@@ -299,7 +305,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
         }
     }
@@ -319,7 +326,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         await waitExpectation(timeout: 1)
@@ -352,7 +360,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         await waitExpectation(timeout: 1)
@@ -385,7 +394,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
         await waitExpectation(timeout: 1)
         // Accept call
@@ -421,7 +431,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         await assertReportCallEnded(.answeredElsewhere) {
@@ -448,7 +459,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         await assertReportCallEnded(.declinedElsewhere) {
@@ -472,7 +484,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         subject.provider(
@@ -502,7 +515,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             secondCallId,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         XCTAssertEqual(subject.callCount, 2)
@@ -529,7 +543,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         try await assertRequestTransaction(CXEndCallAction.self) {
@@ -549,7 +564,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         await waitExpectation(timeout: 2)
@@ -587,7 +603,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
-            callerId: callerId
+            callerId: callerId,
+            hasVideo: false
         ) { _ in }
 
         await waitExpectation(timeout: 2)
@@ -746,7 +763,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             subject.reportIncomingCall(
                 cid,
                 localizedCallerName: localizedCallerName,
-                callerId: callerId
+                callerId: callerId,
+                hasVideo: false
             ) { _ in }
         }
     }

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -57,7 +57,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     // MARK: - reportIncomingCall
 
     @MainActor
-    func test_reportIncomingCall_hasVideo_callUpdateWasConfiguredCorrectly() throws {
+    func test_reportIncomingCall_hasVideoTrue_callUpdateWasConfiguredCorrectly() throws {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
@@ -76,12 +76,52 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     }
 
     @MainActor
-    func test_reportIncomingCall_doesNotSupportVideo_callUpdateWasConfiguredCorrectly() throws {
+    func test_reportIncomingCall_hasVideoFalse_callUpdateWasConfiguredCorrectly() throws {
         subject.reportIncomingCall(
             cid,
             localizedCallerName: localizedCallerName,
             callerId: callerId,
             hasVideo: false
+        ) { _ in }
+
+        let invocation = try XCTUnwrap(callProvider.invocations.first)
+
+        switch invocation {
+        case let .reportNewIncomingCall(_, update, _):
+            XCTAssertFalse(update.hasVideo)
+        default:
+            XCTFail()
+        }
+    }
+
+    @MainActor
+    func test_reportIncomingCall_hasVideoNilSupportsVideoTrue_callUpdateWasConfiguredCorrectly() throws {
+        subject.supportsVideo = true
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: nil
+        ) { _ in }
+
+        let invocation = try XCTUnwrap(callProvider.invocations.first)
+
+        switch invocation {
+        case let .reportNewIncomingCall(_, update, _):
+            XCTAssertTrue(update.hasVideo)
+        default:
+            XCTFail()
+        }
+    }
+
+    @MainActor
+    func test_reportIncomingCall_hasVideoNilSupportsVideoFalse_callUpdateWasConfiguredCorrectly() throws {
+        subject.supportsVideo = false
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: nil
         ) { _ in }
 
         let invocation = try XCTUnwrap(callProvider.invocations.first)

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -95,46 +95,6 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     }
 
     @MainActor
-    func test_reportIncomingCall_hasVideoNilSupportsVideoTrue_callUpdateWasConfiguredCorrectly() throws {
-        subject.supportsVideo = true
-        subject.reportIncomingCall(
-            cid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: nil
-        ) { _ in }
-
-        let invocation = try XCTUnwrap(callProvider.invocations.first)
-
-        switch invocation {
-        case let .reportNewIncomingCall(_, update, _):
-            XCTAssertTrue(update.hasVideo)
-        default:
-            XCTFail()
-        }
-    }
-
-    @MainActor
-    func test_reportIncomingCall_hasVideoNilSupportsVideoFalse_callUpdateWasConfiguredCorrectly() throws {
-        subject.supportsVideo = false
-        subject.reportIncomingCall(
-            cid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: nil
-        ) { _ in }
-
-        let invocation = try XCTUnwrap(callProvider.invocations.first)
-
-        switch invocation {
-        case let .reportNewIncomingCall(_, update, _):
-            XCTAssertFalse(update.hasVideo)
-        default:
-            XCTFail()
-        }
-    }
-
-    @MainActor
     func test_reportIncomingCall_withIconTemplateImageData_callUpdateWasConfiguredCorrectly() throws {
         subject = .init()
         let expectedData = String.unique.data(using: .utf8)

--- a/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
@@ -10,7 +10,7 @@ final class MockCallKitService: CallKitService {
         cid: String,
         callerName: String,
         callerId: String,
-        hasVideo: Bool,
+        hasVideo: Bool?,
         completion: (Error?) -> Void
     )?
 
@@ -20,7 +20,7 @@ final class MockCallKitService: CallKitService {
         _ cid: String,
         localizedCallerName: String,
         callerId: String,
-        hasVideo: Bool,
+        hasVideo: Bool?,
         completion: @escaping ((any Error)?) -> Void
     ) {
         reportIncomingCallWasCalled = (cid, localizedCallerName, callerId, hasVideo, completion)

--- a/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
@@ -6,7 +6,13 @@ import Foundation
 import StreamVideo
 
 final class MockCallKitService: CallKitService {
-    private(set) var reportIncomingCallWasCalled: (cid: String, callerName: String, callerId: String, completion: (Error?) -> Void)?
+    private(set) var reportIncomingCallWasCalled: (
+        cid: String,
+        callerName: String,
+        callerId: String,
+        hasVideo: Bool,
+        completion: (Error?) -> Void
+    )?
 
     override init() { super.init() }
 
@@ -14,8 +20,9 @@ final class MockCallKitService: CallKitService {
         _ cid: String,
         localizedCallerName: String,
         callerId: String,
+        hasVideo: Bool,
         completion: @escaping ((any Error)?) -> Void
     ) {
-        reportIncomingCallWasCalled = (cid, localizedCallerName, callerId, completion)
+        reportIncomingCallWasCalled = (cid, localizedCallerName, callerId, hasVideo, completion)
     }
 }


### PR DESCRIPTION
### 📝 Summary

By handling the `video` property on the VoIP push notification we can inform CallKit so the call will reported with correct suffix (video/audio)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)