### PR TITLE
[Fix]Respect dashboard audio settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Sound resources weren't loaded correctly when the SDK was linked via SPM. [#757](https://github.com/GetStream/stream-video-swift/pull/757)
+- Redefined the priorities by which dashboard audio settings will be applied. [#758](https://github.com/GetStream/stream-video-swift/pull/758)
 
 # [1.20.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.20.0)
 _April 07, 2025_

--- a/Sources/StreamVideo/CallSettings/SpeakerManager.swift
+++ b/Sources/StreamVideo/CallSettings/SpeakerManager.swift
@@ -8,6 +8,16 @@ import Foundation
 /// Handles the speaker state during a call.
 public final class SpeakerManager: ObservableObject, CallSettingsManager, @unchecked Sendable {
 
+    private struct Settings: Hashable {
+        var speakerOn: Bool
+        var audioOutputOn: Bool
+
+        init(_ callSettings: CallSettings) {
+            speakerOn = callSettings.speakerOn
+            audioOutputOn = callSettings.audioOutputOn
+        }
+    }
+
     @Published public internal(set) var status: CallSettingsStatus
     @Published public internal(set) var audioOutputStatus: CallSettingsStatus
 
@@ -96,8 +106,8 @@ public final class SpeakerManager: ObservableObject, CallSettingsManager, @unche
         call
             .state
             .$callSettings
+            .map { Settings($0) }
             .removeDuplicates()
-            .map { (speakerOn: $0.speakerOn, audioOutputOn: $0.audioOutputOn) }
             .log(.debug) { "\(typeOfSelf) callSettings updated speakerOn:\($0.speakerOn) audioOutputOn:\($0.audioOutputOn)." }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -394,7 +394,7 @@ public class CallState: ObservableObject {
         ingress = Ingress(rtmp: rtmp)
         
         if !localCallSettingsUpdate {
-            callSettings = response.settings.toCallSettings
+            callSettings = .init(response.settings)
         }
     }
     

--- a/Sources/StreamVideo/Models/CallSettings.swift
+++ b/Sources/StreamVideo/Models/CallSettings.swift
@@ -17,13 +17,34 @@ public final class CallSettings: ObservableObject, Sendable, Equatable, Reflecti
     public let audioOutputOn: Bool
     /// The camera position for the current user.
     public let cameraPosition: CameraPosition
-    
+
+    public convenience init(
+        _ response: CallSettingsResponse,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        self.init(
+            audioOn: response.audio.micDefaultOn,
+            videoOn: response.video.cameraDefaultOn,
+            speakerOn: response.speakerOnWithSettingsPriority,
+            audioOutputOn: true, // We always have audioOutputOn
+            cameraPosition: response.video.cameraFacing == .back ? .back : .front,
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+
     public init(
         audioOn: Bool = true,
         videoOn: Bool = true,
         speakerOn: Bool = true,
         audioOutputOn: Bool = true,
-        cameraPosition: CameraPosition = .front
+        cameraPosition: CameraPosition = .front,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
     ) {
         self.audioOn = audioOn
         self.speakerOn = speakerOn
@@ -44,8 +65,15 @@ public final class CallSettings: ObservableObject, Sendable, Equatable, Reflecti
             }
             self.videoOn = false
         }
+
+        log.debug(
+            "CallSettings created.",
+            functionName: function,
+            fileName: file,
+            lineNumber: line
+        )
     }
-    
+
     public static func == (lhs: CallSettings, rhs: CallSettings) -> Bool {
         lhs.audioOn == rhs.audioOn &&
             lhs.videoOn == rhs.videoOn &&
@@ -69,67 +97,94 @@ public enum CameraPosition: Sendable, Equatable {
     }
 }
 
-extension CallSettingsResponse {
-    
-    public var toCallSettings: CallSettings {
-        CallSettings(
-            audioOn: audio.micDefaultOn,
-            videoOn: video.cameraDefaultOn,
-            speakerOn: video.cameraDefaultOn ? true : audio.defaultDevice == .speaker,
-            audioOutputOn: audio.speakerDefaultOn,
-            cameraPosition: video.cameraFacing == .back ? .back : .front
-        )
-    }
-}
-
 public extension CallSettings {
-    func withUpdatedCameraPosition(_ cameraPosition: CameraPosition) -> CallSettings {
+    func withUpdatedCameraPosition(
+        _ cameraPosition: CameraPosition,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
             videoOn: videoOn,
             speakerOn: speakerOn,
             audioOutputOn: audioOutputOn,
-            cameraPosition: cameraPosition
+            cameraPosition: cameraPosition,
+            file: file,
+            function: function,
+            line: line
         )
     }
     
-    func withUpdatedAudioState(_ audioOn: Bool) -> CallSettings {
+    func withUpdatedAudioState(
+        _ audioOn: Bool,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
             videoOn: videoOn,
             speakerOn: speakerOn,
             audioOutputOn: audioOutputOn,
-            cameraPosition: cameraPosition
+            cameraPosition: cameraPosition,
+            file: file,
+            function: function,
+            line: line
         )
     }
     
-    func withUpdatedVideoState(_ videoOn: Bool) -> CallSettings {
+    func withUpdatedVideoState(
+        _ videoOn: Bool,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
             videoOn: videoOn,
             speakerOn: speakerOn,
             audioOutputOn: audioOutputOn,
-            cameraPosition: cameraPosition
+            cameraPosition: cameraPosition,
+            file: file,
+            function: function,
+            line: line
         )
     }
     
-    func withUpdatedSpeakerState(_ speakerOn: Bool) -> CallSettings {
+    func withUpdatedSpeakerState(
+        _ speakerOn: Bool,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
             videoOn: videoOn,
             speakerOn: speakerOn,
             audioOutputOn: audioOutputOn,
-            cameraPosition: cameraPosition
+            cameraPosition: cameraPosition,
+            file: file,
+            function: function,
+            line: line
         )
     }
     
-    func withUpdatedAudioOutputState(_ audioOutputOn: Bool) -> CallSettings {
+    func withUpdatedAudioOutputState(
+        _ audioOutputOn: Bool,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> CallSettings {
         CallSettings(
             audioOn: audioOn,
             videoOn: videoOn,
             speakerOn: speakerOn,
             audioOutputOn: audioOutputOn,
-            cameraPosition: cameraPosition
+            cameraPosition: cameraPosition,
+            file: file,
+            function: function,
+            line: line
         )
     }
 }

--- a/Sources/StreamVideo/Models/Extensions/CallSettingsResponse+SettingsPriority.swift
+++ b/Sources/StreamVideo/Models/Extensions/CallSettingsResponse+SettingsPriority.swift
@@ -1,0 +1,28 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension CallSettingsResponse {
+
+    /// Determines if the speaker should be enabled based on a priority hierarchy of
+    /// settings.
+    ///
+    /// The priority order is as follows:
+    /// 1. If video camera is set to be on by default, speaker is enabled
+    /// 2. If audio speaker is set to be on by default, speaker is enabled
+    /// 3. If the default audio device is set to speaker, speaker is enabled
+    ///
+    /// This ensures that the speaker state aligns with the most important user
+    /// preference or system requirement.
+    var speakerOnWithSettingsPriority: Bool {
+        if video.cameraDefaultOn {
+            return true
+        } else if audio.speakerDefaultOn {
+            return true
+        } else {
+            return audio.defaultDevice == .speaker
+        }
+    }
+}

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCAuthenticator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCAuthenticator.swift
@@ -81,7 +81,7 @@ struct WebRTCAuthenticator: WebRTCAuthenticating {
             )
         } else {
             await coordinator.stateAdapter.set(
-                callSettings: response.call.settings.toCallSettings
+                callSettings: .init(response.call.settings)
             )
         }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -424,7 +424,7 @@ open class CallViewModel: ObservableObject {
                 do {
                     let call = streamVideo.call(callType: callType, callId: callId)
                     let info = try await call.get()
-                    self.callSettings = info.call.settings.toCallSettings
+                    self.callSettings = .init(info.call.settings)
                 } catch {
                     log.error(error)
                 }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -209,6 +209,8 @@
 		40429D612C779B7000AC7FFF /* SFUSignalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C689192C64F74F0054528A /* SFUSignalService.swift */; };
 		4045D9D52DAD35790077A660 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9D42DAD35790077A660 /* Resource.swift */; };
 		4045D9DD2DAD5B110077A660 /* Resource_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9DC2DAD5B110077A660 /* Resource_Tests.swift */; };
+		4045D9D92DAD4BD50077A660 /* CallSettingsResponse+SettingsPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9D82DAD4BD50077A660 /* CallSettingsResponse+SettingsPriority.swift */; };
+		4045D9DB2DAD57570077A660 /* CallSettingsResponse+SettingsPriorityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045D9DA2DAD57570077A660 /* CallSettingsResponse+SettingsPriorityTests.swift */; };
 		4046DEE92A9E381F00CA6D2F /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */; };
 		4046DEF02A9F469100CA6D2F /* GDPerformanceView-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 4046DEEF2A9F469100CA6D2F /* GDPerformanceView-Swift */; settings = {ATTRIBUTES = (Required, ); }; };
 		4046DEF22A9F510C00CA6D2F /* DebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */; };
