### PR TITLE
[Fix]Resource loading when used via SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - `CallSettings` won't be propagated between calls when using the `CallViewModel`. [#751](https://github.com/GetStream/stream-video-swift/pull/751)
 
+### 🐞 Fixed
+- Sound resources weren't loaded correctly when the SDK was linked via SPM. [#757](https://github.com/GetStream/stream-video-swift/pull/757)
+
 # [1.20.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.20.0)
 _April 07, 2025_
 

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -65,7 +65,7 @@ fileprivate func content() {
                     // Here we register for incomingCalls and provide
                     // a logo as we did on the previous example
                     // Provide the ringtone to use when a CallKit call is ringing
-                    callKitAdapter.ringtoneSound = sounds.incomingCallSound
+                    callKitAdapter.ringtoneSound = sounds.incomingCallSound.fileName
                 }
             }
         }

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,10 @@ let package = Package(
         ),
         .target(
             name: "StreamVideoSwiftUI",
-            dependencies: ["StreamVideo"]
+            dependencies: ["StreamVideo"],
+            resources: [
+                .process("Resources")
+            ]
         ),
         .target(
             name: "StreamVideoUIKit",

--- a/Sources/StreamVideoSwiftUI/Resource.swift
+++ b/Sources/StreamVideoSwiftUI/Resource.swift
@@ -1,0 +1,72 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamVideo
+
+/// A structure representing a resource with a name and optional file extension.
+///
+/// `Resource` is used to represent audio, image, or other types of resources in the
+/// StreamVideoUI framework. It supports initialization from string literals in the
+/// format "name.extension".
+///
+/// ## Usage
+///
+/// ```swift
+/// // Initialize with name and extension
+/// let resource = Resource(name: "outgoing", extension: "m4a")
+///
+/// // Initialize from string literal
+/// let resource: Resource = "outgoing.m4a"
+/// ```
+public struct Resource: ExpressibleByStringLiteral {
+    /// The name of the resource without the file extension.
+    public var name: String
+
+    /// The file extension of the resource, if any.
+    public var `extension`: String?
+
+    /// Creates a new resource with the specified name and optional extension.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the resource.
+    ///   - extension: The file extension of the resource.
+    public init(name: String, extension: String? = nil) {
+        self.name = name
+        self.extension = `extension`
+    }
+
+    /// Creates a new resource from a string literal.
+    ///
+    /// The string literal should be in the format "name.extension" where the
+    /// extension is optional.
+    ///
+    /// - Parameter value: The string literal to parse.
+    public init(stringLiteral value: StringLiteralType) {
+        guard !value.hasPrefix(".") else {
+            log.warning("Resource name cannot start with `.`")
+            name = ""
+            return
+        }
+
+        let components = value.split(separator: ".").map { String($0) }
+
+        guard !components.isEmpty else {
+            log.warning("Resource name cannot be empty.")
+            name = ""
+            return
+        }
+
+        switch components.count {
+        case 1:
+            name = components[0]
+        case 2:
+            name = components[0]
+            self.extension = components[1]
+        default:
+            name = components.dropLast().joined(separator: ".")
+            self.extension = components.last
+        }
+    }
+}

--- a/Sources/StreamVideoSwiftUI/Resource.swift
+++ b/Sources/StreamVideoSwiftUI/Resource.swift
@@ -27,6 +27,14 @@ public struct Resource: ExpressibleByStringLiteral {
     /// The file extension of the resource, if any.
     public var `extension`: String?
 
+    public var fileName: String {
+        var components = [name]
+        if let fileExtension = self.extension {
+            components.append(fileExtension)
+        }
+        return components.joined(separator: ".")
+    }
+
     /// Creates a new resource with the specified name and optional extension.
     ///
     /// - Parameters:

--- a/Sources/StreamVideoSwiftUI/Sounds.swift
+++ b/Sources/StreamVideoSwiftUI/Sounds.swift
@@ -7,8 +7,8 @@ import StreamVideo
 
 public class Sounds {
     public var bundle: Bundle = .streamVideoUI
-    public var outgoingCallSound = "outgoing.m4a"
-    public var incomingCallSound = "incoming.wav"
-    
+    public var outgoingCallSound: Resource = "outgoing.m4a"
+    public var incomingCallSound: Resource = "incoming.wav"
+
     public init() { /* Public init. */ }
 }

--- a/Sources/StreamVideoSwiftUI/Utils/CallSoundsPlayer.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/CallSoundsPlayer.swift
@@ -33,9 +33,9 @@ open class CallSoundsPlayer {
     
     // MARK: - private
     
-    private func playSound(_ soundFileName: String) {
+    private func playSound(_ soundFile: Resource) {
         let bundle: Bundle = sounds.bundle
-        guard let soundURL = bundle.url(forResource: soundFileName, withExtension: nil) else {
+        guard let soundURL = bundle.url(forResource: soundFile.name, withExtension: soundFile.extension) else {
             log.warning("There's no sound available")
             return
         }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -207,6 +207,8 @@
 		40429D5F2C779B3D00AC7FFF /* ScreenShareSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40429D5E2C779B3D00AC7FFF /* ScreenShareSession.swift */; };
 		40429D602C779B5A00AC7FFF /* TrackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40BBC4872C623C6E002AEF92 /* TrackType.swift */; };
 		40429D612C779B7000AC7FFF /* SFUSignalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C689192C64F74F0054528A /* SFUSignalService.swift */; };
+		4045D9D52DAD35790077A660 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9D42DAD35790077A660 /* Resource.swift */; };
+		4045D9D72DAD36130077A660 /* ResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9D62DAD36130077A660 /* ResourceTests.swift */; };
 		4046DEE92A9E381F00CA6D2F /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */; };
 		4046DEF02A9F469100CA6D2F /* GDPerformanceView-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 4046DEEF2A9F469100CA6D2F /* GDPerformanceView-Swift */; settings = {ATTRIBUTES = (Required, ); }; };
 		4046DEF22A9F510C00CA6D2F /* DebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */; };
