### PR TITLE
[Fix]Failing tests in Xcode 15 iOS 15.5

### DIFF
--- a/StreamVideoTests/Utils/AudioSession/StreamRTCAudioSession_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/StreamRTCAudioSession_Tests.swift
@@ -14,8 +14,8 @@ import XCTest
 
 final class StreamRTCAudioSessionTests: XCTestCase {
 
-    private lazy var subject: StreamRTCAudioSession! = .init()
     private lazy var rtcAudioSession: RTCAudioSession! = .sharedInstance()
+    private lazy var subject: StreamRTCAudioSession! = .init()
     private var cancellables: Set<AnyCancellable>! = []
 
     override func tearDown() async throws {
@@ -144,7 +144,8 @@ final class StreamRTCAudioSessionTests: XCTestCase {
     }
 
     func test_currentRoute_returnsSourceValue() {
-        XCTAssertEqual(subject.currentRoute, rtcAudioSession.currentRoute)
+        XCTAssertEqual(subject.currentRoute.inputs.map(\.portType), rtcAudioSession.currentRoute.inputs.map(\.portType))
+        XCTAssertEqual(subject.currentRoute.outputs.map(\.portType), rtcAudioSession.currentRoute.outputs.map(\.portType))
     }
 
     func test_category_returnsStateCategory() {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-712/flakey-test-currentroute-returnssourcevalue

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)