@@ -1701,6 +1703,8 @@
 		40429D5E2C779B3D00AC7FFF /* ScreenShareSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenShareSession.swift; sourceTree = "<group>"; };
 		4045D9D42DAD35790077A660 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		4045D9DC2DAD5B110077A660 /* Resource_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource_Tests.swift; sourceTree = "<group>"; };
+		4045D9D82DAD4BD50077A660 /* CallSettingsResponse+SettingsPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallSettingsResponse+SettingsPriority.swift"; sourceTree = "<group>"; };
+		4045D9DA2DAD57570077A660 /* CallSettingsResponse+SettingsPriorityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallSettingsResponse+SettingsPriorityTests.swift"; sourceTree = "<group>"; };
 		4046DEE82A9E381F00CA6D2F /* AppIntentVocabulary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		4046DEEA2A9E38DC00CA6D2F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4046DEF12A9F510C00CA6D2F /* DebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenu.swift; sourceTree = "<group>"; };
@@ -4305,6 +4309,7 @@
 				40ADB8592D64AFEC00B06AAF /* Stream_Video_Sfu_Models_Participant+CallParticipant.swift */,
 				40DFA88C2CC10FEF003DCE05 /* Stream_Video_Sfu_Models_AppleThermalState+Convenience.swift */,
 				40C2B5BA2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift */,