@@ -1698,6 +1700,8 @@
 		403FF3F12BA1DC480092CE8A /* YpCbCrPixelRange+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "YpCbCrPixelRange+Default.swift"; sourceTree = "<group>"; };
 		40429D5C2C779AED00AC7FFF /* WebRTCMigrationStatusObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRTCMigrationStatusObserver.swift; sourceTree = "<group>"; };
 		40429D5E2C779B3D00AC7FFF /* ScreenShareSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenShareSession.swift; sourceTree = "<group>"; };
+		4045D9D42DAD35790077A660 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
+		4045D9D62DAD36130077A660 /* ResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceTests.swift; sourceTree = "<group>"; };
 		4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		4046DEEA2A9E38DC00CA6D2F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenu.swift; sourceTree = "<group>"; };
@@ -2914,6 +2918,7 @@
 		401480332A5423C70029166A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				4045D9D62DAD36130077A660 /* ResourceTests.swift */,
 				40B48C0E2D14B8F6002C4EAB /* StreamAppStateAdapter */,
 				40914C962B567B6B00F6A13E /* PictureInPicture */,
 				401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */,
@@ -6093,6 +6098,7 @@
 				8434C526289AA2F00001490A /* Images.swift */,
 				84E86D4E2905E731004BA44C /* Utils.swift */,
 				8415D3E2290BC882006E53CB /* Sounds.swift */,
+				4045D9D42DAD35790077A660 /* Resource.swift */,
 				8498796728A15F0300D06F31 /* ViewFactory.swift */,
 				8406266C2A37A27D004B8748 /* CallViewModel.swift */,
 				84D419B728E7155100F574F9 /* CallContainer.swift */,
@@ -7791,6 +7797,7 @@
 				403FF3E72BA1D2D40092CE8A /* StreamPixelBufferRepository.swift in Sources */,
 				84DCA2092A382B16000C3411 /* CallModels.swift in Sources */,
 				8442993C294232360037232A /* IncomingCallView_iOS13.swift in Sources */,
+				4045D9D52DAD35790077A660 /* Resource.swift in Sources */,
 				84E86D4F2905E731004BA44C /* Utils.swift in Sources */,
 				84D419B828E7155100F574F9 /* CallContainer.swift in Sources */,
 				40073B8A2C458259006A2867 /* LocalVideoView.swift in Sources */,
