### PR TITLE
[Fix]Switch participants in PiP

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureController.swift
@@ -18,6 +18,14 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
 
     // MARK: - Properties
 
+    var preferredContentSize: CGSize = .init(width: 640, height: 480) {
+        didSet {
+            Task { @MainActor in
+                contentViewController?.preferredContentSize = preferredContentSize
+            }
+        }
+    }
+
     /// The RTCVideoTrack for which the picture-in-picture session is created.
     @MainActor
     var track: RTCVideoTrack? {


### PR DESCRIPTION
### 📝 Summary

This revision is part of the bigger effort of improving Picture-In-Picture. Here, we update the logic of updating the participant in PiP and enhancing it so it include more users.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)