+				4045D9D82DAD4BD50077A660 /* CallSettingsResponse+SettingsPriority.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5080,6 +5085,7 @@
 		842747E829EED0AB00E063AD /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				4045D9DA2DAD57570077A660 /* CallSettingsResponse+SettingsPriorityTests.swift */,
 				4029E9542CB9436F00E1D571 /* IncomingVideoQualitySettings_Tests.swift */,
 				842747EB29EED59000E063AD /* JSONDecoder_Tests.swift */,
 				8414081429F28FFC00FF2D7C /* CallSettings_Tests.swift */,
@@ -7027,6 +7033,7 @@
 				84BAD77E2A6BFFB200733156 /* BroadcastSampleHandler.swift in Sources */,
 				40C2B5BB2C2C41DA00EC2C2D /* RejectCallRequest+Reason.swift in Sources */,
 				40C9E4482C94743800802B28 /* Stream_Video_Sfu_Signal_TrackSubscriptionDetails+Convenience.swift in Sources */,
+				4045D9D92DAD4BD50077A660 /* CallSettingsResponse+SettingsPriority.swift in Sources */,
 				40034C282CFE156800A318B1 /* CallKitAvailabilityPolicy.swift in Sources */,
 				40F1016C2D5A654300C49481 /* DefaultAudioSessionPolicy.swift in Sources */,
 				840042C92A6FF9A200917B30 /* BroadcastConstants.swift in Sources */,