@@ -7966,6 +7973,7 @@
 				40245F442BE2745600FCF075 /* CallResponse+Dummy.swift in Sources */,
 				845C09892C0DFA5E00F725B3 /* LimitsSettingsResponse+Dummy.swift in Sources */,
 				401BEC4F2AE1738D00EEEAC5 /* HorizontalParticipantsListView_Tests.swift in Sources */,
+				4045D9D72DAD36130077A660 /* ResourceTests.swift in Sources */,
 				401480342A5423D60029166A /* AudioValuePercentageNormaliser_Tests.swift in Sources */,
 				40073B7D2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift in Sources */,
 				8493223B29082EDB0013C029 /* StreamVideoUITestCase.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -208,7 +208,7 @@
 		40429D602C779B5A00AC7FFF /* TrackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40BBC4872C623C6E002AEF92 /* TrackType.swift */; };
 		40429D612C779B7000AC7FFF /* SFUSignalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C689192C64F74F0054528A /* SFUSignalService.swift */; };
 		4045D9D52DAD35790077A660 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9D42DAD35790077A660 /* Resource.swift */; };
-		4045D9D72DAD36130077A660 /* ResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9D62DAD36130077A660 /* ResourceTests.swift */; };
+		4045D9DD2DAD5B110077A660 /* Resource_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9DC2DAD5B110077A660 /* Resource_Tests.swift */; };
 		4046DEE92A9E381F00CA6D2F /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */; };
 		4046DEF02A9F469100CA6D2F /* GDPerformanceView-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 4046DEEF2A9F469100CA6D2F /* GDPerformanceView-Swift */; settings = {ATTRIBUTES = (Required, ); }; };
 		4046DEF22A9F510C00CA6D2F /* DebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */; };
@@ -1701,7 +1701,7 @@
 		40429D5C2C779AED00AC7FFF /* WebRTCMigrationStatusObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRTCMigrationStatusObserver.swift; sourceTree = "<group>"; };
 		40429D5E2C779B3D00AC7FFF /* ScreenShareSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenShareSession.swift; sourceTree = "<group>"; };
 		4045D9D42DAD35790077A660 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
-		4045D9D62DAD36130077A660 /* ResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceTests.swift; sourceTree = "<group>"; };
+		4045D9DC2DAD5B110077A660 /* Resource_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource_Tests.swift; sourceTree = "<group>"; };
 		4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		4046DEEA2A9E38DC00CA6D2F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenu.swift; sourceTree = "<group>"; };
@@ -2918,7 +2918,7 @@
 		401480332A5423C70029166A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				4045D9D62DAD36130077A660 /* ResourceTests.swift */,
+				4045D9DC2DAD5B110077A660 /* Resource_Tests.swift */,
 				40B48C0E2D14B8F6002C4EAB /* StreamAppStateAdapter */,
 				40914C962B567B6B00F6A13E /* PictureInPicture */,
 				401480312A54238C0029166A /* AudioValuePercentageNormaliser_Tests.swift */,
@@ -7973,7 +7973,6 @@
 				40245F442BE2745600FCF075 /* CallResponse+Dummy.swift in Sources */,
 				845C09892C0DFA5E00F725B3 /* LimitsSettingsResponse+Dummy.swift in Sources */,
 				401BEC4F2AE1738D00EEEAC5 /* HorizontalParticipantsListView_Tests.swift in Sources */,
-				4045D9D72DAD36130077A660 /* ResourceTests.swift in Sources */,
 				401480342A5423D60029166A /* AudioValuePercentageNormaliser_Tests.swift in Sources */,
 				40073B7D2C456F08006A2867 /* MockStreamAVPictureInPictureViewControlling.swift in Sources */,
 				8493223B29082EDB0013C029 /* StreamVideoUITestCase.swift in Sources */,
@@ -7997,6 +7996,7 @@
 				40914C9C2B56AA6600F6A13E /* StreamBufferTransformerTests.swift in Sources */,
 				82FF40C42A17C74D00B4D95E /* IncomingCallView_Tests.swift in Sources */,
 				404C27CB2BF2552800DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */,
+				4045D9DD2DAD5B110077A660 /* Resource_Tests.swift in Sources */,
 				408CE0F82BD95F170052EC3A /* VideoConfig+Dummy.swift in Sources */,
 				829F7BFA29FABC0E003EBACE /* ViewFactory.swift in Sources */,
 				8457BF802A5C18A7000AE567 /* ToastView_Tests.swift in Sources */,

