### PR TITLE
[Fix]NoiseCancellation activating step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix an issue that was stopping NoiseCancellation from being activated [#705](https://github.com/GetStream/stream-video-swift/pull/705)
 
 # [1.18.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.18.0)
 _March 06, 2025_

--- a/DemoApp/Sources/ViewModifiers/MoreControls/DemoNoiseCancellationButtonView.swift
+++ b/DemoApp/Sources/ViewModifiers/MoreControls/DemoNoiseCancellationButtonView.swift
@@ -57,6 +57,9 @@ struct DemoNoiseCancellationButtonView: View {
                     isNoiseCancellationAvailable = false
                 }
             }
+            .onReceive(streamVideo.videoConfig.noiseCancellationFilter?.$isActive) {
+                isActive = $0
+            }
         }
     }
 }

--- a/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
+++ b/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
@@ -66,7 +66,7 @@ public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable, Ob
                     .state
                     .$activeCall
                     .filter { $0 != nil }
-                    .nextValue(dropFirst: 0)
+                    .nextValue(timeout: 2)
             }
 
             guard let activeCall = call else {
@@ -78,7 +78,9 @@ public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable, Ob
             do {
                 try await activeCall.startNoiseCancellation()
                 self.initializeClosure(sampleRate, channels)
-                self.isActive = true
+                _ = await Task { @MainActor in
+                    self.isActive = true
+                }.result
                 self.activationTask = nil
                 log.debug("AudioFilter:\(id) is now active 🟢.")
             } catch {

--- a/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
+++ b/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
@@ -6,7 +6,7 @@ import Foundation
 import StreamWebRTC
 
 /// A concrete implementation of `AudioFilter` that applies noise cancellation effects.
-public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable {
+public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable, ObservableObject {
 
     public typealias InitializeClosure = (Int, Int) -> Void
     public typealias ProcessClosure = (Int, Int, Int, UnsafeMutablePointer<Float>) -> Void
@@ -14,7 +14,7 @@ public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable {
 
     @Injected(\.streamVideo) private var streamVideo
 
-    private var isActive: Bool = false
+    @Published public private(set) var isActive: Bool = false
     private var activationTask: Task<Void, Error>?
 
     private let name: String
@@ -54,21 +54,35 @@ public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable {
 
         let id = self.id
         // Asynchronously activate noise cancellation for the active call.
-        activationTask = Task { @MainActor [weak self] in
-            guard let activeCall = self?.streamVideo.state.activeCall else {
-                self?.activationTask = nil
+        activationTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            var call = streamVideo.state.activeCall
+
+            if call == nil {
+                call = try await streamVideo
+                    .state
+                    .$activeCall
+                    .filter { $0 != nil }
+                    .nextValue(dropFirst: 0)
+            }
+
+            guard let activeCall = call else {
+                self.activationTask = nil
                 log.warning("AudioFilter:\(id) cannot be activated. No activeCall found.")
                 return
             }
 
             do {
                 try await activeCall.startNoiseCancellation()
-                self?.initializeClosure(sampleRate, channels)
-                self?.isActive = true
-                self?.activationTask = nil
+                self.initializeClosure(sampleRate, channels)
+                self.isActive = true
+                self.activationTask = nil
                 log.debug("AudioFilter:\(id) is now active 🟢.")
             } catch {
-                self?.activationTask = nil
+                self.activationTask = nil
                 log.debug("AudioFilter:\(id) failed to activate with error:\(error)")
             }
         }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-731/noisecancellation-cannot-be-activated

### 🛠 Implementation

NoiseCancellation activation requires an activeCall from StreamVideo client. When the value hasn't been updated we should defer the execution until we have a value.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)