### PR TITLE
[Swift6 Migration]Fix CallKit crash

### DIFF
--- a/DemoApp/Sources/Components/MemoryLogDestination/OSLogDestination.swift
+++ b/DemoApp/Sources/Components/MemoryLogDestination/OSLogDestination.swift
@@ -50,13 +50,13 @@ final class OSLogDestination: BaseLogDestination, @unchecked Sendable {
 
         switch logDetails.level {
         case .debug:
-            logger.debug("\(formattedMessage)")
+            logger.debug("\(formattedMessage, privacy: .public)")
         case .info:
-            logger.notice("\(formattedMessage)")
+            logger.notice("\(formattedMessage, privacy: .public)")
         case .warning:
-            logger.warning("\(formattedMessage)")
+            logger.warning("\(formattedMessage, privacy: .public)")
         case .error:
-            logger.critical("\(formattedMessage)")
+            logger.critical("\(formattedMessage, privacy: .public)")
         }
     }
 }

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -107,19 +107,17 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
                 "Received VoIP push notification with cid:\(content.cid) callerId:\(content.callerId) callerName:\(content.localizedCallerName)."
             )
 
-        Task { @MainActor [weak self] in
-            self?.callKitService.reportIncomingCall(
-                content.cid,
-                localizedCallerName: content.localizedCallerName,
-                callerId: content.callerId,
-                hasVideo: content.hasVideo,
-                completion: { error in
-                    if let error {
-                        log.error(error)
-                    }
+        callKitService.reportIncomingCall(
+            content.cid,
+            localizedCallerName: content.localizedCallerName,
+            callerId: content.callerId,
+            hasVideo: content.hasVideo,
+            completion: { error in
+                if let error {
+                    log.error(error)
                 }
-            )
-        }
+            }
+        )
     }
 
     /// Decodes push notification Payload to a type that the CallKit implementation can use.

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -111,7 +111,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     ///   - callerId: The caller's identifier.
     ///   - hasVideo: Indicator if call is video or audio.
     ///   - completion: A closure to be called upon completion.
-    @MainActor
     open func reportIncomingCall(
         _ cid: String,
         localizedCallerName: String,
@@ -157,7 +156,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         Task {
             do {
                 if streamVideo.state.connection != .connected {
-                    let result = await Task { @MainActor in
+                    let result = await Task {
                         try await streamVideo.connect()
                     }.result
 
@@ -170,7 +169,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 }
 
                 if streamVideo.state.ringingCall?.cId != callEntry.call.cId {
-                    Task { @MainActor in
+                    Task {
                         streamVideo.state.ringingCall = callEntry.call
                     }
                 }
@@ -576,7 +575,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         return provider
     }
 
-    @MainActor
     private func buildCallUpdate(
         cid: String,
         localizedCallerName: String,


### PR DESCRIPTION
### 📝 Summary

Due to the recent changes of Swift 6 Migration, CallKit reporting was changed to async operation. Unfortunately, CallKit expects call reporting to happen synchronously from the moment the PushNotification has been received. ([note](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/pushregistry(_:didreceiveincomingpushwith:for:completion:)))

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)