--- a/StreamVideoSwiftUITests/Utils/ResourceTests.swift
+++ b/StreamVideoSwiftUITests/Utils/ResourceTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideoSwiftUI
+import XCTest
+
+final class ResourceTests: XCTestCase, @unchecked Sendable {
+
+    // MARK: - Initialization Tests
+    
+    func test_initWithNameAndExtension() {
+        // Given
+        let name = "testResource"
+        let fileExtension = "m4a"
+        
+        // When
+        let resource = Resource(name: name, extension: fileExtension)
+        
+        // Then
+        XCTAssertEqual(resource.name, name)
+        XCTAssertEqual(resource.extension, fileExtension)
+    }
+    
+    func test_initWithNameOnly() {
+        // Given
+        let name = "testResource"
+        
+        // When
+        let resource = Resource(name: name)
+        
+        // Then
+        XCTAssertEqual(resource.name, name)
+        XCTAssertNil(resource.extension)
+    }
+    
+    // MARK: - String Literal Initialization Tests
+    
+    func test_initFromStringLiteralWithExtension() {
+        // Given
+        let resource: Resource = "testResource.m4a"
+        
+        // Then
+        XCTAssertEqual(resource.name, "testResource")
+        XCTAssertEqual(resource.extension, "m4a")
+    }
+    
+    func test_initFromStringLiteralWithoutExtension() {
+        // Given
+        let resource: Resource = "testResource"
+        
+        // Then
+        XCTAssertEqual(resource.name, "testResource")
+        XCTAssertNil(resource.extension)
+    }
+    
+    func test_initFromStringLiteralWithMultipleDots() {
+        // Given
+        let resource: Resource = "test.resource.m4a"
+        
+        // Then
+        XCTAssertEqual(resource.name, "test.resource")
+        XCTAssertEqual(resource.extension, "m4a")
+    }
+    
+    // MARK: - Edge Cases
+    
+    func test_initFromEmptyStringLiteral() {
+        // Given
+        let resource: Resource = ""
+        
+        // Then
+        XCTAssertEqual(resource.name, "")
+        XCTAssertNil(resource.extension)
+    }
+    
+    func test_initFromStringLiteralWithOnlyExtension() {
+        // Given
+        let resource: Resource = ".m4a"
+        
+        // Then
+        XCTAssertEqual(resource.name, "")
+        XCTAssertNil(resource.extension)
+    }
+}

--- a/StreamVideoSwiftUITests/Utils/Resource_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/Resource_Tests.swift
@@ -5,7 +5,7 @@
 @testable import StreamVideoSwiftUI
 import XCTest
 
-final class ResourceTests: XCTestCase, @unchecked Sendable {
+final class Resource_Tests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Initialization Tests
     
@@ -81,5 +81,17 @@ final class ResourceTests: XCTestCase, @unchecked Sendable {
         // Then
         XCTAssertEqual(resource.name, "")
         XCTAssertNil(resource.extension)
+    }
+
+    // MARK: - fileName
+
+    func test_fileName_withNameAndExtension() {
+        let resource: Resource = "testResource.m4a"
+        XCTAssertEqual(resource.fileName, "testResource.m4a")
+    }
+
+    func test_fileName_withNameOnly() {
+        let resource: Resource = "testResource"
+        XCTAssertEqual(resource.fileName, "testResource")
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-785/[blink]outgoing-call-sound-not-playing

### Docs PR

https://github.com/GetStream/docs-content/pull/291

### 📝 Summary

When using the SDK via SPM, Sound resources aren't playable. There are 2 reasons for that:
- Resources aren't being processed for `StreamVideoSwiftUI`
- In order for the resource to be found we should pass both the name and the extension in the Bundle load call. Specifically we need to pass the values separately and not as a single string value.

### 🛠 Implementation

Sound resources are now represented by a new struct called `Resource`. The struct conforms to `ExpressibleByStringLiteral` which ensures that existing overrides won't be affected.
The following lines have been added to the `Package.swift`: 
```swift
...
resources: [
    .process("Resources")
]
...
```

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)