### PR TITLE
[Fix]Avoid showing the current user twice during a migration/reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- During a reconnection/migration the current user will not be appearing twice any more. [#731](https://github.com/GetStream/stream-video-swift/pull/731)
 
 # [1.19.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.19.1)
 _March 25, 2025_

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -351,6 +351,9 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 .callState
                 .participants
                 .map { $0.toCallParticipant() }
+                /// We remove the existing user (if we are rejoiinig) in order to avoid showing a stale
+                /// video tile in the Call.
+                .filter { $0.sessionId != context.isRejoiningFromSessionID }
                 .reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
 
             await coordinator

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -323,6 +323,9 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
     func cleanUpForReconnection() async {
         set(
             participants: participants
+                /// We remove the existing user in order to avoid showing a stale video tile
+                /// in the Call.
+                .filter { $0.key != sessionID }
                 .reduce(into: ParticipantsStorage()) { $0[$1.key] = $1.value.withUpdated(track: nil) }
         )
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -475,7 +475,11 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         let ownCapabilities = Set([OwnCapability.blockUsers])
         let pins = [PinInfo(isLocal: true, pinnedAt: .init())]
         let userId = String.unique
-        let participants = [userId: CallParticipant.dummy(id: userId)]
+        let currentParticipant = await CallParticipant.dummy(id: subject.sessionID)
+        let participants = [
+            userId: CallParticipant.dummy(id: userId),
+            currentParticipant.sessionId: currentParticipant
+        ]
         try await prepare(
             sfuStack: sfuStack,
             ownCapabilities: ownCapabilities,


### PR DESCRIPTION
### 📝 Summary

When a migration or reconnection is in progress, then the local participant appears twice in the call screen (two video tiles) until we receive the finalised update from the SFU. With this change we filter out any participant that matches the sessionId of the session from which we rejoin or migrate from.

### 🧪 Manual Testing Notes

- Join a call with someone else
- Open the More Menu > Reconnect > Rejoin/Migrate
- During the process the current user shouldn't appear more than once in the Participants View

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)