### PR TITLE
[Fix]Avoid current user showing up as duplicated during reconnection and migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 _March 27, 2025_
 
 ### 🐞 Fixed
-- SPM dependency for SwiftProtobuf was outdated and sometimes Xcode couldn't fetch the latest required version. [#730](https://github.com/GetStream/stream-video-swift/pull/730)
+- During a reconnection/migration the current user will not be appearing twice any more. [#731](https://github.com/GetStream/stream-video-swift/pull/731)
 
 # [1.19.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.19.1)
 _March 25, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- During a reconnection/migration the current user will not be appearing twice any more. [#731](https://github.com/GetStream/stream-video-swift/pull/731)
 
 # [1.19.2](https://github.com/GetStream/stream-video-swift/releases/tag/1.19.2)
 _March 27, 2025_
 
 ### 🐞 Fixed
-- During a reconnection/migration the current user will not be appearing twice any more. [#731](https://github.com/GetStream/stream-video-swift/pull/731)
+- SPM dependency for SwiftProtobuf was outdated and sometimes Xcode couldn't fetch the latest required version. [#730](https://github.com/GetStream/stream-video-swift/pull/730)
 
 # [1.19.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.19.1)
 _March 25, 2025_

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -351,7 +351,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 .callState
                 .participants
                 .map { $0.toCallParticipant() }
-                /// We remove the existing user (if we are rejoiinig) in order to avoid showing a stale
+                /// We remove the existing user (if we are rejoining) in order to avoid showing a stale
                 /// video tile in the Call.
                 .filter { $0.sessionId != context.isRejoiningFromSessionID }
                 .reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -351,6 +351,9 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 .callState
                 .participants
                 .map { $0.toCallParticipant() }
+                /// We remove the existing user (if we are rejoiinig) in order to avoid showing a stale
+                /// video tile in the Call.
+                .filter { $0.sessionId != context.isRejoiningFromSessionID }
                 .reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
 
             await coordinator

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -323,6 +323,9 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
     func cleanUpForReconnection() async {
         set(
             participants: participants
+                /// We remove the existing user in order to avoid showing a stale video tile
+                /// in the Call.
+                .filter { $0.key != sessionID }
                 .reduce(into: ParticipantsStorage()) { $0[$1.key] = $1.value.withUpdated(track: nil) }
         )
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -475,7 +475,11 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         let ownCapabilities = Set([OwnCapability.blockUsers])
         let pins = [PinInfo(isLocal: true, pinnedAt: .init())]
         let userId = String.unique
-        let participants = [userId: CallParticipant.dummy(id: userId)]
+        let currentParticipant = await CallParticipant.dummy(id: subject.sessionID)
+        let participants = [
+            userId: CallParticipant.dummy(id: userId),
+            currentParticipant.sessionId: currentParticipant
+        ]
         try await prepare(
             sfuStack: sfuStack,
             ownCapabilities: ownCapabilities,


### PR DESCRIPTION
Duplicate of https://github.com/GetStream/stream-video-swift/pull/731