@@ -7522,6 +7529,7 @@
 				40B48C212D14CB1B002C4EAB /* Int_DefaultValuesTests.swift in Sources */,
 				40F017612BBEF15E00E89FD1 /* CallParticipantResponse+Dummy.swift in Sources */,
 				40034C2E2CFE15AC00A318B1 /* CallKitRegionBasedAvailabilityPolicy.swift in Sources */,
+				4045D9DB2DAD57570077A660 /* CallSettingsResponse+SettingsPriorityTests.swift in Sources */,
 				406B3C552C92031000FC93A1 /* WebRTCCoordinatorStateMachine_JoiningStageTests.swift in Sources */,
 				40C9E4642C99886900802B28 /* WebRTCCoorindator_Tests.swift in Sources */,
 				40F017772BBEF43B00E89FD1 /* CallSessionParticipantLeftEvent+Dummy.swift in Sources */,

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessAudioOutputIconView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateless/StatelessAudioOutputIconView_Tests.swift
@@ -38,7 +38,7 @@ final class StatelessAudioOutputIconView_Tests: StreamVideoUITestCase, @unchecke
 
     @MainActor
     private func makeSubject(
-        _ speakerOn: Bool,
+        _ audioOutputOn: Bool,
         actionHandler: (() -> Void)? = nil,
         file: StaticString = #file,
         line: UInt = #line
@@ -51,13 +51,8 @@ final class StatelessAudioOutputIconView_Tests: StreamVideoUITestCase, @unchecke
             file: file,
             line: line
         )
-        call.state.update(
-            from: .dummy(
-                settings: .dummy(
-                    audio: .dummy(speakerDefaultOn: speakerOn)
-                )
-            )
-        )
+
+        call.state.callSettings = .init(audioOutputOn: audioOutputOn)
 
         return .init(call: call, actionHandler: actionHandler)
     }

