### PR TITLE
[Fix]Make StateMachine invalid transitions warnings rather than errors

### DIFF
--- a/DemoApp/Sources/Components/MemoryLogDestination/MemoryLogViewer.swift
+++ b/DemoApp/Sources/Components/MemoryLogDestination/MemoryLogViewer.swift
@@ -11,6 +11,8 @@ struct MemoryLogViewer: View {
     @Injected(\.appearance) var appearance
     
     @State private var logs = LogQueue.queue.elements
+    @State private var isSharePresented = false
+    @State private var logFileURL: URL?
 
     var body: some View {
         List {
@@ -23,6 +25,11 @@ struct MemoryLogViewer: View {
             }
         }
         .navigationTitle("Logs Viewer")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                shareButtonView
+            }
+        }
         .modifier(
             SearchableModifier { query in
                 if query.isEmpty {
@@ -34,8 +41,76 @@ struct MemoryLogViewer: View {
                 }
             }
         )
+        .sheet(isPresented: $isSharePresented) {
+            if let logFileURL = logFileURL {
+                ShareActivityView(activityItems: [logFileURL])
+            }
+        }
+        .onDisappear {
+            deleteTemporaryLogFile()
+        }
+        .onChange(of: isSharePresented) { isPresented in
+            if !isPresented {
+                // Delete the file after sharing is complete
+                deleteTemporaryLogFile()
+            }
+        }
+    }
+
+    @ViewBuilder
+    var shareButtonView: some View {
+        Button {
+            createAndShareLogFile()
+        } label: {
+            Image(systemName: "square.and.arrow.up.fill")
+        }
     }
     
+    private func createAndShareLogFile() {
+        Task {
+            // Delete any existing temporary file first
+            deleteTemporaryLogFile()
+
+            // Create a temporary file URL
+            let temporaryDirectoryURL = FileManager.default.temporaryDirectory
+            let fileName = "stream_video_logs_\(Date().timeIntervalSince1970).txt"
+            let fileURL = temporaryDirectoryURL.appendingPathComponent(fileName)
+
+            // Create log content
+
+            // Add all logs to the content
+            let logs = LogQueue.queue.elements
+            let logContent = """
+            Stream Video Logs - Generated: \(Date())
+            \(logs.reversed().map { "\($0.level) - [\($0.fileName):\($0.lineNumber):\($0.functionName)] \($0.message)" }
+                .joined(separator: "\n"))
+            """
+
+            // Write to file
+            do {
+                try logContent.write(to: fileURL, atomically: true, encoding: .utf8)
+                self.logFileURL = fileURL
+                Task { @MainActor in
+                    self.isSharePresented = true
+                }
+            } catch {
+                print("Error creating log file: \(error)")
+            }
+        }
+    }
+    
+    private func deleteTemporaryLogFile() {
+        if let fileURL = logFileURL {
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+                logFileURL = nil
+                print("Temporary log file deleted successfully")
+            } catch {
+                print("Error deleting temporary log file: \(error)")
+            }
+        }
+    }
+
     @ViewBuilder
     func makeEntryView(for entry: LogDetails) -> some View {
         let (iconName, iconColor): (String, Color) = {

--- a/DemoApp/Sources/Views/CallTopView/DemoCallTopView.swift
+++ b/DemoApp/Sources/Views/CallTopView/DemoCallTopView.swift
@@ -29,6 +29,9 @@ struct DemoCallTopView: View {
                 }
 
                 ToggleCameraIconView(viewModel: viewModel)
+                if AppEnvironment.configuration == .debug {
+                    LogsViewerButtonView()
+                }
 
                 Spacer()
             }
@@ -176,5 +179,25 @@ private struct ShadowModifier: ViewModifier {
         content
             .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 12)
             .shadow(color: Color.black.opacity(0.1), radius: 1, x: 0, y: 1)
+    }
+}
+
+private struct LogsViewerButtonView: View {
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            CallIconView(
+                icon: Image(systemName: "ladybug.fill"),
+                size: 44,
+                iconStyle: .secondary
+            )
+        }.sheet(isPresented: $isPresented) {
+            NavigationView {
+                MemoryLogViewer()
+            }
+        }
     }
 }

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -138,7 +138,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
             let stage = currentStage as! StreamCallStateMachine.Stage.JoinedStage
             return stage.response
         default:
-            try stateMachine.transition(
+            stateMachine.transition(
                 .joining(
                     self,
                     actionBlock: { [weak self] in
@@ -343,7 +343,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
             let stage = currentStage as! StreamCallStateMachine.Stage.AcceptedStage
             return stage.response
         default:
-            try stateMachine.transition(.accepting(self, actionBlock: { [coordinatorClient, callType, callId] in
+            stateMachine.transition(.accepting(self, actionBlock: { [coordinatorClient, callType, callId] in
                 try await coordinatorClient.acceptCall(type: callType, id: callId)
             }))
         }
@@ -371,7 +371,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
             let stage = currentStage as! StreamCallStateMachine.Stage.RejectedStage
             return stage.response
         default:
-            try stateMachine.transition(.rejecting(self, actionBlock: { [coordinatorClient, callType, callId, streamVideo, cId] in
+            stateMachine.transition(.rejecting(self, actionBlock: { [coordinatorClient, callType, callId, streamVideo, cId] in
                 let response = try await coordinatorClient.rejectCall(
                     type: callType,
                     id: callId,
@@ -522,7 +522,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         eventHandlers.removeAll()
         callController.leave()
         closedCaptionsAdapter.stop()
-        try? stateMachine.transition(.idle(self))
+        stateMachine.transition(.idle(self))
         /// Upon `Call.leave` we remove the call from the cache. Any further actions that are required
         /// to happen on the call object (e.g. rejoin) will need to fetch a new instance from `StreamVideo`
         /// client.
@@ -1394,14 +1394,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
 
     @MainActor
     internal func transitionDueToError(_ error: Error) {
-        do {
-            if stateMachine.currentStage.id == .joined {
-                state.disconnectionError = error
-            }
-            try stateMachine.transition(.error(self, error: error))
-        } catch {
-            log.error(error)
+        if stateMachine.currentStage.id == .joined {
+            state.disconnectionError = error
         }
+        stateMachine.transition(.error(self, error: error))
     }
 
     // MARK: - private

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -646,18 +646,10 @@ class CallController: @unchecked Sendable {
                 .log(.debug, subsystems: .webRTC) { _ in "Current user was blocked. Will leave the call now." }
                 .sinkTask { [weak self] _ in
                     guard let self else { return }
-                    do {
-                        try self
-                            .webRTCCoordinator
-                            .stateMachine
-                            .transition(.blocked(self.webRTCCoordinator.stateMachine.currentStage.context))
-                    } catch {
-                        log.error(
-                            "Unable to handle event that blocked current user.",
-                            subsystems: .webRTC,
-                            error: error
-                        )
-                    }
+                    self
+                        .webRTCCoordinator
+                        .stateMachine
+                        .transition(.blocked(self.webRTCCoordinator.stateMachine.currentStage.context))
                 }
                 .store(in: disposableBag, key: "current-user-blocked")
         }

--- a/Sources/StreamVideo/Utils/StateMachine/CallStateMachine/StreamCallStateMachine.swift
+++ b/Sources/StreamVideo/Utils/StateMachine/CallStateMachine/StreamCallStateMachine.swift
@@ -27,8 +27,8 @@ final class StreamCallStateMachine {
     ///
     /// - Parameter nextStage: The next stage to transition to.
     /// - Throws: An error if the transition is invalid.
-    func transition(_ nextStage: Stage) throws {
-        try stateMachine.transition(to: nextStage)
+    func transition(_ nextStage: Stage) {
+        stateMachine.transition(to: nextStage)
     }
 
     /// Waits for the next stage of the specified type after optionally skipping initial stages.

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
@@ -91,7 +91,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
             case .rejoining:
                 if ring || notify || options != nil {
                     log.assert(ring == false, "Ring cannot be true when rejoining.")
-                    log.assert(notify == false, "Notfiy cannot be true when rejoining.")
+                    log.assert(notify == false, "Notify cannot be true when rejoining.")
                     log.assert(options == nil, "CreateCallOptions cannot be non-nil when rejoining.")
                 }
                 execute(

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
@@ -86,13 +86,13 @@ extension WebRTCCoordinator.StateMachine.Stage {
             case .disconnected:
                 execute()
                 return self
-            case .fastReconnecting:
+            case .fastReconnecting, .fastReconnected:
                 execute()
                 return self
             case .rejoining:
                 execute()
                 return self
-            case .migrated:
+            case .migrated, .migrating:
                 execute()
                 return self
             default:

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/WebRTCCoordinator+StateMachine.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/WebRTCCoordinator+StateMachine.swift
@@ -27,8 +27,8 @@ extension WebRTCCoordinator {
         ///
         /// - Parameter nextStage: The next stage to transition to.
         /// - Throws: An error if the transition is invalid.
-        func transition(_ nextStage: Stage) throws {
-            try stateMachine.transition(to: nextStage)
+        func transition(_ nextStage: Stage) {
+            stateMachine.transition(to: nextStage)
         }
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -98,7 +98,7 @@ final class WebRTCCoordinator: @unchecked Sendable {
         notify: Bool
     ) async throws {
         await stateAdapter.set(initialCallSettings: callSettings)
-        try stateMachine.transition(
+        stateMachine.transition(
             .connecting(
                 stateMachine.currentStage.context,
                 create: create,
@@ -116,13 +116,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
 
     /// Leaves the call and transitions the state machine to the `leaving` stage.
     func leave() {
-        do {
-            try stateMachine.transition(
-                .leaving(stateMachine.currentStage.context)
-            )
-        } catch {
-            log.error(error, subsystems: .webRTC)
-        }
+        stateMachine.transition(
+            .leaving(stateMachine.currentStage.context)
+        )
     }
 
     // MARK: - Media
@@ -458,13 +454,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
                     disconnectedSince: .init(),
                     deadline: stateMachine.currentStage.context.fastReconnectDeadlineSeconds
                 )
-                do {
-                    try stateMachine.transition(
-                        .disconnected(stateMachine.currentStage.context)
-                    )
-                } catch {
-                    log.error(error, subsystems: .webRTC)
-                }
+                stateMachine.transition(
+                    .disconnected(stateMachine.currentStage.context)
+                )
             }
             .store(in: disposableBag)
 
@@ -474,13 +466,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
             .sink { [weak self] _ in
                 guard let self else { return }
                 stateMachine.currentStage.context.reconnectionStrategy = .rejoin
-                do {
-                    try stateMachine.transition(
-                        .disconnected(stateMachine.currentStage.context)
-                    )
-                } catch {
-                    log.error(error, subsystems: .webRTC)
-                }
+                stateMachine.transition(
+                    .disconnected(stateMachine.currentStage.context)
+                )
             }
             .store(in: disposableBag)
 
@@ -490,13 +478,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
             .sink { [weak self] _ in
                 guard let self else { return }
                 stateMachine.currentStage.context.reconnectionStrategy = .migrate
-                do {
-                    try stateMachine.transition(
-                        .disconnected(stateMachine.currentStage.context)
-                    )
-                } catch {
-                    log.error(error, subsystems: .webRTC)
-                }
+                stateMachine.transition(
+                    .disconnected(stateMachine.currentStage.context)
+                )
             }
             .store(in: disposableBag)
     }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -38,11 +38,11 @@
 		401338782BF248B9007318BD /* MockStreamVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338772BF248B9007318BD /* MockStreamVideo.swift */; };
 		4013387A2BF248CC007318BD /* MockCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338792BF248CC007318BD /* MockCall.swift */; };
 		4013387C2BF248E9007318BD /* Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013387B2BF248E9007318BD /* Mockable.swift */; };
+		4013A8ED2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8EC2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift */; };
+		4013A8EF2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8EE2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift */; };
 		4013A8F32D82D99D00F81C15 /* StreamPictureInPictureAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8F02D82D93900F81C15 /* StreamPictureInPictureAdapterTests.swift */; };
 		4013A8F42D82DA8500F81C15 /* MockCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338792BF248CC007318BD /* MockCall.swift */; };
 		4013A8F52D82DAB300F81C15 /* MockStreamVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401338772BF248B9007318BD /* MockStreamVideo.swift */; };
-		4013A8ED2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8EC2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift */; };
-		4013A8EF2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4013A8EE2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift */; };
 		401480302A5317640029166A /* AudioValuePercentageNormaliser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014802F2A5317640029166A /* AudioValuePercentageNormaliser.swift */; };
 		401480342A5423D60029166A /* AudioValuePercentageNormaliser_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */; };
 		401480362A5447C50029166A /* LocalParticipantViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401480352A5447C50029166A /* LocalParticipantViewModifier.swift */; };
@@ -1578,9 +1578,9 @@
 		401338772BF248B9007318BD /* MockStreamVideo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStreamVideo.swift; sourceTree = "<group>"; };
 		401338792BF248CC007318BD /* MockCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCall.swift; sourceTree = "<group>"; };
 		4013387B2BF248E9007318BD /* Mockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mockable.swift; sourceTree = "<group>"; };
-		4013A8F02D82D93900F81C15 /* StreamPictureInPictureAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureAdapterTests.swift; sourceTree = "<group>"; };
 		4013A8EC2D81E43E00F81C15 /* WebRTCCoordinator+Blocked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebRTCCoordinator+Blocked.swift"; sourceTree = "<group>"; };
 		4013A8EE2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCCoordinatorStateMachine_BlockedStageTests.swift; sourceTree = "<group>"; };
+		4013A8F02D82D93900F81C15 /* StreamPictureInPictureAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPictureInPictureAdapterTests.swift; sourceTree = "<group>"; };
 		4014802F2A5317640029166A /* AudioValuePercentageNormaliser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioValuePercentageNormaliser.swift; sourceTree = "<group>"; };
 		401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioValuePercentageNormaliser_Tests.swift; sourceTree = "<group>"; };
 		401480352A5447C50029166A /* LocalParticipantViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalParticipantViewModifier.swift; sourceTree = "<group>"; };

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -519,7 +519,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         let call = streamVideo.call(callType: .default, callId: .unique)
         subject.call = call
         await wait(for: 1)
-        try mockWebRTCCoordinatorFactory
+        mockWebRTCCoordinatorFactory
             .mockCoordinatorStack
             .coordinator
             .stateMachine

--- a/StreamVideoTests/Utils/StateMachine/CallStateMachine/StreamCallStateMachine_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/CallStateMachine/StreamCallStateMachine_Tests.swift
@@ -32,7 +32,7 @@ final class StreamCallStateMachineTests: StreamVideoTestCase, @unchecked Sendabl
         XCTAssertEqual(subject.currentStage.id, .idle)
 
         // When
-        XCTAssertNoThrow(try subject.transition(nextState), "Transition should not throw")
+        XCTAssertNoThrow(subject.transition(nextState), "Transition should not throw")
 
         // Then
         XCTAssertEqual(subject.currentStage.call?.callId, mockCall.callId, "Current stage call ID should match mock call ID")
@@ -47,7 +47,7 @@ final class StreamCallStateMachineTests: StreamVideoTestCase, @unchecked Sendabl
         )
 
         // When
-        XCTAssertThrowsError(try subject.transition(nextState), "Transition should throw")
+        XCTAssertNoThrow(subject.transition(nextState), "Transition should not throw")
 
         // Then
         XCTAssertEqual(subject.currentStage.call?.callId, mockCall.callId, "Current stage call ID should match mock call ID")
@@ -61,7 +61,7 @@ final class StreamCallStateMachineTests: StreamVideoTestCase, @unchecked Sendabl
         let response = AcceptCallResponse(duration: "123")
 
         // When
-        try subject.transition(.accepting(mockCall, actionBlock: {
+        subject.transition(.accepting(mockCall, actionBlock: {
             try await Task.sleep(nanoseconds: 500_000_000)
             return response
         }))

--- a/StreamVideoTests/Utils/StateMachine/StreamStateMachine_Tests.swift
+++ b/StreamVideoTests/Utils/StateMachine/StreamStateMachine_Tests.swift
@@ -35,7 +35,7 @@ final class StreamStateMachineTests: XCTestCase, @unchecked Sendable {
         let stateMachine = StreamStateMachine(initialStage: initialState)
 
         // When
-        XCTAssertNoThrow(try stateMachine.transition(to: nextState), "Transition should not throw")
+        XCTAssertNoThrow(stateMachine.transition(to: nextState), "Transition should not throw")
 
         // Then
         XCTAssertEqual(stateMachine.currentStage.id, nextState.id, "Current state should match next state")
@@ -47,10 +47,11 @@ final class StreamStateMachineTests: XCTestCase, @unchecked Sendable {
         let nextState = MockStage(id: "Next", description: "Next State", allowedTransitions: [])
         let stateMachine = StreamStateMachine(initialStage: initialState)
 
-        // When, Then
-        XCTAssertThrowsError(try stateMachine.transition(to: nextState), "Transition should throw") { error in
-            XCTAssertTrue(error is ClientError.InvalidStateMachineTransition, "Error should be of type ClientError")
-        }
+        // When
+        XCTAssertNoThrow(stateMachine.transition(to: nextState), "Transition should not throw")
+
+        // Then
+        XCTAssertEqual(stateMachine.currentStage.id, initialState.id)
     }
 
     // MARK: - Mocks

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift
@@ -22,8 +22,10 @@ final class WebRTCCoordinatorStateMachine_DisconnectedStageTests: XCTestCase, @u
         .joined,
         .disconnected,
         .fastReconnecting,
+        .fastReconnected,
         .rejoining,
-        .migrated
+        .migrated,
+        .migrating
     ]
     private lazy var subject: WebRTCCoordinator.StateMachine.Stage! = .disconnected(.init())
     private lazy var mockCoordinatorStack: MockWebRTCCoordinatorStack! = .init(

--- a/StreamVideoTests/WebRTC/v2/StateMachine/WebRTCCoordinator_StateMachineTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/WebRTCCoordinator_StateMachineTests.swift
@@ -34,7 +34,7 @@ final class WebRTCCoordinator_StateMachineTests: XCTestCase, @unchecked Sendable
         XCTAssertEqual(subject.currentStage.id, .idle)
 
         // When
-        XCTAssertNoThrow(try subject.transition(nextState), "Transition should not throw")
+        XCTAssertNoThrow(subject.transition(nextState), "Transition should not throw")
 
         // Then
         XCTAssertEqual(subject.currentStage.id, .connecting)
@@ -46,7 +46,7 @@ final class WebRTCCoordinator_StateMachineTests: XCTestCase, @unchecked Sendable
         XCTAssertEqual(subject.currentStage.id, .idle)
 
         // When
-        XCTAssertThrowsError(try subject.transition(nextState), "Transition should throw")
+        XCTAssertNoThrow(subject.transition(nextState), "Transition should throw")
 
         // Then
         XCTAssertEqual(subject.currentStage.id, .idle)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves 
- https://linear.app/stream/issue/IOS-741/[investigate]video-not-recovering-when-using-link-conditioner
- https://linear.app/stream/issue/IOS-738/[video]investigate-reconnection-on-ios

### 📝 Summary

Relax StateMachine transitions, so that on invalid transitions rather than erroring we just print a warning. We still do not fulfil the invalid transition!

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)