### PR TITLE
[CI] Remove all the SwiftUICore module shadows in xcframeworks

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -376,7 +376,7 @@ private_lane :remove_swiftui_core_module_shadow do |options|
   Dir.glob("#{options[:output_directory]}/**/*.swiftinterface").each do |file|
     if File.file?(file)
       UI.important("Removing the SwiftUICore module's shadow at: #{file}...")
-      File.write(file, File.read(file).gsub(/SwiftUICore.View/, 'View'))
+      File.write(file, File.read(file).gsub('SwiftUICore.', ''))
     end
   end
 end


### PR DESCRIPTION
It used to remove all the `SwiftUICore.View` entries, but it turned out there are also `SwiftUICore.EmptyView`, `SwiftUICore.Font`, etc...