--- a/StreamVideoTests/Models/CallSettingsResponse+SettingsPriorityTests.swift
+++ b/StreamVideoTests/Models/CallSettingsResponse+SettingsPriorityTests.swift
@@ -1,0 +1,133 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+import XCTest
+
+final class CallSettingsResponse_SettingsPriorityTests: XCTestCase, @unchecked Sendable {
+    
+    func test_speakerOnWithSettingsPriority_whenVideoCameraDefaultOn_returnsTrue() {
+        // Given
+        let videoSettings = VideoSettings(
+            accessRequestEnabled: true,
+            cameraDefaultOn: true,
+            cameraFacing: .front,
+            enabled: true,
+            targetResolution: .init(bitrate: 100, height: 100, width: 100)
+        )
+        
+        let audioSettings = AudioSettings(
+            accessRequestEnabled: true,
+            defaultDevice: .earpiece,
+            micDefaultOn: true,
+            opusDtxEnabled: true,
+            redundantCodingEnabled: true,
+            speakerDefaultOn: false
+        )
+        
+        let settings = CallSettingsResponse.dummy(
+            audio: audioSettings,
+            video: videoSettings
+        )
+        
+        // When
+        let result = settings.speakerOnWithSettingsPriority
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_speakerOnWithSettingsPriority_whenAudioSpeakerDefaultOn_returnsTrue() {
+        // Given
+        let videoSettings = VideoSettings(
+            accessRequestEnabled: true,
+            cameraDefaultOn: false,
+            cameraFacing: .front,
+            enabled: true,
+            targetResolution: .init(bitrate: 100, height: 100, width: 100)
+        )
+        
+        let audioSettings = AudioSettings(
+            accessRequestEnabled: true,
+            defaultDevice: .earpiece,
+            micDefaultOn: true,
+            opusDtxEnabled: true,
+            redundantCodingEnabled: true,
+            speakerDefaultOn: true
+        )
+        
+        let settings = CallSettingsResponse.dummy(
+            audio: audioSettings,
+            video: videoSettings
+        )
+
+        // When
+        let result = settings.speakerOnWithSettingsPriority
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_speakerOnWithSettingsPriority_whenDefaultDeviceIsSpeaker_returnsTrue() {
+        // Given
+        let videoSettings = VideoSettings(
+            accessRequestEnabled: true,
+            cameraDefaultOn: false,
+            cameraFacing: .front,
+            enabled: true,
+            targetResolution: .init(bitrate: 100, height: 100, width: 100)
+        )
+        
+        let audioSettings = AudioSettings(
+            accessRequestEnabled: true,
+            defaultDevice: .speaker,
+            micDefaultOn: true,
+            opusDtxEnabled: true,
+            redundantCodingEnabled: true,
+            speakerDefaultOn: false
+        )
+        
+        let settings = CallSettingsResponse.dummy(
+            audio: audioSettings,
+            video: videoSettings
+        )
+        
+        // When
+        let result = settings.speakerOnWithSettingsPriority
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_speakerOnWithSettingsPriority_whenNoConditionsMet_returnsFalse() {
+        // Given
+        let videoSettings = VideoSettings(
+            accessRequestEnabled: true,
+            cameraDefaultOn: false,
+            cameraFacing: .front,
+            enabled: true,
+            targetResolution: .init(bitrate: 100, height: 100, width: 100)
+        )
+        
+        let audioSettings = AudioSettings(
+            accessRequestEnabled: true,
+            defaultDevice: .earpiece,
+            micDefaultOn: true,
+            opusDtxEnabled: true,
+            redundantCodingEnabled: true,
+            speakerDefaultOn: false
+        )
+        
+        let settings = CallSettingsResponse.dummy(
+            audio: audioSettings,
+            video: videoSettings
+        )
+        
+        // When
+        let result = settings.speakerOnWithSettingsPriority
+        
+        // Then
+        XCTAssertFalse(result)
+    }
+}

--- a/StreamVideoTests/WebRTC/v2/WebRTCAuthenticator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCAuthenticator_Tests.swift
@@ -153,7 +153,7 @@ final class WebRTCAuthenticator_Tests: XCTestCase, @unchecked Sendable {
             .coordinator
             .stateAdapter
             .callSettings
-        XCTAssertEqual(callSettings, expected.call.settings.toCallSettings)
+        XCTAssertEqual(callSettings, .init(expected.call.settings))
     }
 
     func test_authenticate_withCreateFalseAndInitialCallSettings_shouldSetInitialCallSettings() async throws {
@@ -210,7 +210,7 @@ final class WebRTCAuthenticator_Tests: XCTestCase, @unchecked Sendable {
             .coordinator
             .stateAdapter
             .callSettings
-        XCTAssertEqual(callSettings, expected.call.settings.toCallSettings)
+        XCTAssertEqual(callSettings, .init(expected.call.settings))
     }
 
     func test_authenticate_updatesVideoOptions() async throws {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-796/[blink]speaker-icon-flashing

### 📝 Summary

Dashboard contains the following configurations

![image](https://github.com/user-attachments/assets/564165df-146e-4170-a96d-3dbab272c07a)

This revision ensures that the settings above will be applied with the following priority:
- If camera is on, speaker will be on by default
- If camera is off, and `Speaker on by Default`, speaker will be on
- If camera is off, `Speaker on by Default` is off and default device is speaker, speaker will be on
- Otherwise earpiece will be on

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)