### PR TITLE
[Fix]CallKit end call wasn't completing successfully

### DIFF
--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -403,26 +403,27 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 callerId:\(stackEntry.createdBy?.id)
                 """
             )
-            do {
-                let rejectionReason = await streamVideo?
-                    .rejectionReasonProvider
-                    .reason(
-                        for: stackEntry.call.cId,
-                        ringTimeout: false
-                    )
-                log.debug(
-                    """
-                    Rejecting with reason: \(rejectionReason ?? "nil")
-                    call:\(stackEntry.call.callId)
-                    callType: \(stackEntry.call.callType)
-                    """
-                )
-                try await stackEntry.call.reject(reason: rejectionReason)
-            } catch {
-                log.error(error)
-            }
             if currentCallWasEnded {
                 stackEntry.call.leave()
+            } else {
+                do {
+                    let rejectionReason = await streamVideo?
+                        .rejectionReasonProvider
+                        .reason(
+                            for: stackEntry.call.cId,
+                            ringTimeout: false
+                        )
+                    log.debug(
+                        """
+                        Rejecting with reason: \(rejectionReason ?? "nil")
+                        call:\(stackEntry.call.callId)
+                        callType: \(stackEntry.call.callType)
+                        """
+                    )
+                    try await stackEntry.call.reject(reason: rejectionReason)
+                } catch {
+                    log.error(error)
+                }
             }
             set(nil, for: actionCallUUID)
         }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-784/[blink]callkit-end-call-doesnt-leave-the-call-when-device-is-locked

### 📝 Summary

When the device is locked and the user accepts a call via CallKit, once they press the end call button the participant isn't removed from the call.

### 🧪 Manual Testing Notes

- Lock the device (the app can be running or not in the background)
- Ring the device from another device
- Answer using CallKit. Do not unlock the device
- Once you have answered the call, end it
- The participant should be removed from the call

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)