### PR TITLE
Fix handling of session join/leave events for existing users

### DIFF
--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -209,12 +209,16 @@ public class CallState: ObservableObject {
         case let .typeCallSessionEndedEvent(event):
             update(from: event.call)
         case let .typeCallSessionParticipantJoinedEvent(event):
-            if session?.participants.contains(event.participant) == false {
+            if let index = session?.participants.firstIndex(where: {
+                $0.userSessionId == event.participant.userSessionId
+            }), index < (session?.participants.count ?? 0) {
+                session?.participants[index] = event.participant
+            } else {
                 session?.participants.append(event.participant)
             }
         case let .typeCallSessionParticipantLeftEvent(event):
             session?.participants.removeAll(where: { participant in
-                participant == event.participant
+                participant.userSessionId == event.participant.userSessionId
             })
         case let .typeCallSessionStartedEvent(event):
             update(from: event.call)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-813/session-participants-event-handling.

### 🎯 Goal

Fix duplicated session participants.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
