### PR TITLE
[Fix]SerialQueue processing for MicrophoneChecker operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Support for Swift 6 [#684](https://github.com/GetStream/stream-video-swift/pull/684)
 
+### 🐞 Fixed
+- Fix a race condition caused in the MicrophoneChecker. [#700](https://github.com/GetStream/stream-video-swift/pull/700)
+
 # [1.17.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.17.0)
 _February 14, 2025_
 

--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -29,6 +29,7 @@ public final class MicrophoneChecker: ObservableObject {
 
     deinit {
         updateMetersCancellable?.cancel()
+        updateMetersCancellable = nil
     }
 
     /// Checks if there are audible values available.


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-730/[khealth]crash-on-microphonechecker

### 📝 Summary

Resolve a race condition that could make the MicrophoneChecker crash.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)