### PR TITLE
[Improvement]Handle blocked users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix an issue that was stopping NoiseCancellation from being activated [#705](https://github.com/GetStream/stream-video-swift/pull/705)
 - Fix an issue where SetPublisher request was firing when nothing was published [#706](https://github.com/GetStream/stream-video-swift/pull/706)
 
+### ✅ Added
+- Better handling for blocked users [#707](https://github.com/GetStream/stream-video-swift/pull/707)
+
 # [1.18.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.18.0)
 _March 06, 2025_
 

--- a/Sources/StreamVideo/Errors/Errors.swift
+++ b/Sources/StreamVideo/Errors/Errors.swift
@@ -138,3 +138,5 @@ extension ClosedRange where Bound == Int {
 struct APIErrorContainer: Codable {
     let error: APIError
 }
+
+extension APIError: Error {}

--- a/Sources/StreamVideo/Errors/Errors.swift
+++ b/Sources/StreamVideo/Errors/Errors.swift
@@ -4,8 +4,6 @@
 
 import Foundation
 
-extension APIError: Error {}
-
 extension Stream_Video_Sfu_Models_Error: Error, ReflectiveStringConvertible {}
 
 /// A Client error.
@@ -26,10 +24,11 @@ public class ClientError: Error, ReflectiveStringConvertible, @unchecked Sendabl
     public let apiError: APIError?
     
     var errorDescription: String? {
-        if apiError != nil {
-            return apiError.map(String.init(describing:))
+        if let apiError {
+            return apiError.message
+        } else {
+            return underlyingError.map(String.init(describing:))
         }
-        return underlyingError.map(String.init(describing:))
     }
     
     /// Retrieve the localized description for this error.

--- a/Sources/StreamVideo/OpenApi/generated/Models/APIError.swift
+++ b/Sources/StreamVideo/OpenApi/generated/Models/APIError.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public final class APIError: Error, @unchecked Sendable, Codable, JSONEncodable, Hashable, ReflectiveStringConvertible {
+public final class APIError: @unchecked Sendable, Codable, JSONEncodable, Hashable, ReflectiveStringConvertible {
 
     public var code: Int
     public var details: [Int]

--- a/Sources/StreamVideo/OpenApi/generated/Models/APIError.swift
+++ b/Sources/StreamVideo/OpenApi/generated/Models/APIError.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public final class APIError: @unchecked Sendable, Codable, JSONEncodable, Hashable, ReflectiveStringConvertible {
+public final class APIError: Error, @unchecked Sendable, Codable, JSONEncodable, Hashable, ReflectiveStringConvertible {
 
     public var code: Int
     public var details: [Int]

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Blocked.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Blocked.swift
@@ -1,0 +1,80 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension WebRTCCoordinator.StateMachine.Stage {
+
+    /// Creates and returns a leaving stage for the WebRTC coordinator state
+    /// machine.
+    /// - Parameter context: The context for the leaving stage.
+    /// - Returns: A `LeavingStage` instance representing the leaving state of
+    ///   the WebRTC coordinator.
+    static func blocked(
+        _ context: Context
+    ) -> WebRTCCoordinator.StateMachine.Stage {
+        BlockedStage(
+            context
+        )
+    }
+}
+
+extension WebRTCCoordinator.StateMachine.Stage {
+
+    /// Represents the leaving stage in the WebRTC coordinator state machine.
+    final class BlockedStage:
+        WebRTCCoordinator.StateMachine.Stage,
+        @unchecked Sendable
+    {
+        private let disposableBag = DisposableBag()
+
+        /// Initializes a new instance of `BlockedStage`.
+        /// - Parameter context: The context for the leaving stage.
+        init(
+            _ context: Context
+        ) {
+            super.init(id: .blocked, context: context)
+        }
+
+        /// Performs the transition from a previous stage to this leaving stage.
+        /// - Parameter previousStage: The stage from which the transition is
+        ///   occurring.
+        /// - Returns: This `BlockedStage` instance if the transition is valid,
+        ///   otherwise `nil`.
+        /// - Note: Valid transition from: `.joined`, `.disconnected`
+        override func transition(
+            from previousStage: WebRTCCoordinator.StateMachine.Stage
+        ) -> Self? {
+            switch previousStage.id {
+            case .cleanUp, .leaving, .error, .idle:
+                // We do nothing in those as the user isn't in the call
+                return nil
+            default:
+                execute()
+                return self
+            }
+        }
+
+        /// Executes the leaving process.
+        private func execute() {
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    guard
+                        let coordinator = context.coordinator
+                    else {
+                        throw ClientError("WebRCTAdapter instance not available.")
+                    }
+
+                    try Task.checkCancellation()
+
+                    try transition?(.cleanUp(context))
+                } catch {
+                    transitionErrorOrLog(error)
+                }
+            }
+            .store(in: disposableBag)
+        }
+    }
+}

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Blocked.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Blocked.swift
@@ -62,7 +62,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 guard let self else { return }
                 do {
                     guard
-                        let coordinator = context.coordinator
+                        context.coordinator != nil
                     else {
                         throw ClientError("WebRCTAdapter instance not available.")
                     }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -45,7 +45,11 @@ extension WebRTCCoordinator.StateMachine {
         enum ID: Hashable, CaseIterable {
             case idle, connecting, connected, joining, joined, leaving, cleanUp,
                  disconnected, fastReconnecting, fastReconnected, rejoining,
-                 migrating, migrated, error
+                 migrating, migrated, error, blocked
+
+            #if canImport(XCTest)
+            case testOnly
+            #endif
         }
 
         /// The identifier for the current stage.

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -81,7 +81,9 @@ open class CallViewModel: ObservableObject {
     public var error: Error? {
         didSet {
             errorAlertShown = error != nil
-            if let error {
+            if let error = error as? APIError {
+                toast = Toast(style: .error, message: error.message)
+            } else if let error {
                 toast = Toast(style: .error, message: error.localizedDescription)
             } else {
                 toast = nil

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		401338782BF248B9007318BD /* MockStreamVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338772BF248B9007318BD /* MockStreamVideo.swift */; };
 		4013387A2BF248CC007318BD /* MockCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338792BF248CC007318BD /* MockCall.swift */; };
 		4013387C2BF248E9007318BD /* Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013387B2BF248E9007318BD /* Mockable.swift */; };
+		4013A8ED2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8EC2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift */; };
+		4013A8EF2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8EE2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift */; };
 		401480302A5317640029166A /* AudioValuePercentageNormaliser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014802F2A5317640029166A /* AudioValuePercentageNormaliser.swift */; };
 		401480342A5423D60029166A /* AudioValuePercentageNormaliser_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */; };
 		401480362A5447C50029166A /* LocalParticipantViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480352A5447C50029166A /* LocalParticipantViewModifier.swift */; };
@@ -208,11 +210,11 @@
 		404C27CB2BF2552800DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		404C27CC2BF2552900DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		404CAEE72B8F48F6007087BC /* DemoBackgroundEffectSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */; };
-		405687AE2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
-		405687AF2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		4051A26F2D665B03000C3167 /* Sendable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */; };
 		4051A2732D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4051A2742D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
+		405687AE2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
+		405687AF2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
 		406128812CF32FEF007F5CDC /* SDPLineVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406128802CF32FEF007F5CDC /* SDPLineVisitor.swift */; };
 		406128832CF33000007F5CDC /* SDPParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406128822CF33000007F5CDC /* SDPParser.swift */; };
@@ -1571,6 +1573,8 @@
 		401338772BF248B9007318BD /* MockStreamVideo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStreamVideo.swift; sourceTree = "<group>"; };
 		401338792BF248CC007318BD /* MockCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCall.swift; sourceTree = "<group>"; };
 		4013387B2BF248E9007318BD /* Mockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mockable.swift; sourceTree = "<group>"; };
+		4013A8EC2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebRTCCoordinator+Blocked.swift"; sourceTree = "<group>"; };
+		4013A8EE2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCCoordinatorStateMachine_BlockedStageTests.swift; sourceTree = "<group>"; };
 		4014802F2A5317640029166A /* AudioValuePercentageNormaliser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioValuePercentageNormaliser.swift; sourceTree = "<group>"; };
 		401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioValuePercentageNormaliser_Tests.swift; sourceTree = "<group>"; };
 		401480352A5447C50029166A /* LocalParticipantViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalParticipantViewModifier.swift; sourceTree = "<group>"; };
@@ -1687,9 +1691,9 @@
 		4049CE812BBBF74C003D07D2 /* LegacyAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyAsyncImage.swift; sourceTree = "<group>"; };
 		4049CE832BBBF8EF003D07D2 /* StreamAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamAsyncImage.swift; sourceTree = "<group>"; };
 		404A5CFA2AD5648100EF1C62 /* DemoChatModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatModifier.swift; sourceTree = "<group>"; };
-		405687AD2D78A0E700093B98 /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sendable+Extensions.swift"; sourceTree = "<group>"; };
 		4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomStringConvertible+Conformances.swift"; sourceTree = "<group>"; };
+		405687AD2D78A0E700093B98 /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
 		406128802CF32FEF007F5CDC /* SDPLineVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDPLineVisitor.swift; sourceTree = "<group>"; };
 		406128822CF33000007F5CDC /* SDPParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDPParser.swift; sourceTree = "<group>"; };
@@ -3601,6 +3605,7 @@
 				40AF6A402C9356B700BA2935 /* WebRTCCoordinatorStateMachine_MigratingStageTests.swift */,
 				40AF6A422C93585B00BA2935 /* WebRTCCoordinatorStateMachine_MigratedStageTests.swift */,
 				40AF6A442C935D1900BA2935 /* WebRTCCoordinatorStateMachine_LeavingStageTests.swift */,
+				4013A8EE2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift */,
 				40AF6A482C935EB600BA2935 /* WebRTCCoordinatorStateMachine_CleanUpStageTests.swift */,
 				40AF6A4A2C9369A900BA2935 /* WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift */,
 				40C9E4412C943DC000802B28 /* WebRTCCoordinatorStateMachine_ErrorStageTests.swift */,
@@ -4237,6 +4242,7 @@
 				40BBC4E72C63A64E002AEF92 /* WebRTCCoordinator+Migrating.swift */,
 				40BBC4E92C63A665002AEF92 /* WebRTCCoordinator+Migrated.swift */,
 				40BBC4DB2C63A4C8002AEF92 /* WebRTCCoordinator+Leaving.swift */,
+				4013A8EC2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift */,
 				40BBC4DD2C63A507002AEF92 /* WebRTCCoordinator+CleanUp.swift */,
 				40BBC4DF2C63A564002AEF92 /* WebRTCCoordinator+Disconnected.swift */,
 				40BBC4CB2C639053002AEF92 /* WebRTCCoordinator+Error.swift */,
@@ -6921,6 +6927,7 @@
 				40382F2E2C88B87D00C2D00F /* ReflectiveStringConvertible.swift in Sources */,
 				40BBC48F2C623C6E002AEF92 /* StreamRTCPeerConnection+Events.swift in Sources */,
 				40FF825F2D63532C0029AA80 /* Participants.swift in Sources */,
+				4013A8ED2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift in Sources */,
 				40034C2C2CFE157300A318B1 /* CallKitAlwaysAvailabilityPolicy.swift in Sources */,
 				84C4004229E3F446007B69C2 /* ConnectedEvent.swift in Sources */,
 				402D0E882D0C94CD00E9B83F /* RTCAudioTrack+Clone.swift in Sources */,
@@ -7582,6 +7589,7 @@
 				40B48C4C2D14F721002C4EAB /* RTPMapVisitorTests.swift in Sources */,
 				40B48C152D14C93B002C4EAB /* CGSize_AdaptTests.swift in Sources */,
 				40382F3D2C89C11D00C2D00F /* MockRTCPeerConnectionCoordinatorFactory.swift in Sources */,
+				4013A8EF2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift in Sources */,
 				40AB31262A49838000C270E1 /* EventTests.swift in Sources */,
 				84F58B7C29EE979F00010C4C /* VirtualTime.swift in Sources */,
 				40F0173E2BBEB86800E89FD1 /* TestsAuthenticationProvider.swift in Sources */,

--- a/StreamVideoTests/Utils/StateMachine/StreamStateMachine_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/StreamStateMachine_Tests.swift
@@ -56,9 +56,8 @@ final class StreamStateMachineTests: XCTestCase, @unchecked Sendable {
     // MARK: - Mocks
 
     private final class MockStage: StreamStateMachineStage {
-
         var id: String
-        let container: String
+        var container: String
         var description: String
         var allowedTransitions: [MockStage]
 

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_BlockedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_BlockedStageTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+import XCTest
+
+final class WebRTCCoordinatorStateMachine_BlockedStageTests: XCTestCase, @unchecked Sendable {
+
+    private nonisolated(unsafe) static var videoConfig: VideoConfig! = .dummy()
+
+    private lazy var allOtherStages: [WebRTCCoordinator.StateMachine.Stage]! = WebRTCCoordinator
+        .StateMachine
+        .Stage
+        .ID
+        .allCases
+        .filter { $0 != subject.id }
+        .map { WebRTCCoordinator.StateMachine.Stage(id: $0, context: .init()) }
+    private lazy var validStages: Set<WebRTCCoordinator.StateMachine.Stage.ID>! = .init(
+        WebRTCCoordinator
+            .StateMachine
+            .Stage
+            .ID
+            .allCases
+            .filter { $0 != .idle && $0 != .error && $0 != .cleanUp && $0 != .leaving }
+    )
+    private lazy var subject: WebRTCCoordinator.StateMachine.Stage! = .blocked(.init())
+    private lazy var mockCoordinatorStack: MockWebRTCCoordinatorStack! = .init(
+        videoConfig: Self.videoConfig
+    )
+
+    // MARK: - Lifecycle
+
+    override class func tearDown() {
+        Self.videoConfig = nil
+        super.tearDown()
+    }
+
+    override func tearDown() {
+        allOtherStages = nil
+        validStages = nil
+        subject = nil
+        mockCoordinatorStack = nil
+        super.tearDown()
+    }
+
+    // MARK: - init
+
+    func test_init() {
+        XCTAssertEqual(subject.id, .blocked)
+    }
+
+    // MARK: - transition
+
+    func test_transition() {
+        for nextStage in allOtherStages {
+            if validStages.contains(nextStage.id) {
+                XCTAssertNotNil(subject.transition(from: nextStage))
+            } else {
+                XCTAssertNil(subject.transition(from: nextStage))
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func assertTransition(
+        from: WebRTCCoordinator.StateMachine.Stage.ID,
+        expectedTarget: WebRTCCoordinator.StateMachine.Stage.ID,
+        subject: WebRTCCoordinator.StateMachine.Stage,
+        validator: @escaping @Sendable(WebRTCCoordinator.StateMachine.Stage) async throws -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws {
+        let transitionExpectation =
+            expectation(description: "Stage id:\(subject.id) is expected to transition to id:\(expectedTarget).")
+        subject.transition = { [validator] target in
+            guard target.id == expectedTarget else {
+                transitionExpectation
+                    .expectationDescription =
+                    "Stage id:\(subject.id) is expected to transition to id:\(expectedTarget) but landed on id:\(target.id)"
+                return
+            }
+            Task {
+                do {
+                    try await validator(target)
+                    transitionExpectation.fulfill()
+                } catch {
+                    XCTFail(file: file, line: line)
+                }
+            }
+        }
+        _ = subject.transition(from: .init(id: from, context: subject.context))
+
+        await fulfillment(of: [transitionExpectation], timeout: defaultTimeout)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-740/[video]handle-blocked-user-correctly

### 📝 Summary

By default, blocked users are being kicked out from the call (by the backend). If a user somehow manage to find themselves in the call again, we add an additional check that is based on the blockIds from the joinResponse. If the user id is in there, we are making them leave the call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)