### PR TITLE
[Enhancement]Allow resetting local call settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- `CallSettings` won't be propagated between calls when using the `CallViewModel`. [#751](https://github.com/GetStream/stream-video-swift/pull/751)
 
 # [1.20.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.20.0)
 _April 07, 2025_

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -74,6 +74,9 @@ open class CallViewModel: ObservableObject {
     @Published public var callingState: CallingState = .idle {
         didSet {
             handleRingingEvents()
+            if callingState == .idle {
+                prepareForReuse()
+            }
         }
     }
 
@@ -150,6 +153,8 @@ open class CallViewModel: ObservableObject {
 
     /// A flag controlling whether picture-in-picture should be enabled for the call. Default value is `true`.
     @Published public var isPictureInPictureEnabled = true
+
+    public var persistCallSettingsAcrossCalls: Bool = true
 
     /// Returns the local participant of the call.
     public var localParticipant: CallParticipant? {
@@ -231,6 +236,12 @@ open class CallViewModel: ObservableObject {
     deinit {
         enteringCallTask?.cancel()
         callEventsSubscriptionTask?.cancel()
+    }
+
+    private func prepareForReuse() {
+        if !persistCallSettingsAcrossCalls {
+            localCallSettingsChange = false
+        }
     }
 
     /// Toggles the state of the camera (visible vs non-visible).

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -1204,6 +1204,33 @@ final class CallViewModel_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - leaveCall
+
+    @MainActor
+    func test_leaveCall_resetsCallSettings() async {
+        let subject = CallViewModel()
+
+        subject.toggleMicrophoneEnabled()
+        subject.toggleAudioOutput()
+        await fulfilmentInMainActor {
+            subject.callSettings.audioOn == false
+            && subject.callSettings.audioOutputOn == false
+        }
+        XCTAssertTrue(subject.localCallSettingsChange)
+
+        // When
+        subject.joinCall(callType: callType, callId: callId)
+        await fulfilmentInMainActor { subject.callingState == .inCall }
+
+        subject.hangUp()
+
+        await fulfilmentInMainActor {
+            subject.callSettings.audioOn == true
+            && subject.callSettings.audioOutputOn == true
+        }
+        XCTAssertFalse(subject.localCallSettingsChange)
+    }
+
     // MARK: - Private helpers
 
     private struct ParticipantsScenario {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-783/[blink]reset-callsetting-on-callviewmodel-after-call-is-being-left

### 📝 Summary

This revision removes the `CallSettings` propagation, between calls, when using the `CallViewModel`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)