### PR TITLE
[Enhancement]Expose custom data on IncomingCall

### DIFF
--- a/Sources/StreamVideoSwiftUI/Models/CallEventsHandler.swift
+++ b/Sources/StreamVideoSwiftUI/Models/CallEventsHandler.swift
@@ -56,7 +56,8 @@ public class CallEventsHandler {
                 type: type,
                 members: members,
                 timeout: TimeInterval(ringEvent.call.settings.ring.autoCancelTimeoutMs / 1000),
-                video: ringEvent.video
+                video: ringEvent.video,
+                customData: ringEvent.call.custom
             )
             return .incoming(incomingCall)
         case let .typeCallSessionStartedEvent(callSessionStartedEvent):

--- a/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
+++ b/Sources/StreamVideoSwiftUI/Models/IncomingCall.swift
@@ -18,6 +18,7 @@ public struct IncomingCall: Identifiable, Sendable, Equatable {
     public let members: [Member]
     public let timeout: TimeInterval
     public let video: Bool
+    public let customData: [String: RawJSON]
 
     public init(
         id: String,
@@ -25,7 +26,8 @@ public struct IncomingCall: Identifiable, Sendable, Equatable {
         type: String,
         members: [Member],
         timeout: TimeInterval,
-        video: Bool = false
+        video: Bool = false,
+        customData: [String: RawJSON] = [:]
     ) {
         self.id = id
         self.caller = caller
@@ -33,5 +35,6 @@ public struct IncomingCall: Identifiable, Sendable, Equatable {
         self.members = members
         self.timeout = timeout
         self.video = video
+        self.customData = customData
     }
 }

--- a/StreamVideoSwiftUITests/CallingViews/IncomingCallView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/IncomingCallView_Tests.swift
@@ -20,7 +20,8 @@ final class IncomingCallView_Tests: StreamVideoUITestCase, @unchecked Sendable {
                 type: callType,
                 members: members,
                 timeout: 15000,
-                video: false
+                video: false,
+                customData: [:]
             )
             let view = IncomingCallView(
                 callInfo: callInfo,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-810/[blink]expose-custom-data-on-incomingcall

### 🎯 Goal

Expose custom-data on the IncomingCall object.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)