### PR TITLE
[Fix]CallSettings not respected when `create=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CallKit should only handle the CallAccepted events that match the userId of the current user. [#733](https://github.com/GetStream/stream-video-swift/pull/733)
 - During a reconnection/migration the current user will not be appearing twice any more. [#731](https://github.com/GetStream/stream-video-swift/pull/731)
 - ParticipantsCount and AnonymousParticipantsCount weren't updating correctly. [#736](https://github.com/GetStream/stream-video-swift/pull/736)
+- CallSettings weren't set correctly (either when you were passing manually or from dashboard) when a call was joined without setting the create flag to `true`. [#745](https://github.com/GetStream/stream-video-swift/pull/745)
 
 # [1.19.2](https://github.com/GetStream/stream-video-swift/releases/tag/1.19.2)
 _March 27, 2025_

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCAuthenticator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCAuthenticator.swift
@@ -74,17 +74,16 @@ struct WebRTCAuthenticator: WebRTCAuthenticating {
             )
         )
 
-        if create {
-            if let callSettings = await coordinator.stateAdapter.initialCallSettings {
-                await coordinator.stateAdapter.set(
-                    callSettings: callSettings
-                )
-            } else {
-                await coordinator.stateAdapter.set(
-                    callSettings: response.call.settings.toCallSettings
-                )
-            }
+        if let callSettings = await coordinator.stateAdapter.initialCallSettings {
+            await coordinator.stateAdapter.set(
+                callSettings: callSettings
+            )
+        } else {
+            await coordinator.stateAdapter.set(
+                callSettings: response.call.settings.toCallSettings
+            )
         }
+
         await coordinator.stateAdapter.set(
             videoOptions: .init(preferredCameraPosition: {
                 switch response.call.settings.video.cameraFacing {

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCAuthenticator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCAuthenticator.swift
@@ -74,6 +74,7 @@ struct WebRTCAuthenticator: WebRTCAuthenticating {
             )
         )
 
+        /// Always apply either the provided callSettings or the ones from the dashboard.
         if let callSettings = await coordinator.stateAdapter.initialCallSettings {
             await coordinator.stateAdapter.set(
                 callSettings: callSettings


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-778/livestream-viewer-attempts-to-publish-audio-when-not-capability-exist

### 📝 Summary

This revision fixes an issue that only applying CallSettings (either the provided ones or from the dashboard) when the call was created and joined. The issue was discovered when testing with Livestream viewers who are only joining the call (not creating it).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)