### PR TITLE
Fix/back camera appears flipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix an issue that was stopping NoiseCancellation from being activated [#705](https://github.com/GetStream/stream-video-swift/pull/705)
 - Fix an issue where SetPublisher request was firing when nothing was published [#706](https://github.com/GetStream/stream-video-swift/pull/706)
+- The VideoRendererView for the localParticipant, will flip **only** the front camera feed, not the back one [#708](https://github.com/GetStream/stream-video-swift/pull/708)
 
 # [1.18.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.18.0)
 _March 06, 2025_

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -389,9 +389,14 @@ public struct VideoCallParticipantView<Factory: ViewFactory>: View {
         @ViewBuilder _ content: () -> some View
     ) -> some View {
         if participant.id == streamVideo.state.activeCall?.state.localParticipant?.id {
-            content()
-                .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
-                .onReceive(call?.state.$callSettings) { self.isUsingFrontCameraForLocalUser = $0.cameraPosition == .front }
+            Group {
+                if isUsingFrontCameraForLocalUser {
+                    content()
+                        .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
+                } else {
+                    content()
+                }
+            }.onReceive(call?.state.$callSettings) { self.isUsingFrontCameraForLocalUser = $0.cameraPosition == .front }
         } else {
             content()
         }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-739/[video]back-camera-appears-flipped

### 📝 Summary

Only flip the front camera feed and avoid flipping the back camera feed.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)