### PR TITLE
[Fix]Bind transcription and noise cancelling to session

### DIFF
--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1501,10 +1501,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     private func subscribeToNoiseCancellationSettingsChanges() {
         executeOnMain { [weak self] in
             guard let self else { return }
-            self
-                .state
-                .$settings
-                .map(\.?.audio.noiseCancellation)
+            Publishers
+                .CombineLatest(self.state.$session, self.state.$settings)
+                .filter { $0.0 != nil }
+                .map { $0.1?.audio.noiseCancellation }
                 .removeDuplicates()
                 .sink { [weak self] in self?.didUpdate($0) }
                 .store(in: cancellables)
@@ -1514,10 +1514,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     private func subscribeToTranscriptionSettingsChanges() {
         executeOnMain { [weak self] in
             guard let self else { return }
-            self
-                .state
-                .$settings
-                .map(\.?.transcription)
+            Publishers
+                .CombineLatest(self.state.$session, self.state.$settings)
+                .filter { $0.0 != nil }
+                .map { $0.1?.transcription }
                 .removeDuplicates()
                 .sink { [weak self] in self?.didUpdate($0) }
                 .store(in: cancellables)
@@ -1527,10 +1527,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     private func subscribeToClosedCaptionsSettingsChanges() {
         executeOnMain { [weak self] in
             guard let self else { return }
-            self
-                .state
-                .$settings
-                .map(\.?.transcription.closedCaptionMode)
+            Publishers
+                .CombineLatest(self.state.$session, self.state.$settings)
+                .filter { $0.0 != nil }
+                .map { $0.1?.transcription.closedCaptionMode }
                 .removeDuplicates()
                 .sink { [weak self] in self?.didUpdate($0) }
                 .store(in: cancellables)


### PR DESCRIPTION
### 📝 Summary

This revision fixes the errors showing when in a user enters the lobby and we try to activate transcriptions, closed captions and noise-cancellation. Those operations are failing because there is no active-call-session yet. We now tie those operations to the session, once there is an active-call-session we trigger them.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)