### PR TITLE
[Fix]E2E main thread access issue

### DIFF
--- a/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot+Asserts.swift
@@ -28,12 +28,12 @@ extension UserRobot {
     
     @discardableResult
     func assertUserMicrophoneIsEnabled() -> Self {
-        assertToogle(CallPage.microphoneToggle.firstMatch, state: .enable)
+        assertToogle(CallPage.microphoneToggle, state: .enable)
     }
     
     @discardableResult
     func assertUserMicrophoneIsDisabled() -> Self {
-        assertToogle(CallPage.microphoneToggle.firstMatch, state: .disable)
+        assertToogle(CallPage.microphoneToggle, state: .disable)
     }
     
     @discardableResult

--- a/SwiftUIDemoAppUITests/Robots/UserRobot.swift
+++ b/SwiftUIDemoAppUITests/Robots/UserRobot.swift
@@ -152,7 +152,7 @@ extension UserRobot {
     
     @discardableResult
     func microphone(_ action: UserControls) -> Self {
-        userControls(toggle: CallPage.microphoneToggle.firstMatch, action: action)
+        userControls(toggle: CallPage.microphoneToggle, action: action)
     }
     
     @discardableResult
@@ -256,9 +256,15 @@ extension UserRobot {
     
     @discardableResult
     private func userControls(toggle: XCUIElement, action: UserControls) -> Self {
-        if action == .disable && toggle.isOn || action == .enable && toggle.isOff {
+        switch (action, toggle.isOn) {
+        case (.disable, true):
             toggle.tap()
+        case (.enable, false):
+            toggle.tap()
+        default:
+            break
         }
+
         return self
     }
 

--- a/SwiftUIDemoAppUITests/Tests/CallViewsTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/CallViewsTests.swift
@@ -3,6 +3,7 @@
 //
 
 import XCTest
+import StreamVideo
 
 final class CallViewsTests: StreamTestCase {
     
@@ -22,6 +23,7 @@ final class CallViewsTests: StreamTestCase {
     }
     
     func testOneParticipantOnTheCall() throws {
+        LogConfig.level = .debug
         linkToScenario(withId: 1766)
         
         try XCTSkipIf(TestRunnerEnvironment.isCI, "https://github.com/GetStream/ios-issues-tracking/issues/688")
@@ -281,23 +283,21 @@ final class CallViewsTests: StreamTestCase {
     func testMicrophoneIcon() throws {
         linkToScenario(withId: 1777)
         
-        throw XCTSkip("DemoApp/Gleap related issue. Fix is coming soon.")
-        
         GIVEN("user starts a call") {
             userRobot
                 .waitForAutoLogin()
                 .startCall(callId)
         }
-        WHEN("user unmutes themselves") {
+        WHEN("user unmutes themselves - or if already enabled do nothing") {
             userRobot.microphone(.enable)
         }
-        THEN("mic icon updates") {
+        THEN("mic icon updates - should be enabled") {
             userRobot.assertUserMicrophoneIsEnabled()
         }
         WHEN("user mutes themselves") {
             userRobot.microphone(.disable)
         }
-        THEN("mic icon updates") {
+        THEN("mic icon updates - should be disabled") {
             userRobot.assertUserMicrophoneIsDisabled()
         }
     }


### PR DESCRIPTION
Resolves https://linear.app/stream/issue/IOS-766/disable-gleap-for-e2e-tests

### 📝 Summary

This revision fixes an issue that was affecting E2E tests. The usage of `firstMatch` was causing non-ending loops of looking for the element and couldn't find it while it was there.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)