### PR TITLE
[Feature]Expose UserAvatar view slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- You can now override the default `UserAvatar`, that is used across various SDK components, by using overriding the new `makeUserAvatar` method on your `ViewFactory` implementation. [#644](https://github.com/GetStream/stream-video-swift/pull/644)
 
 ### 🐞 Fixed
 - Fix an issue that was causing the video capturer to no be cleaned up when the call was ended, causing the camera access system indicator to remain on while the `CallEnded` screen is visible. [#636](https://github.com/GetStream/stream-video-swift/pull/636)

--- a/DemoApp/Sources/Components/DemoAppViewFactory.swift
+++ b/DemoApp/Sources/Components/DemoAppViewFactory.swift
@@ -17,10 +17,6 @@ final class DemoAppViewFactory: ViewFactory {
         DemoWaitingLocalUserView(viewFactory: self, viewModel: viewModel)
     }
 
-    func makeUserAvatar(imageURL: URL?, size: CGFloat) -> AnyView {
-        .init(UserAvatar(imageURL: imageURL, size: size))
-    }
-
     func makeLobbyView(
         viewModel: CallViewModel,
         lobbyInfo: LobbyInfo,

--- a/DemoApp/Sources/ViewModifiers/CallModifier/DemoCallModifier.swift
+++ b/DemoApp/Sources/ViewModifiers/CallModifier/DemoCallModifier.swift
@@ -39,6 +39,7 @@ struct DemoCallModifier<Factory: ViewFactory>: ViewModifier {
             ZStack {
                 rootView
                 LivestreamPlayer(
+                    viewFactory: viewFactory,
                     type: call.callType,
                     id: call.callId,
                     joinPolicy: .none,

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -7,7 +7,7 @@ import StreamVideo
 import StreamVideoSwiftUI
 import SwiftUI
 
-struct DetailedCallingView: View {
+struct DetailedCallingView<Factory: ViewFactory>: View {
     enum CallAction: String, Equatable, CaseIterable {
         case startCall = "Start a call"
         case joinCall = "Join a call"
@@ -25,6 +25,7 @@ struct DetailedCallingView: View {
     @ObservedObject var viewModel: CallViewModel
     @ObservedObject private var appState = AppState.shared
 
+    private var viewFactory: Factory
     private let imageSize: CGFloat = 32
 
     private var participants: [User] {
@@ -65,7 +66,12 @@ struct DetailedCallingView: View {
     private var isAnonymous: Bool { appState.currentUser == .anonymous }
     private var canStartCall: Bool { appState.currentUser?.type == .regular }
 
-    init(viewModel: CallViewModel, callId: String) {
+    init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel,
+        callId: String
+    ) {
+        self.viewFactory = viewFactory
         _text = .init(initialValue: callId)
         self.viewModel = viewModel
     }
@@ -191,9 +197,7 @@ struct DetailedCallingView: View {
                                 Text(participant.name)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             } icon: {
-                                DemoAppViewFactory
-                                    .shared
-                                    .makeUserAvatar(participant.user, size: imageSize)
+                                viewFactory.makeUserAvatar(participant, size: imageSize)
                             }
 
                             if selectedParticipants.contains(participant) {

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -191,7 +191,9 @@ struct DetailedCallingView: View {
                                 Text(participant.name)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             } icon: {
-                                UserAvatar(imageURL: participant.imageURL, size: imageSize)
+                                DemoAppViewFactory
+                                    .shared
+                                    .makeUserAvatar(participant.user, size: imageSize)
                             }
 
                             if selectedParticipants.contains(participant) {

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -197,7 +197,10 @@ struct DetailedCallingView<Factory: ViewFactory>: View {
                                 Text(participant.name)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             } icon: {
-                                viewFactory.makeUserAvatar(participant, size: imageSize)
+                                viewFactory.makeUserAvatar(
+                                    participant,
+                                    with: .init(size: imageSize)
+                                )
                             }
 
                             if selectedParticipants.contains(participant) {

--- a/DemoApp/Sources/Views/Login/LoginView.swift
+++ b/DemoApp/Sources/Views/Login/LoginView.swift
@@ -211,7 +211,7 @@ struct AppUserView: View {
         if let imageURL = user.imageURL {
             DemoAppViewFactory
                 .shared
-                .makeUserAvatar(user, size: size)
+                .makeUserAvatar(user, with: .init(size: size))
                 .accessibilityIdentifier("userAvatar")
         } else if let firstCharacter = (overrideUserName ?? user.name).first {
             Text(String(firstCharacter))

--- a/DemoApp/Sources/Views/Login/LoginView.swift
+++ b/DemoApp/Sources/Views/Login/LoginView.swift
@@ -209,7 +209,9 @@ struct AppUserView: View {
 
     var body: some View {
         if let imageURL = user.imageURL {
-            UserAvatar(imageURL: imageURL, size: size)
+            DemoAppViewFactory
+                .shared
+                .makeUserAvatar(user, size: size)
                 .accessibilityIdentifier("userAvatar")
         } else if let firstCharacter = (overrideUserName ?? user.name).first {
             Text(String(firstCharacter))

--- a/Sources/StreamVideoSwiftUI/CallContainer.swift
+++ b/Sources/StreamVideoSwiftUI/CallContainer.swift
@@ -12,7 +12,11 @@ public struct VideoViewOverlay<RootView: View, Factory: ViewFactory>: View {
     var viewFactory: Factory
     @StateObject var viewModel: CallViewModel
     
-    public init(rootView: RootView, viewFactory: Factory, viewModel: CallViewModel) {
+    public init(
+        rootView: RootView,
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel
+    ) {
         self.rootView = rootView
         self.viewFactory = viewFactory
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -36,7 +40,10 @@ public struct CallContainer<Factory: ViewFactory>: View {
     
     private let padding: CGFloat = 16
     
-    public init(viewFactory: Factory, viewModel: CallViewModel) {
+    public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel
+    ) {
         self.viewFactory = viewFactory
         _viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -156,7 +163,10 @@ public struct CallModifier<Factory: ViewFactory>: ViewModifier {
     var viewModel: CallViewModel
 
     @MainActor
-    public init(viewFactory: Factory, viewModel: CallViewModel) {
+    public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel
+    ) {
         self.viewFactory = viewFactory
         self.viewModel = viewModel
     }

--- a/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
@@ -5,17 +5,24 @@
 import StreamVideo
 import SwiftUI
 
-public struct CallParticipantImageView: View {
+public struct CallParticipantImageView<Factory: ViewFactory>: View {
 
     @Injected(\.colors) var colors
     
     private let size: CGFloat = 138
 
+    var viewFactory: Factory
     var id: String
     var name: String
     var imageURL: URL?
 
-    public init(id: String, name: String, imageURL: URL? = nil) {
+    public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        id: String,
+        name: String,
+        imageURL: URL? = nil
+    ) {
+        self.viewFactory = viewFactory
         self.id = id
         self.name = name
         self.imageURL = imageURL
@@ -27,10 +34,15 @@ public struct CallParticipantImageView: View {
         }
         .blur(radius: 8)
         .overlay(
-            UserAvatar(imageURL: imageURL, size: size) {
-                CircledTitleView(
-                    title: name.isEmpty ? id : String(name.uppercased().first!),
-                    size: size
+            viewFactory.makeUserAvatar(
+                .init(id: id, name: name, imageURL: imageURL),
+                size: size
+            ) {
+                AnyView(
+                    CircledTitleView(
+                        title: name.isEmpty ? id : String(name.uppercased().first!),
+                        size: size
+                    )
                 )
             }
         )

--- a/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallParticipantImageView.swift
@@ -36,15 +36,15 @@ public struct CallParticipantImageView<Factory: ViewFactory>: View {
         .overlay(
             viewFactory.makeUserAvatar(
                 .init(id: id, name: name, imageURL: imageURL),
-                size: size
-            ) {
-                AnyView(
-                    CircledTitleView(
-                        title: name.isEmpty ? id : String(name.uppercased().first!),
-                        size: size
+                with: .init(size: size) {
+                    AnyView(
+                        CircledTitleView(
+                            title: name.isEmpty ? id : String(name.uppercased().first!),
+                            size: size
+                        )
                     )
-                )
-            }
+                }
+            )
         )
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/CallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallView.swift
@@ -15,7 +15,10 @@ public struct CallView<Factory: ViewFactory>: View {
     var viewFactory: Factory
     @ObservedObject var viewModel: CallViewModel
 
-    public init(viewFactory: Factory, viewModel: CallViewModel) {
+    public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel
+    ) {
         self.viewFactory = viewFactory
         self.viewModel = viewModel
     }

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/HorizontalParticipantsListView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/HorizontalParticipantsListView.swift
@@ -38,7 +38,7 @@ public struct HorizontalParticipantsListView<Factory: ViewFactory>: View {
 
     /// Creates a new instance of `HorizontalParticipantsListView`.
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         participants: [CallParticipant],
         frame: CGRect,
         call: Call?,

--- a/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/SpotlightSpeakerView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LayoutComponents/SpotlightSpeakerView.swift
@@ -32,7 +32,7 @@ public struct SpotlightSpeakerView<Factory: ViewFactory>: View {
 
     /// Creates a new instance of `SpotlightSpeakerView`.
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         participant: CallParticipant,
         viewIdSuffix: String,
         call: Call?,

--- a/Sources/StreamVideoSwiftUI/CallView/MinimizedCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/MinimizedCallView.swift
@@ -5,14 +5,19 @@
 import StreamVideo
 import SwiftUI
 
-public struct MinimizedCallView: View {
+public struct MinimizedCallView<Factory: ViewFactory>: View {
+    var viewFactory: Factory
     @ObservedObject var viewModel: CallViewModel
-    
+
     @State var callViewPlacement = CallViewPlacement.topTrailing
     
     @State private var dragAmount = CGSize.zero
         
-    public init(viewModel: CallViewModel) {
+    public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel
+    ) {
+        self.viewFactory = viewFactory
         self.viewModel = viewModel
     }
     
@@ -32,6 +37,7 @@ public struct MinimizedCallView: View {
         Group {
             if !viewModel.participants.isEmpty {
                 VideoCallParticipantView(
+                    viewFactory: viewFactory,
                     participant: viewModel.participants[0],
                     availableFrame: availableFrame,
                     contentMode: .scaleAspectFill,

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/CallParticipantsInfoView.swift
@@ -290,17 +290,17 @@ struct CallParticipantView<Factory: ViewFactory>: View {
             HStack {
                 viewFactory.makeUserAvatar(
                     participant.user,
-                    size: imageSize
-                ) {
-                    AnyView(
-                        CircledTitleView(
-                            title: participant.name.isEmpty
-                                ? participant.id
-                                : String(participant.name.uppercased().first!),
-                            size: imageSize
+                    with: .init(size: imageSize) {
+                        AnyView(
+                            CircledTitleView(
+                                title: participant.name.isEmpty
+                                    ? participant.id
+                                    : String(participant.name.uppercased().first!),
+                                size: imageSize
+                            )
                         )
-                    )
-                }
+                    }
+                )
                 .overlay(TopRightView { OnlineIndicatorView(indicatorSize: imageSize * 0.3) })
 
                 Text(participant.name)

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/InviteParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/InviteParticipantsView.swift
@@ -132,7 +132,7 @@ struct VideoUserView<Factory: ViewFactory>: View {
 
     var body: some View {
         HStack {
-            viewFactory.makeUserAvatar(user, size: avatarSize)
+            viewFactory.makeUserAvatar(user, with: .init(size: avatarSize))
 
             Text(user.name)
                 .lineLimit(1)

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/InviteParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/InviteParticipantsView.swift
@@ -6,17 +6,20 @@ import StreamVideo
 import SwiftUI
 
 @available(iOS 14.0, *)
-public struct InviteParticipantsView: View {
+public struct InviteParticipantsView<Factory: ViewFactory>: View {
 
+    var viewFactory: Factory
     @StateObject var viewModel: InviteParticipantsViewModel
     
     @Binding var inviteParticipantsShown: Bool
     
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         inviteParticipantsShown: Binding<Bool>,
         currentParticipants: [CallParticipant],
         call: Call?
     ) {
+        self.viewFactory = viewFactory
         _viewModel = StateObject(
             wrappedValue: InviteParticipantsViewModel(
                 currentParticipants: currentParticipants,
@@ -34,7 +37,7 @@ public struct InviteParticipantsView: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 16) {
                     ForEach(viewModel.selectedUsers) { user in
-                        SelectedParticipantView(user: user) { user in
+                        SelectedParticipantView(viewFactory: viewFactory, user: user) { user in
                             viewModel.userTapped(user)
                         }
                     }
@@ -50,6 +53,7 @@ public struct InviteParticipantsView: View {
                     }
                 } label: {
                     VideoUserView(
+                        viewFactory: viewFactory,
                         user: user,
                         isSelected: viewModel.isSelected(user: user)
                     )
@@ -105,19 +109,30 @@ struct UsersHeaderView: View {
     }
 }
 
-struct VideoUserView: View {
-    
+struct VideoUserView<Factory: ViewFactory>: View {
+
     @Injected(\.colors) var colors
     @Injected(\.fonts) var fonts
     
     private let avatarSize: CGFloat = 56
-    
+
+    var viewFactory: Factory
     var user: User
     var isSelected: Bool
-    
+
+    init(
+        viewFactory: Factory,
+        user: User,
+        isSelected: Bool
+    ) {
+        self.viewFactory = viewFactory
+        self.user = user
+        self.isSelected = isSelected
+    }
+
     var body: some View {
         HStack {
-            UserAvatar(imageURL: user.imageURL, size: avatarSize)
+            viewFactory.makeUserAvatar(user, size: avatarSize)
 
             Text(user.name)
                 .lineLimit(1)

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/SelectedParticipantView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/SelectedParticipantView.swift
@@ -10,13 +10,24 @@ struct SelectedParticipantView<Factory: ViewFactory>: View {
     @Injected(\.fonts) var fonts
     
     private let avatarSize: CGFloat = 50
-    
+
+    var viewFactory: Factory
     var user: User
     var onUserTapped: (User) -> Void
-    
+
+    init(
+        viewFactory: Factory,
+        user: User,
+        onUserTapped: @escaping (User) -> Void
+    ) {
+        self.viewFactory = viewFactory
+        self.user = user
+        self.onUserTapped = onUserTapped
+    }
+
     var body: some View {
         VStack {
-            UserAvatar(imageURL: user.imageURL, size: avatarSize)
+            viewFactory.makeUserAvatar(user, size: avatarSize)
 
             Text(user.name)
                 .lineLimit(1)

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/SelectedParticipantView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/SelectedParticipantView.swift
@@ -5,8 +5,8 @@
 import StreamVideo
 import SwiftUI
 
-struct SelectedParticipantView: View {
-    
+struct SelectedParticipantView<Factory: ViewFactory>: View {
+
     @Injected(\.fonts) var fonts
     
     private let avatarSize: CGFloat = 50

--- a/Sources/StreamVideoSwiftUI/CallView/Participants/SelectedParticipantView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/Participants/SelectedParticipantView.swift
@@ -27,7 +27,7 @@ struct SelectedParticipantView<Factory: ViewFactory>: View {
 
     var body: some View {
         VStack {
-            viewFactory.makeUserAvatar(user, size: avatarSize)
+            viewFactory.makeUserAvatar(user, with: .init(size: avatarSize))
 
             Text(user.name)
                 .lineLimit(1)

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsFullScreenLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsFullScreenLayout.swift
@@ -15,7 +15,7 @@ public struct ParticipantsFullScreenLayout<Factory: ViewFactory>: View {
     var onChangeTrackVisibility: @MainActor(CallParticipant, Bool) -> Void
     
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         participant: CallParticipant,
         call: Call?,
         frame: CGRect,

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsGridLayout.swift
@@ -17,7 +17,7 @@ public struct ParticipantsGridLayout<Factory: ViewFactory>: View {
     @ObservedObject private var orientationAdapter = InjectedValues[\.orientationAdapter]
 
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         call: Call?,
         participants: [CallParticipant],
         availableFrame: CGRect,

--- a/Sources/StreamVideoSwiftUI/CallView/ParticipantsSpotlightLayout.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ParticipantsSpotlightLayout.swift
@@ -15,7 +15,7 @@ public struct ParticipantsSpotlightLayout<Factory: ViewFactory>: View {
     var onChangeTrackVisibility: @MainActor(CallParticipant, Bool) -> Void
     
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         participant: CallParticipant,
         call: Call?,
         participants: [CallParticipant],

--- a/Sources/StreamVideoSwiftUI/CallView/ReconnectionView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ReconnectionView.swift
@@ -14,7 +14,7 @@ public struct ReconnectionView<Factory: ViewFactory>: View {
     
     public init(
         viewModel: CallViewModel,
-        viewFactory: Factory
+        viewFactory: Factory = DefaultViewFactory.shared
     ) {
         self.viewModel = viewModel
         self.viewFactory = viewFactory

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -14,7 +14,7 @@ public struct VideoParticipantsView<Factory: ViewFactory>: View {
     var onChangeTrackVisibility: @MainActor(CallParticipant, Bool) -> Void
 
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         viewModel: CallViewModel,
         availableFrame: CGRect,
         onChangeTrackVisibility: @escaping @MainActor(CallParticipant, Bool) -> Void
@@ -311,11 +311,12 @@ public struct VideoCallParticipantSpeakingModifier: ViewModifier {
     }
 }
 
-public struct VideoCallParticipantView: View {
-    
+public struct VideoCallParticipantView<Factory: ViewFactory>: View {
+
     @Injected(\.images) var images
     @Injected(\.streamVideo) var streamVideo
-        
+
+    var viewFactory: Factory
     let participant: CallParticipant
     var id: String
     var availableFrame: CGRect
@@ -327,6 +328,7 @@ public struct VideoCallParticipantView: View {
     @State private var isUsingFrontCameraForLocalUser: Bool = false
 
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         participant: CallParticipant,
         id: String? = nil,
         availableFrame: CGRect,
@@ -335,6 +337,7 @@ public struct VideoCallParticipantView: View {
         customData: [String: RawJSON],
         call: Call?
     ) {
+        self.viewFactory = viewFactory
         self.participant = participant
         self.id = id ?? participant.id
         self.availableFrame = availableFrame
@@ -367,6 +370,7 @@ public struct VideoCallParticipantView: View {
         .streamAccessibility(value: showVideo ? "1" : "0")
         .overlay(
             CallParticipantImageView(
+                viewFactory: viewFactory,
                 id: participant.id,
                 name: participant.name,
                 imageURL: participant.profileImageURL

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRenderer/LocalVideoView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRenderer/LocalVideoView.swift
@@ -18,7 +18,7 @@ public struct LocalVideoView<Factory: ViewFactory>: View {
     private var availableFrame: CGRect
 
     public init(
-        viewFactory: Factory,
+        viewFactory: Factory = DefaultViewFactory.shared,
         participant: CallParticipant,
         idSuffix: String = "local",
         callSettings: CallSettings,

--- a/Sources/StreamVideoSwiftUI/CallView/ViewModifiers/ParticipantsListViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ViewModifiers/ParticipantsListViewModifier.swift
@@ -13,7 +13,7 @@ extension View {
     @MainActor
     public func presentParticipantListView<Factory: ViewFactory>(
         @ObservedObject viewModel: CallViewModel,
-        viewFactory: Factory
+        viewFactory: Factory = DefaultViewFactory.shared
     ) -> some View {
         halfSheet(isPresented: $viewModel.participantsShown) {
             viewFactory.makeParticipantsListView(viewModel: viewModel)

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
@@ -5,25 +5,28 @@
 import StreamVideo
 import SwiftUI
 
-public struct CallConnectingView<CallControls: View, CallTopView: View>: View {
+public struct CallConnectingView<CallControls: View, CallTopView: View, Factory: ViewFactory>: View {
     @Injected(\.streamVideo) var streamVideo
     
     @Injected(\.colors) var colors
     @Injected(\.fonts) var fonts
     @Injected(\.images) var images
     @Injected(\.utils) var utils
-    
+
+    var viewFactory: Factory
     public var outgoingCallMembers: [Member]
     public var title: String
     public var callControls: CallControls
     public var callTopView: CallTopView
 
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         outgoingCallMembers: [Member],
         title: String,
         callControls: CallControls,
         callTopView: CallTopView
     ) {
+        self.viewFactory = viewFactory
         self.outgoingCallMembers = outgoingCallMembers
         self.title = title
         self.callControls = callControls
@@ -39,12 +42,14 @@ public struct CallConnectingView<CallControls: View, CallTopView: View>: View {
                 
                 if outgoingCallMembers.count > 1 {
                     CallingGroupView(
+                        viewFactory: viewFactory,
                         participants: outgoingCallMembers
                     )
                     .accessibilityElement(children: .combine)
                     .accessibility(identifier: "callConnectingGroupView")
                 } else if !outgoingCallMembers.isEmpty {
                     AnimatingParticipantView(
+                        viewFactory: viewFactory,
                         participant: outgoingCallMembers.first
                     )
                     .accessibility(identifier: "callConnectingParticipantView")

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallingGroupView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallingGroupView.swift
@@ -5,13 +5,24 @@
 import StreamVideo
 import SwiftUI
 
-struct CallingGroupView: View {
-    
+struct CallingGroupView<Factory: ViewFactory>: View {
+
     let easeGently = Animation.easeOut(duration: 1).repeatForever(autoreverses: true)
-    
+
+    var viewFactory: Factory
     var participants: [Member]
-    @State var isCalling = false
-    
+    @State var isCalling: Bool
+
+    init(
+        viewFactory: Factory,
+        participants: [Member],
+        isCalling: Bool = false
+    ) {
+        self.viewFactory = viewFactory
+        self.participants = participants
+        self.isCalling = .init(isCalling)
+    }
+
     var body: some View {
         VStack {
             if participants.count >= 3 {
@@ -31,6 +42,7 @@ struct CallingGroupView: View {
                     ZStack {
                         if participants.count == 3 {
                             IncomingCallParticipantView(
+                                viewFactory: viewFactory,
                                 participant: participants[2],
                                 size: .standardAvatarSize
                             )
@@ -76,6 +88,7 @@ struct CallingGroupView: View {
         animation: Animation
     ) -> some View {
         IncomingCallParticipantView(
+            viewFactory: viewFactory,
             participant: participant,
             size: .standardAvatarSize
         )
@@ -91,16 +104,27 @@ struct CallingGroupView: View {
     }
 }
 
-struct IncomingCallParticipantView: View {
-        
+struct IncomingCallParticipantView<Factory: ViewFactory>: View {
+
+    var viewFactory: Factory
     var participant: Member
-    var size: CGFloat = .expandedAvatarSize
-    
+    var size: CGFloat
+
+    init(
+        viewFactory: Factory,
+        participant: Member,
+        size: CGFloat = .expandedAvatarSize
+    ) {
+        self.viewFactory = viewFactory
+        self.participant = participant
+        self.size = size
+    }
+
     var body: some View {
-        UserAvatar(
-            imageURL: participant.user.imageURL,
+        viewFactory.makeUserAvatar(
+            participant.user,
             size: size
-        ) { CircledTitleView(title: title, size: size) }
+        ) { AnyView(CircledTitleView(title: title, size: size)) }
             .frame(width: size, height: size)
             .modifier(ShadowModifier())
             .animation(nil)

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallingGroupView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallingGroupView.swift
@@ -123,11 +123,13 @@ struct IncomingCallParticipantView<Factory: ViewFactory>: View {
     var body: some View {
         viewFactory.makeUserAvatar(
             participant.user,
-            size: size
-        ) { AnyView(CircledTitleView(title: title, size: size)) }
-            .frame(width: size, height: size)
-            .modifier(ShadowModifier())
-            .animation(nil)
+            with: .init(size: size) {
+                AnyView(CircledTitleView(title: title, size: size))
+            }
+        )
+        .frame(width: size, height: size)
+        .modifier(ShadowModifier())
+        .animation(nil)
     }
 
     private var title: String {

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallingParticipantView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallingParticipantView.swift
@@ -5,15 +5,19 @@
 import StreamVideo
 import SwiftUI
 
-struct CallingParticipantView: View {
-    
+struct CallingParticipantView<Factory: ViewFactory>: View {
+
+    var viewFactory: Factory
     var participant: Member?
     var caller: String = ""
     
     var body: some View {
         ZStack {
             if let participant = participant {
-                IncomingCallParticipantView(participant: participant)
+                IncomingCallParticipantView(
+                    viewFactory: viewFactory,
+                    participant: participant
+                )
             } else {
                 CircledTitleView(title: caller.isEmpty ? "" : String(caller.uppercased().first!))
             }
@@ -21,49 +25,54 @@ struct CallingParticipantView: View {
     }
 }
 
-struct AnimatingParticipantView: View {
-    
+struct AnimatingParticipantView<Factory: ViewFactory>: View {
+
     @Injected(\.colors) var colors
     
     @State var isCalling = false
-    
+
+    var viewFactory: Factory
     var participant: Member?
     var caller: String = ""
     
     var body: some View {
-        CallingParticipantView(participant: participant, caller: caller)
-            .scaleEffect(isCalling ? 0.8 : 1)
-            .animation(
-                .easeOut(duration: 1).repeatForever(autoreverses: true),
-                value: isCalling
-            )
-            .background(
-                ZStack {
-                    // Outer circle
-                    PulsatingCircle(
-                        scaleEffect: isCalling ? 0.8 : 1.2,
-                        opacity: 0.2,
-                        isCalling: isCalling
-                    )
+        CallingParticipantView(
+            viewFactory: viewFactory,
+            participant: participant,
+            caller: caller
+        )
+        .scaleEffect(isCalling ? 0.8 : 1)
+        .animation(
+            .easeOut(duration: 1).repeatForever(autoreverses: true),
+            value: isCalling
+        )
+        .background(
+            ZStack {
+                // Outer circle
+                PulsatingCircle(
+                    scaleEffect: isCalling ? 0.8 : 1.2,
+                    opacity: 0.2,
+                    isCalling: isCalling
+                )
                     
-                    // Middle circle
-                    PulsatingCircle(
-                        scaleEffect: isCalling ? 0.7 : 1.1,
-                        opacity: 0.5,
-                        isCalling: isCalling
-                    )
+                // Middle circle
+                PulsatingCircle(
+                    scaleEffect: isCalling ? 0.7 : 1.1,
+                    opacity: 0.5,
+                    isCalling: isCalling
+                )
                     
-                    // Inner circle
-                    PulsatingCircle(
-                        scaleEffect: isCalling ? 0.5 : 1.2,
-                        opacity: 0.3,
-                        isCalling: isCalling
-                    )
-                }
-            )
-            .onAppear {
-                isCalling.toggle()
+                // Inner circle
+                PulsatingCircle(
+                    scaleEffect: isCalling ? 0.5 : 1.2,
+                    opacity: 0.3,
+                    isCalling: isCalling
+                )
             }
+        )
+        .onAppear {
+            isCalling.toggle()
+        }
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/IncomingCallView.swift
@@ -7,13 +7,14 @@ import SwiftUI
 
 /// A SwiftUI view for displaying an incoming call screen.
 @available(iOS 14.0, *)
-public struct IncomingCallView: View {
+public struct IncomingCallView<Factory: ViewFactory>: View {
 
     @Injected(\.fonts) var fonts
     @Injected(\.colors) var colors
     @Injected(\.images) var images
     @Injected(\.utils) var utils
 
+    var viewFactory: Factory
     @StateObject var viewModel: IncomingViewModel
 
     var onCallAccepted: (String) -> Void
@@ -25,6 +26,7 @@ public struct IncomingCallView: View {
     ///   - onCallAccepted: Callback when the incoming call is accepted.
     ///   - onCallRejected: Callback when the incoming call is rejected.
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         callInfo: IncomingCall,
         onCallAccepted: @escaping (String) -> Void,
         onCallRejected: @escaping (String) -> Void
@@ -32,12 +34,14 @@ public struct IncomingCallView: View {
         _viewModel = StateObject(
             wrappedValue: IncomingViewModel(callInfo: callInfo)
         )
+        self.viewFactory = viewFactory
         self.onCallAccepted = onCallAccepted
         self.onCallRejected = onCallRejected
     }
 
     public var body: some View {
         IncomingCallViewContent(
+            viewFactory: viewFactory,
             callParticipants: viewModel.callParticipants,
             callInfo: viewModel.callInfo,
             onCallAccepted: onCallAccepted,
@@ -47,13 +51,14 @@ public struct IncomingCallView: View {
 }
 
 /// The content view of the incoming call screen.
-struct IncomingCallViewContent: View {
+struct IncomingCallViewContent<Factory: ViewFactory>: View {
 
     @Injected(\.fonts) var fonts
     @Injected(\.colors) var colors
     @Injected(\.images) var images
     @Injected(\.utils) var utils
 
+    var viewFactory: Factory
     var callParticipants: [Member]
     var callInfo: IncomingCall
     var onCallAccepted: (String) -> Void
@@ -65,10 +70,12 @@ struct IncomingCallViewContent: View {
 
             if callParticipants.count > 1 {
                 CallingGroupView(
+                    viewFactory: viewFactory,
                     participants: callParticipants
                 )
             } else {
                 AnimatingParticipantView(
+                    viewFactory: viewFactory,
                     participant: callParticipants.first,
                     caller: callInfo.caller.name
                 )

--- a/Sources/StreamVideoSwiftUI/CallingViews/JoiningCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/JoiningCallView.swift
@@ -5,21 +5,25 @@
 import StreamVideo
 import SwiftUI
 
-public struct JoiningCallView<CallControls: View, CallTopView: View>: View {
+public struct JoiningCallView<CallControls: View, CallTopView: View, Factory: ViewFactory>: View {
 
+    var viewFactory: Factory
     var callTopView: CallTopView
     var callControls: CallControls
     
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         callTopView: CallTopView,
         callControls: CallControls
     ) {
+        self.viewFactory = viewFactory
         self.callTopView = callTopView
         self.callControls = callControls
     }
     
     public var body: some View {
         CallConnectingView(
+            viewFactory: viewFactory,
             outgoingCallMembers: [],
             title: L10n.Call.Joining.title,
             callControls: callControls,

--- a/Sources/StreamVideoSwiftUI/CallingViews/OutgoingCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/OutgoingCallView.swift
@@ -5,7 +5,7 @@
 import StreamVideo
 import SwiftUI
 
-public struct OutgoingCallView<CallControls: View, CallTopView: View>: View {
+public struct OutgoingCallView<CallControls: View, CallTopView: View, Factory: ViewFactory>: View {
 
     @Injected(\.streamVideo) var streamVideo
     
@@ -14,15 +14,18 @@ public struct OutgoingCallView<CallControls: View, CallTopView: View>: View {
     @Injected(\.images) var images
     @Injected(\.utils) var utils
     
+    var viewFactory: Factory
     var outgoingCallMembers: [Member]
     var callTopView: CallTopView
     var callControls: CallControls
     
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         outgoingCallMembers: [Member],
         callTopView: CallTopView,
         callControls: CallControls
     ) {
+        self.viewFactory = viewFactory
         self.outgoingCallMembers = outgoingCallMembers
         self.callTopView = callTopView
         self.callControls = callControls
@@ -30,6 +33,7 @@ public struct OutgoingCallView<CallControls: View, CallTopView: View>: View {
     
     public var body: some View {
         CallConnectingView(
+            viewFactory: viewFactory,
             outgoingCallMembers: outgoingCallMembers,
             title: L10n.Call.Outgoing.title,
             callControls: callControls,

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -177,7 +177,7 @@ struct CameraCheckView<Factory: ViewFactory>: View {
 
                         viewFactory.makeUserAvatar(
                             streamVideo.user,
-                            size: 80
+                            with: .init(size: 80)
                         )
                         .accessibility(identifier: "cameraCheckView")
                         .streamAccessibility(value: "0")
@@ -351,16 +351,16 @@ struct ParticipantsInCallView<Factory: ViewFactory>: View {
                     VStack {
                         viewFactory.makeUserAvatar(
                             participant.user,
-                            size: 40
-                        ) {
-                            AnyView(
-                                CircledTitleView(
-                                    title: participant.user.name.isEmpty ? participant.user
-                                        .id : String(participant.user.name.uppercased().first!),
-                                    size: 40
+                            with: .init(size: 40) {
+                                AnyView(
+                                    CircledTitleView(
+                                        title: participant.user.name.isEmpty ? participant.user
+                                            .id : String(participant.user.name.uppercased().first!),
+                                        size: 40
+                                    )
                                 )
-                            )
-                        }
+                            }
+                        )
 
                         Text(participant.user.name)
                             .font(.caption)

--- a/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/PreJoiningView.swift
@@ -6,11 +6,12 @@ import StreamVideo
 import SwiftUI
 
 @available(iOS 14.0, *)
-public struct LobbyView: View {
-    
+public struct LobbyView<Factory: ViewFactory>: View {
+
     @StateObject var viewModel: LobbyViewModel
     @StateObject var microphoneChecker = MicrophoneChecker()
-    
+
+    var viewFactory: Factory
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
@@ -18,6 +19,7 @@ public struct LobbyView: View {
     var onCloseLobby: () -> Void
         
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         viewModel: LobbyViewModel? = nil,
         callId: String,
         callType: String,
@@ -25,6 +27,7 @@ public struct LobbyView: View {
         onJoinCallTap: @escaping () -> Void,
         onCloseLobby: @escaping () -> Void
     ) {
+        self.viewFactory = viewFactory
         self.callId = callId
         self.callType = callType
         self.onJoinCallTap = onJoinCallTap
@@ -50,6 +53,7 @@ public struct LobbyView: View {
         LobbyContentView(
             viewModel: viewModel,
             microphoneChecker: microphoneChecker,
+            viewFactory: viewFactory,
             callId: callId,
             callType: callType,
             callSettings: $callSettings,
@@ -66,15 +70,16 @@ public struct LobbyView: View {
     }
 }
 
-struct LobbyContentView: View {
-    
+struct LobbyContentView<Factory: ViewFactory>: View {
+
     @Injected(\.images) var images
     @Injected(\.colors) var colors
     @Injected(\.streamVideo) var streamVideo
     
     @ObservedObject var viewModel: LobbyViewModel
     @ObservedObject var microphoneChecker: MicrophoneChecker
-    
+
+    var viewFactory: Factory
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
@@ -113,6 +118,7 @@ struct LobbyContentView: View {
                 CameraCheckView(
                     viewModel: viewModel,
                     microphoneChecker: microphoneChecker,
+                    viewFactory: viewFactory,
                     callSettings: callSettings
                 )
 
@@ -125,6 +131,7 @@ struct LobbyContentView: View {
                 CallSettingsView(callSettings: $callSettings)
 
                 JoinCallView(
+                    viewFactory: viewFactory,
                     callId: callId,
                     callType: callType,
                     callParticipants: viewModel.participants,
@@ -143,14 +150,15 @@ struct LobbyContentView: View {
     }
 }
 
-struct CameraCheckView: View {
-    
+struct CameraCheckView<Factory: ViewFactory>: View {
+
     @Injected(\.images) var images
     @Injected(\.colors) var colors
     @Injected(\.streamVideo) var streamVideo
     
     @ObservedObject var viewModel: LobbyViewModel
     @ObservedObject var microphoneChecker: MicrophoneChecker
+    var viewFactory: Factory
     var callSettings: CallSettings
 
     var body: some View {
@@ -167,9 +175,12 @@ struct CameraCheckView: View {
                         Rectangle()
                             .fill(colors.lobbySecondaryBackground)
 
-                        UserAvatar(imageURL: streamVideo.user.imageURL, size: 80)
-                            .accessibility(identifier: "cameraCheckView")
-                            .streamAccessibility(value: "0")
+                        viewFactory.makeUserAvatar(
+                            streamVideo.user,
+                            size: 80
+                        )
+                        .accessibility(identifier: "cameraCheckView")
+                        .streamAccessibility(value: "0")
                     }
                     .opacity(callSettings.videoOn ? 0 : 1)
                 }
@@ -196,10 +207,11 @@ struct CameraCheckView: View {
     }
 }
 
-struct JoinCallView: View {
-    
+struct JoinCallView<Factory: ViewFactory>: View {
+
     @Injected(\.colors) var colors
-    
+
+    var viewFactory: Factory
     var callId: String
     var callType: String
     var callParticipants: [User]
@@ -217,6 +229,7 @@ struct JoinCallView: View {
             if #available(iOS 14, *) {
                 if !callParticipants.isEmpty {
                     ParticipantsInCallView(
+                        viewFactory: viewFactory,
                         callParticipants: callParticipants
                     )
                 }
@@ -301,15 +314,24 @@ struct CallSettingsView: View {
 }
 
 @available(iOS 14.0, *)
-struct ParticipantsInCallView: View {
-    
+struct ParticipantsInCallView<Factory: ViewFactory>: View {
+
     struct ParticipantInCall: Identifiable {
         let id: String
         let user: User
     }
-    
+
+    var viewFactory: Factory
     var callParticipants: [User]
-    
+
+    init(
+        viewFactory: Factory,
+        callParticipants: [User]
+    ) {
+        self.viewFactory = viewFactory
+        self.callParticipants = callParticipants
+    }
+
     var participantsInCall: [ParticipantInCall] {
         var result = [ParticipantInCall]()
         for (index, participant) in callParticipants.enumerated() {
@@ -327,11 +349,16 @@ struct ParticipantsInCallView: View {
             LazyHStack {
                 ForEach(participantsInCall) { participant in
                     VStack {
-                        UserAvatar(imageURL: participant.user.imageURL, size: 40) {
-                            CircledTitleView(
-                                title: participant.user.name.isEmpty ? participant.user
-                                    .id : String(participant.user.name.uppercased().first!),
-                                size: 40
+                        viewFactory.makeUserAvatar(
+                            participant.user,
+                            size: 40
+                        ) {
+                            AnyView(
+                                CircledTitleView(
+                                    title: participant.user.name.isEmpty ? participant.user
+                                        .id : String(participant.user.name.uppercased().first!),
+                                    size: 40
+                                )
                             )
                         }
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/IncomingCallView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/IncomingCallView_iOS13.swift
@@ -6,19 +6,21 @@ import StreamVideo
 import SwiftUI
 
 @available(iOS, introduced: 13, obsoleted: 14)
-public struct IncomingCallView_iOS13: View {
+public struct IncomingCallView_iOS13<Factory: ViewFactory>: View {
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.fonts) var fonts
     @Injected(\.colors) var colors
     @Injected(\.images) var images
     @Injected(\.utils) var utils
-    
+
+    var viewFactory: Factory
     @BackportStateObject var viewModel: IncomingViewModel
             
     var onCallAccepted: (String) -> Void
     var onCallRejected: (String) -> Void
     
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         callInfo: IncomingCall,
         onCallAccepted: @escaping (String) -> Void,
         onCallRejected: @escaping (String) -> Void
@@ -26,12 +28,14 @@ public struct IncomingCallView_iOS13: View {
         _viewModel = BackportStateObject(
             wrappedValue: IncomingViewModel(callInfo: callInfo)
         )
+        self.viewFactory = viewFactory
         self.onCallAccepted = onCallAccepted
         self.onCallRejected = onCallRejected
     }
     
     public var body: some View {
         IncomingCallViewContent(
+            viewFactory: viewFactory,
             callParticipants: viewModel.callParticipants,
             callInfo: viewModel.callInfo,
             onCallAccepted: onCallAccepted,

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -6,12 +6,13 @@ import StreamVideo
 import SwiftUI
 
 @available(iOS, introduced: 13, obsoleted: 14)
-struct LobbyView_iOS13: View {
-    
+public struct LobbyView_iOS13<Factory: ViewFactory>: View {
+
     @ObservedObject var callViewModel: CallViewModel
     @BackportStateObject var viewModel: LobbyViewModel
     @BackportStateObject var microphoneChecker: MicrophoneChecker
 
+    var viewFactory: Factory
     var callId: String
     var callType: String
     @Binding var callSettings: CallSettings
@@ -19,6 +20,7 @@ struct LobbyView_iOS13: View {
     var onCloseLobby: () -> Void
     
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         callViewModel: CallViewModel,
         callId: String,
         callType: String,
@@ -36,6 +38,7 @@ struct LobbyView_iOS13: View {
         let microphoneCheckerInstance = MicrophoneChecker()
         _microphoneChecker = BackportStateObject(wrappedValue: microphoneCheckerInstance)
         _callSettings = callSettings
+        self.viewFactory = viewFactory
         self.callId = callId
         self.callType = callType
         self.onJoinCallTap = onJoinCallTap
@@ -52,6 +55,7 @@ struct LobbyView_iOS13: View {
         LobbyContentView(
             viewModel: viewModel,
             microphoneChecker: microphoneChecker,
+            viewFactory: viewFactory,
             callId: callId,
             callType: callType,
             callSettings: $callSettings,

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/VideoView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/VideoView_iOS13.swift
@@ -15,7 +15,10 @@ public struct CallContainer_iOS13<Factory: ViewFactory>: View {
     
     private let padding: CGFloat = 16
     
-    public init(viewFactory: Factory, viewModel: CallViewModel) {
+    public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
+        viewModel: CallViewModel
+    ) {
         self.viewFactory = viewFactory
         _viewModel = BackportStateObject(wrappedValue: viewModel)
     }

--- a/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayer.swift
+++ b/Sources/StreamVideoSwiftUI/Livestreaming/LivestreamPlayer.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// The view reacts dynamically to the state of the associated call and allows
 /// customisation of its behaviour through policies and callback actions.
 @available(iOS 14.0, *)
-public struct LivestreamPlayer: View {
+public struct LivestreamPlayer<Factory: ViewFactory>: View {
 
     /// Determines the join behavior for the livestream.
     public enum JoinPolicy {
@@ -25,6 +25,8 @@ public struct LivestreamPlayer: View {
 
     /// Accesses the color palette from the app's dependency injection.
     @Injected(\.colors) var colors
+
+    var viewFactory: Factory
 
     /// The policy that defines how users join the livestream.
     var joinPolicy: JoinPolicy
@@ -52,6 +54,7 @@ public struct LivestreamPlayer: View {
     ///   - showsLeaveCallButton: Whether to show a button to leave the call. Defaults to `false`.
     ///   - onFullScreenStateChange: A callback for fullscreen state changes.
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         type: String,
         id: String,
         muted: Bool = false,
@@ -60,6 +63,7 @@ public struct LivestreamPlayer: View {
         showsLeaveCallButton: Bool = false,
         onFullScreenStateChange: ((Bool) -> Void)? = nil
     ) {
+        self.viewFactory = viewFactory
         let viewModel = LivestreamPlayerViewModel(
             type: type,
             id: id,
@@ -86,6 +90,7 @@ public struct LivestreamPlayer: View {
                     GeometryReader { reader in
                         if let participant = state.participants.first {
                             VideoCallParticipantView(
+                                viewFactory: viewFactory,
                                 participant: participant,
                                 availableFrame: reader.frame(in: .global),
                                 contentMode: .scaleAspectFit,

--- a/Sources/StreamVideoSwiftUI/Utils/UserAvatar.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/UserAvatar.swift
@@ -4,14 +4,26 @@
 
 import SwiftUI
 
+/// A view that displays a user's avatar image.
+///
+/// `UserAvatar` fetches and displays an image from a given URL. If the image
+/// cannot be loaded, a failback view is displayed instead.
 public struct UserAvatar<Failback: View>: View {
 
+    /// Typealias for a provider that returns either a Failback view or an EmptyView
     public typealias FailbackProvider = () -> _ConditionalContent<Failback, EmptyView>
 
-    public var imageURL: URL?
-    public var size: CGFloat
-    public var failbackProvider: FailbackProvider
+    public var imageURL: URL? // URL of the user's avatar image
+    public var size: CGFloat // Size of the avatar
+    public var failbackProvider: FailbackProvider // Provider for the failback view
 
+    /// Initializes a `UserAvatar` view.
+    ///
+    /// - Parameters:
+    ///   - imageURL: The URL of the user's avatar image.
+    ///   - size: The size of the avatar.
+    ///   - failbackProvider: A provider that returns either a failback view or an
+    ///     empty view.
     public init(imageURL: URL?, size: CGFloat, failbackProvider: (() -> Failback)?) {
         self.imageURL = imageURL
         self.size = size
@@ -24,6 +36,7 @@ public struct UserAvatar<Failback: View>: View {
         }
     }
     
+    /// The content and behavior of the `UserAvatar` view.
     public var body: some View {
         StreamLazyImage(imageURL: imageURL, placeholder: failbackProvider)
             .frame(width: size, height: size)
@@ -31,9 +44,44 @@ public struct UserAvatar<Failback: View>: View {
     }
 }
 
+/// Extension for `UserAvatar` when `Failback` is `EmptyView`.
 extension UserAvatar where Failback == EmptyView {
 
+    /// Initializes a `UserAvatar` view with no failback provider.
+    ///
+    /// - Parameters:
+    ///   - imageURL: The URL of the user's avatar image.
+    ///   - size: The size of the avatar.
     public init(imageURL: URL?, size: CGFloat) {
         self.init(imageURL: imageURL, size: size, failbackProvider: nil)
+    }
+}
+
+/// Options to configure `UserAvatarView`.
+///
+/// `UserAvatarViewOptions` provides configuration options for the `UserAvatar`
+/// view, including the size of the avatar and a provider for the failback view.
+///
+/// - Parameters:
+///   - size: The size of the avatar.
+///   - failbackProvider: A provider that returns a failback view.
+public struct UserAvatarViewOptions {
+    /// Size of the avatar
+    public var size: CGFloat
+
+    /// Provider for the failback view
+    public var failbackProvider: (() -> AnyView)?
+
+    /// Initializes a `UserAvatarViewOptions` instance.
+    ///
+    /// - Parameters:
+    ///   - size: The size of the avatar.
+    ///   - failbackProvider: A provider that returns a failback view.
+    public init(
+        size: CGFloat,
+        failbackProvider: (() -> AnyView)? = nil
+    ) {
+        self.size = size
+        self.failbackProvider = failbackProvider
     }
 }

--- a/Sources/StreamVideoSwiftUI/ViewFactory.swift
+++ b/Sources/StreamVideoSwiftUI/ViewFactory.swift
@@ -153,6 +153,12 @@ public protocol ViewFactory: AnyObject {
         callSettings: Binding<CallSettings>,
         call: Call?
     ) -> LocalParticipantViewModifierType
+
+    associatedtype UserAvatarViewType: View
+    func makeUserAvatar(
+        _ user: User,
+        size: CGFloat
+    ) -> UserAvatarViewType
 }
 
 extension ViewFactory {
@@ -339,6 +345,13 @@ extension ViewFactory {
                 showAllInfo: true
             )
         }
+    }
+
+    public func makeUserAvatar(
+        _ user: User,
+        size: CGFloat
+    ) -> some View {
+        UserAvatar(imageURL: user.imageURL, size: size)
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/ViewFactory.swift
+++ b/Sources/StreamVideoSwiftUI/ViewFactory.swift
@@ -148,6 +148,12 @@ public protocol ViewFactory: AnyObject {
     func makeReconnectionView(viewModel: CallViewModel) -> ReconnectionViewType
 
     associatedtype LocalParticipantViewModifierType: ViewModifier
+    /// Creates a view modifier for the local participant view.
+    /// - Parameters:
+    ///   - localParticipant: The local participant.
+    ///   - callSettings: The call settings.
+    ///   - call: The current call.
+    /// - Returns: A view modifier for the local participant view.
     func makeLocalParticipantViewModifier(
         localParticipant: CallParticipant,
         callSettings: Binding<CallSettings>,
@@ -155,10 +161,14 @@ public protocol ViewFactory: AnyObject {
     ) -> LocalParticipantViewModifierType
 
     associatedtype UserAvatarViewType: View
+    /// Creates a user avatar view.
+    /// - Parameters:
+    ///   - user: The user for whom the avatar is created.
+    ///   - options: The options for the avatar view.
+    /// - Returns: A view representing the user's avatar.
     func makeUserAvatar(
         _ user: User,
-        size: CGFloat,
-        failBackProvider: (() -> AnyView)?
+        with options: UserAvatarViewOptions
     ) -> UserAvatarViewType
 }
 
@@ -368,13 +378,12 @@ extension ViewFactory {
 
     public func makeUserAvatar(
         _ user: User,
-        size: CGFloat,
-        failBackProvider: (() -> AnyView)? = nil
+        with options: UserAvatarViewOptions
     ) -> some View {
         UserAvatar(
             imageURL: user.imageURL,
-            size: size,
-            failbackProvider: failBackProvider
+            size: options.size,
+            failbackProvider: options.failbackProvider
         )
     }
 }

--- a/StreamVideoSwiftUITests/CallingViews/CallingGroupView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/CallingGroupView_Tests.swift
@@ -13,7 +13,11 @@ final class CallingGroupView_Tests: StreamVideoUITestCase {
     func test_callingGroupView_isCalling_snapshot() throws {
         for count in spotlightParticipants {
             let users = UserFactory.get(count)
-            let view = CallingGroupView(participants: users, isCalling: true)
+            let view = CallingGroupView(
+                viewFactory: DefaultViewFactory.shared,
+                participants: users,
+                isCalling: true
+            )
             AssertSnapshot(
                 view,
                 variants: snapshotVariants,
@@ -25,7 +29,11 @@ final class CallingGroupView_Tests: StreamVideoUITestCase {
     func test_callingGroupView_isNotCalling_snapshot() throws {
         for count in spotlightParticipants {
             let users = UserFactory.get(count)
-            let view = CallingGroupView(participants: users, isCalling: true)
+            let view = CallingGroupView(
+                viewFactory: DefaultViewFactory.shared,
+                participants: users,
+                isCalling: true
+            )
             AssertSnapshot(
                 view,
                 variants: snapshotVariants,

--- a/StreamVideoSwiftUITests/CallingViews/CallingParticipantView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/CallingParticipantView_Tests.swift
@@ -12,7 +12,11 @@ import XCTest
 final class CallingParticipantView_Tests: StreamVideoUITestCase {
     
     func test_callingParticipantView_snapshot() throws {
-        let view = CallingParticipantView(participant: UserFactory.get(2).last, caller: "caller.123")
+        let view = CallingParticipantView(
+            viewFactory: DefaultViewFactory.shared,
+            participant: UserFactory.get(2).last,
+            caller: "caller.123"
+        )
         AssertSnapshot(view, variants: snapshotVariants)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-675/[video]blinkallow-useravatar-override

### 📝 Summary

This revision exposes the `UserAvatar` view slot. You can use this slot to override the `avatar` view that appears in the various SDK components.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)