### PR TITLE
[Enhancement]Debounce SetPublisher requests

### DIFF
--- a/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
@@ -307,7 +307,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         XCTAssertEqual(mockPeerConnection?.timesCalled(.setRemoteDescription), 0)
     }
 
-    func test_negotiate_subjectIsPublisher_multipleRequestsExecuteSerially_callSetPublisherOnSFUWithCorrectOfferEveryTime(
+    func test_negotiate_subjectIsPublisher_multipleRequestsExecuteSerially_callSetPublisherOnSFUWithCorrectOfferOnlyOnce(
     ) async throws {
         _ = subject
         let offerA = RTCSessionDescription(
@@ -341,7 +341,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         }
 
         await fulfillment { [mockPeerConnection] in
-            mockPeerConnection?.timesCalled(.setLocalDescription) == 2
+            mockPeerConnection?.timesCalled(.setLocalDescription) == 1
         }
 
         XCTAssertEqual(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-742/[video]debounce-setpublisher-requests

### 🎯 Goal

By debouncing the SetPublisher requests to reduce the load on the backend.

### 🛠 Implementation

I tried setting the debounce interval to the screen refresh rate but it wasn't sufficient. Setting the interval to 250 milliseconds it allows us to join a call with audio and video enabled and only fire a single SetPublisher request

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
