### PR TITLE
[Enhancement]Implement proximity policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- You can now configure policies based on the the device's proximity information. Those policies can be used to toggle speaker and video. [#770](https://github.com/GetStream/stream-video-swift/pull/770)
 
 # [1.21.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.21.1)
 _April 25, 2025_

--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -591,6 +591,35 @@ extension AppEnvironment {
     static var preferredCallType: String?
 }
 
+extension AppEnvironment {
+
+    enum ProximityPolicyDebugConfiguration: Hashable, Debuggable, Sendable, CaseIterable {
+        case speaker, video
+
+        var title: String {
+            switch self {
+            case .speaker:
+                return "Speaker"
+            case .video:
+                return "Video"
+            }
+        }
+
+        var value: ProximityPolicy {
+            switch self {
+            case .speaker:
+                return SpeakerProximityPolicy()
+            case .video:
+                return VideoProximityPolicy()
+            }
+        }
+    }
+
+    static var proximityPolicies: Set<ProximityPolicyDebugConfiguration> = {
+        [.speaker, .video]
+    }()
+}
+
 extension String: Debuggable {
     var title: String {
         self

--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -188,6 +188,15 @@ struct SimpleCallingView: View {
         try await call.updateAudioSessionPolicy(AppEnvironment.audioSessionPolicy.value)
     }
 
+    private func setProximityPolicies(for callId: String) throws {
+        let policies = AppEnvironment.proximityPolicies.map(\.value)
+        guard !policies.isEmpty else {
+            return
+        }
+        let call = streamVideo.call(callType: callType, callId: callId)
+        try policies.forEach { try call.addProximityPolicy($0) }
+    }
+
     private func parseURLIfRequired(_ text: String) {
         let adapter = DeeplinkAdapter()
         guard
@@ -224,6 +233,7 @@ struct SimpleCallingView: View {
         case .lobby:
             await setPreferredVideoCodec(for: text)
             try? await setAudioSessionPolicyOverride(for: text)
+            try? setProximityPolicies(for: text)
             viewModel.enterLobby(
                 callType: callType,
                 callId: text,
@@ -232,10 +242,12 @@ struct SimpleCallingView: View {
         case .join:
             await setPreferredVideoCodec(for: text)
             try? await setAudioSessionPolicyOverride(for: text)
+            try? setProximityPolicies(for: text)
             viewModel.joinCall(callType: callType, callId: text)
         case let .start(callId):
             await setPreferredVideoCodec(for: callId)
             try? await setAudioSessionPolicyOverride(for: callId)
+            try? setProximityPolicies(for: text)
             viewModel.startCall(
                 callType: callType,
                 callId: callId,

--- a/DemoApp/Sources/Views/Login/DebugMenu.swift
+++ b/DemoApp/Sources/Views/Login/DebugMenu.swift
@@ -125,6 +125,10 @@ struct DebugMenu: View {
         didSet { AppEnvironment.audioSessionPolicy = audioSessionPolicy }
     }
 
+    @State private var proximityPolicies = AppEnvironment.proximityPolicies {
+        didSet { AppEnvironment.proximityPolicies = proximityPolicies }
+    }
+
     var body: some View {
         Menu {
             makeMenu(
@@ -189,6 +193,18 @@ struct DebugMenu: View {
                 currentValue: audioSessionPolicy,
                 label: "AudioSession policy"
             ) { self.audioSessionPolicy = $0 }
+
+            makeMultipleSelectMenu(
+                for: AppEnvironment.ProximityPolicyDebugConfiguration.allCases,
+                currentValues: proximityPolicies,
+                label: "Proximity policies"
+            ) { item, isSelected in
+                if isSelected {
+                    proximityPolicies = proximityPolicies.filter { item != $0 }
+                } else {
+                    proximityPolicies.insert(item)
+                }
+            }
 
             makeMenu(
                 for: [.default, .lastParticipant],

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		409C396F2B67CDF30090044C /* 09-broadcasting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C396E2B67CDF30090044C /* 09-broadcasting.swift */; };
 		409F10EA2BE11698000A984B /* StreamVideoNoiseCancellation in Frameworks */ = {isa = PBXBuildFile; productRef = 409F10E92BE11698000A984B /* StreamVideoNoiseCancellation */; };
 		40AB356B2B73965D00E465CC /* 16-snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB356A2B73965D00E465CC /* 16-snapshot.swift */; };
+		40AD64BB2DC2671E0077AE15 /* 05-proximity-policies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AD64BA2DC2671B0077AE15 /* 05-proximity-policies.swift */; };
 		40B468982B67B6DF009B5B3E /* 01-deeplinking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */; };
 		40CB9FA92B7FC7DB006BED93 /* 17-camera-zoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CB9FA82B7FC7DB006BED93 /* 17-camera-zoom.swift */; };
 		40E23B9B2B67BA4100D11FC1 /* 02-push-notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */; };
@@ -108,6 +109,7 @@
 		409C396C2B67CD780090044C /* 08-recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "08-recording.swift"; sourceTree = "<group>"; };
 		409C396E2B67CDF30090044C /* 09-broadcasting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "09-broadcasting.swift"; sourceTree = "<group>"; };
 		40AB356A2B73965D00E465CC /* 16-snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "16-snapshot.swift"; sourceTree = "<group>"; };
+		40AD64BA2DC2671B0077AE15 /* 05-proximity-policies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "05-proximity-policies.swift"; sourceTree = "<group>"; };
 		40B468972B67B6DF009B5B3E /* 01-deeplinking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-deeplinking.swift"; sourceTree = "<group>"; };
 		40CB9FA82B7FC7DB006BED93 /* 17-camera-zoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "17-camera-zoom.swift"; sourceTree = "<group>"; };
 		40E23B9A2B67BA4100D11FC1 /* 02-push-notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-push-notifications.swift"; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				409C39682B67CC5C0090044C /* 04-screensharing.swift */,
 				409C396A2B67CD0B0090044C /* 05-picture-in-picture.swift */,
 				404CAED72B8E3874007087BC /* 06-apply-video-filters.swift */,
+				40AD64BA2DC2671B0077AE15 /* 05-proximity-policies.swift */,
 				409C396C2B67CD780090044C /* 08-recording.swift */,
 				409C396E2B67CDF30090044C /* 09-broadcasting.swift */,
 			);
@@ -440,6 +443,7 @@
 			files = (
 				40FFDC5A2B63F08D004DA7A2 /* 01-call-participant.swift in Sources */,
 				40FFDC9A2B6405C7004DA7A2 /* 10-network-quality-indicator.swift in Sources */,
+				40AD64BB2DC2671E0077AE15 /* 05-proximity-policies.swift in Sources */,
 				400D91D12B63DEA200EBA47D /* 04-camera-and-microphone.swift in Sources */,
 				40FFDC4F2B63EE50004DA7A2 /* 04-active-call.swift in Sources */,
 				40FFDCA02B640676004DA7A2 /* 13-pinning-users.swift in Sources */,

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/05-proximity-policies.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/05-proximity-policies.swift
@@ -1,0 +1,49 @@
+//
+//  05-proximity-policies.swift
+//  DocumentationTests
+//
+//  Created by Ilias Pavlidakis on 30/4/25.
+//
+
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    container {
+        let call = streamVideo.call(callType: "default", callId: "chat-123")
+        let policy = VideoProximityPolicy()
+
+        do {
+            try call.addProximityPolicy(policy)
+        } catch {
+            log.error(error)
+        }
+    }
+
+    container {
+        let call = streamVideo.call(callType: "default", callId: "team-meet")
+        let policy = SpeakerProximityPolicy()
+
+        do {
+            try call.addProximityPolicy(policy)
+        } catch {
+            log.error(error)
+        }
+    }
+
+    container {
+        let call = streamVideo.call(callType: "default", callId: "chat-123")
+        let videoPolicy = VideoProximityPolicy()
+        let speakerPolicy = SpeakerProximityPolicy()
+
+        do {
+            try call.addProximityPolicy(videoPolicy)
+            try call.addProximityPolicy(speakerPolicy)
+        } catch {
+            log.error(error)
+        }
+    }
+}

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -48,6 +48,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     public let camera: CameraManager
     /// Provides access to the speaker.
     public let speaker: SpeakerManager
+    /// Provides access to device's proximity
+    private lazy var proximity: ProximityManager = .init(self)
 
     internal let callController: CallController
     internal let coordinatorClient: DefaultAPI
@@ -1232,7 +1234,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     /// Sets the disconnection timeout for a user who has temporarily lost connection.
     ///
     /// This method defines the duration a user, who has already joined the call, can remain
-    /// in a disconnected state due to temporary internet issues. If the user’s connection
+    /// in a disconnected state due to temporary internet issues. If the user's connection
     /// remains disrupted beyond the specified timeout period, they will be dropped from the call.
     /// This timeout helps ensure that users with unstable connections do not stay in the call
     /// indefinitely if they cannot reconnect.
@@ -1365,6 +1367,20 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     /// - Throws: An error if the update fails.
     public func updateAudioSessionPolicy(_ policy: AudioSessionPolicy) async throws {
         try await callController.updateAudioSessionPolicy(policy)
+    }
+
+    /// Adds a proximity policy to manage device proximity behavior during the call.
+    /// Only supported on phone devices.
+    /// - Parameter policy: Policy to add for managing proximity behavior
+    /// - Throws: ClientError if the call is not in a valid state
+    public func addProximityPolicy(_ policy: any ProximityPolicy) throws {
+        try proximity.add(policy)
+    }
+
+    /// Removes a previously added proximity policy from the call.
+    /// - Parameter policy: Policy to remove
+    public func removeProximityPolicy(_ policy: any ProximityPolicy) {
+        proximity.remove(policy)
     }
 
     // MARK: - Internal

--- a/Sources/StreamVideo/CallSettings/ProximityManager.swift
+++ b/Sources/StreamVideo/CallSettings/ProximityManager.swift
@@ -1,0 +1,116 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// Manages proximity-related functionality for a call, including policy management
+/// and proximity state observation. Only active on phone devices.
+final class ProximityManager: @unchecked Sendable {
+
+    @Injected(\.streamVideo) private var streamVideo
+    @Injected(\.currentDevice) private var currentDevice
+    @Injected(\.proximityMonitor) private var proximityMonitor
+
+    /// Whether proximity monitoring is supported on the current device
+    var isSupported: Bool { currentDevice.deviceType == .phone }
+
+    /// Weak reference to the associated call
+    private weak var call: Call?
+    /// Thread-safe storage for registered proximity policies
+    @Atomic private var policies: [ObjectIdentifier: any ProximityPolicy] = [:]
+
+    /// Cancellable for active call observation
+    private var activeCallCancellable: AnyCancellable?
+    /// Cancellable for proximity state observation
+    private var observationCancellable: AnyCancellable?
+
+    /// Creates a new proximity manager for the specified call
+    /// - Parameter call: Call instance to manage proximity for
+    init(_ call: Call) {
+        self.call = call
+
+        if isSupported {
+            activeCallCancellable = streamVideo
+                .state
+                .$activeCall
+                .sinkTask { @MainActor [weak self] in self?.didUpdateActiveCall($0) }
+        }
+    }
+
+    deinit {
+        activeCallCancellable?.cancel()
+        observationCancellable?.cancel()
+    }
+
+    // MARK: - Policies
+
+    /// Adds a proximity policy to be managed by this instance
+    /// - Parameter policy: Policy to add
+    /// - Throws: ClientError if call is nil
+    func add(_ policy: any ProximityPolicy) throws {
+        guard isSupported else { return }
+
+        guard let call else {
+            throw ClientError("ProximityPolicy identifier:\(policy) cannot be attached while Call is nil.")
+        }
+        policies[type(of: policy).identifier] = policy
+        log.info("ProximityPolicy identifier:\(policy) has been attached on Call id:\(call.callId) type:\(call.callType).")
+    }
+
+    /// Removes a proximity policy from management
+    /// - Parameter policy: Policy to remove
+    func remove(_ policy: any ProximityPolicy) {
+        guard isSupported else { return }
+
+        policies[type(of: policy).identifier] = nil
+
+        guard let call else {
+            return
+        }
+        log.info("ProximityPolicy identifier:\(policy) has been removed from Call id:\(call.callId) type:\(call.callType).")
+    }
+
+    // MARK: - Private Helpers
+
+    /// Handles active call changes by starting/stopping proximity observation
+    /// - Parameter activeCall: New active call or nil if no active call
+    @MainActor
+    private func didUpdateActiveCall(_ activeCall: Call?) {
+        if
+            let activeCall,
+            call?.cId == activeCall.cId,
+            policies.isEmpty == false,
+            observationCancellable == nil {
+            proximityMonitor.startObservation()
+            observationCancellable = proximityMonitor
+                .statePublisher
+                .removeDuplicates()
+                .sink { [weak self] in self?.didUpdateProximity($0) }
+            log.info("Proximity observation has started.")
+        } else if
+            activeCall == nil,
+            observationCancellable != nil
+        {
+            observationCancellable?.cancel()
+            observationCancellable = nil
+            proximityMonitor.stopObservation()
+            log.info("Proximity observation has stopped.")
+        } else {
+            /* No-op */
+        }
+    }
+
+    /// Notifies all registered policies of a proximity state change
+    /// - Parameter proximity: New proximity state
+    private func didUpdateProximity(_ proximity: ProximityState) {
+        guard let call else {
+            return
+        }
+
+        for policy in policies {
+            policy.value.didUpdateProximity(proximity, on: call)
+        }
+    }
+}

--- a/Sources/StreamVideo/Utils/Proximity/Monitor/ProximityMonitor.swift
+++ b/Sources/StreamVideo/Utils/Proximity/Monitor/ProximityMonitor.swift
@@ -1,0 +1,98 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+#endif
+import Combine
+
+/// Represents the proximity state of a device's sensor.
+public enum ProximityState: Hashable, Sendable {
+    /// Device is close to user (e.g., near ear during call)
+    case near
+    /// Device is far from user
+    case far
+    init(_ value: Bool) { self = value ? .near : .far }
+}
+
+/// Protocol defining the interface for proximity monitoring functionality.
+public protocol ProximityProviding {
+    /// Current proximity state of the device
+    var state: ProximityState { get }
+    /// Publisher that emits proximity state changes
+    var statePublisher: AnyPublisher<ProximityState, Never> { get }
+    /// Whether proximity monitoring is currently active
+    var isActive: Bool { get }
+
+    /// Starts monitoring device proximity state
+    @MainActor
+    func startObservation()
+
+    /// Stops monitoring device proximity state
+    func stopObservation()
+}
+
+/// Monitors device proximity state using the device's proximity sensor.
+/// Only available on iOS devices with proximity sensor capability.
+final class ProximityMonitor: ProximityProviding, ObservableObject, @unchecked Sendable {
+    @Injected(\.currentDevice) private var currentDevice
+
+    private var stateObservationCancellable: AnyCancellable?
+
+    /// Current proximity state of the device
+    @Published public private(set) var state: ProximityState = .far
+    /// Publisher that emits proximity state changes
+    var statePublisher: AnyPublisher<ProximityState, Never> {
+        $state.eraseToAnyPublisher()
+    }
+
+    /// Whether proximity monitoring is currently active
+    var isActive: Bool { stateObservationCancellable != nil }
+
+    init() {}
+
+    /// Starts monitoring device proximity state.
+    /// Only activates on iPhone devices and if not already monitoring.
+    @MainActor
+    func startObservation() {
+        #if canImport(UIKit)
+        guard currentDevice.deviceType == .phone, !isActive else {
+            return
+        }
+        currentDevice.isProximityMonitoringEnabled = true
+
+        stateObservationCancellable = NotificationCenter
+            .default
+            .publisher(for: UIDevice.proximityStateDidChangeNotification)
+            .map { _ in ProximityState(UIDevice.current.proximityState) }
+            .removeDuplicates()
+            .log(.debug, subsystems: .audioSession) { "Proximity state updated \($0)." }
+            .assign(to: \.state, onWeak: self)
+        #endif
+    }
+
+    /// Stops monitoring device proximity state.
+    /// No-op if monitoring is not active.
+    func stopObservation() {
+        guard isActive else {
+            return
+        }
+        stateObservationCancellable?.cancel()
+        stateObservationCancellable = nil
+    }
+}
+
+/// Injection key for the proximity monitor dependency
+enum ProximityProviderKey: InjectionKey {
+    nonisolated(unsafe) public static var currentValue: ProximityProviding = ProximityMonitor()
+}
+
+extension InjectedValues {
+    /// Provides access to the shared proximity monitor instance.
+    /// Used to monitor device proximity state changes.
+    public internal(set) var proximityMonitor: ProximityProviding {
+        get { Self[ProximityProviderKey.self] }
+        set { Self[ProximityProviderKey.self] = newValue }
+    }
+}

--- a/Sources/StreamVideo/Utils/Proximity/Policies/ProximityPolicy.swift
+++ b/Sources/StreamVideo/Utils/Proximity/Policies/ProximityPolicy.swift
@@ -1,0 +1,23 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol defining behavior for handling device proximity changes during calls.
+/// Implementations can react to proximity state changes with custom logic.
+public protocol ProximityPolicy: Sendable, CustomStringConvertible {
+    /// Unique identifier for the policy implementation
+    static var identifier: ObjectIdentifier { get }
+
+    /// Called when device proximity state changes during a call
+    /// - Parameters:
+    ///   - proximity: New proximity state of the device
+    ///   - call: Call instance where the proximity change occurred
+    func didUpdateProximity(_ proximity: ProximityState, on call: Call)
+}
+
+extension ProximityPolicy {
+    /// Default description implementation using the policy's identifier
+    public var description: String { "\(Self.identifier)" }
+}

--- a/Sources/StreamVideo/Utils/Proximity/Policies/SpeakerProximityPolicy.swift
+++ b/Sources/StreamVideo/Utils/Proximity/Policies/SpeakerProximityPolicy.swift
@@ -1,0 +1,84 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Combine
+import Foundation
+
+/// Policy that manages speaker state based on device proximity during calls.
+/// Automatically disables speaker when device is near user (e.g., during phone call)
+/// and restores previous speaker state when device moves away.
+public final class SpeakerProximityPolicy: ProximityPolicy, @unchecked Sendable {
+
+    @Injected(\.activeCallAudioSession) private var activeCallAudioSession
+    /// Unique identifier for this policy implementation
+    public static let identifier: ObjectIdentifier = .init("speaker-proximity-policy" as NSString)
+
+    /// Queue for processing proximity state changes
+    private let processingQueue = SerialActorQueue()
+    /// Stores call settings before proximity change for restoration
+    private var callSettingsBeforeProximityChange: CallSettings?
+
+    public init() {}
+
+    /// Handles proximity state changes by managing speaker settings.
+    /// - When device is near: Disables speaker if enabled
+    /// - When device is far: Restores previous speaker settings
+    /// - Parameters:
+    ///   - proximity: New proximity state of the device
+    ///   - call: Call instance where the proximity change occurred
+    public func didUpdateProximity(
+        _ proximity: ProximityState,
+        on call: Call
+    ) {
+        processingQueue.async { @MainActor [weak self, weak call] in
+            guard
+                let self,
+                let call,
+                activeCallAudioSession?.currentRoute.isExternal == false
+            else {
+                return
+            }
+
+            switch proximity {
+            case .near:
+                if call.state.callSettings.speakerOn {
+                    self.callSettingsBeforeProximityChange = call.state.callSettings
+                    let updatedCallSettings = call
+                        .state
+                        .callSettings
+                        .withUpdatedSpeakerState(false)
+
+                    call.state.callSettings = updatedCallSettings
+
+                    log.debug(
+                        "Device proximity was updated to .near. Speaker was disabled.",
+                        subsystems: .audioSession
+                    )
+                } else if !call.state.callSettings.speakerOn {
+                    log.debug(
+                        "Device proximity was updated to .near but speaker is already off.",
+                        subsystems: .audioSession
+                    )
+                } else {
+                    /* No-op */
+                }
+            case .far:
+                if let callSettingsBeforeProximityChange {
+                    self.callSettingsBeforeProximityChange = nil
+                    call.state.callSettings = callSettingsBeforeProximityChange
+                    log.debug(
+                        "Device proximity was updated to .far. We restored the CallSettings.",
+                        subsystems: .audioSession
+                    )
+                } else {
+                    log.debug(
+                        "Device proximity was updated to .far but no CallSettings found to restore.",
+                        subsystems: .audioSession
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/StreamVideo/Utils/Proximity/Policies/VideoProximityPolicy.swift
+++ b/Sources/StreamVideo/Utils/Proximity/Policies/VideoProximityPolicy.swift
@@ -46,14 +46,15 @@ public final class VideoProximityPolicy: ProximityPolicy, @unchecked Sendable {
 
             switch proximity {
             case .near:
+                let callSettings = call.state.callSettings
                 let cachedValue = CachedValue(
                     incomingVideoQualitySettings: call.state.incomingVideoQualitySettings,
-                    videoOn: call.state.callSettings.videoOn
+                    videoOn: callSettings.videoOn
                 )
                 self.cachedValue = cachedValue
                 await call.setIncomingVideoQualitySettings(.disabled(group: .all))
                 if cachedValue.videoOn {
-                    try? await call.camera.disable()
+                    try? await call.callController.changeVideoState(isEnabled: false)
                 }
             case .far:
                 if let cachedValue {
@@ -62,7 +63,7 @@ public final class VideoProximityPolicy: ProximityPolicy, @unchecked Sendable {
                     }
 
                     if cachedValue.videoOn {
-                        try? await call.camera.enable()
+                        try? await call.callController.changeVideoState(isEnabled: true)
                     }
                 }
             }

--- a/Sources/StreamVideo/Utils/Proximity/Policies/VideoProximityPolicy.swift
+++ b/Sources/StreamVideo/Utils/Proximity/Policies/VideoProximityPolicy.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Combine
+import Foundation
+
+/// Policy that manages video settings based on device proximity during calls.
+/// Automatically disables video when device is near user and restores previous
+/// video settings when device moves away.
+public final class VideoProximityPolicy: ProximityPolicy, @unchecked Sendable {
+
+    /// Stores video settings to be restored when device moves away
+    private struct CachedValue {
+        /// Cached incoming video quality settings
+        var incomingVideoQualitySettings: IncomingVideoQualitySettings?
+        /// Cached video state (enabled/disabled)
+        var videoOn: Bool
+    }
+
+    /// Unique identifier for this policy implementation
+    public static let identifier: ObjectIdentifier = .init("video-proximity-policy" as NSString)
+
+    /// Queue for processing proximity state changes
+    private let processingQueue = SerialActorQueue()
+    /// Thread-safe storage for cached video settings
+    @Atomic private var cachedValue: CachedValue?
+
+    public init() {}
+
+    /// Handles proximity state changes by managing video settings.
+    /// - When device is near: Disables video and incoming video quality
+    /// - When device is far: Restores previous video settings
+    /// - Parameters:
+    ///   - proximity: New proximity state of the device
+    ///   - call: Call instance where the proximity change occurred
+    public func didUpdateProximity(
+        _ proximity: ProximityState,
+        on call: Call
+    ) {
+        processingQueue.async { @MainActor [weak self, weak call] in
+            guard let self, let call else {
+                return
+            }
+
+            switch proximity {
+            case .near:
+                let cachedValue = CachedValue(
+                    incomingVideoQualitySettings: call.state.incomingVideoQualitySettings,
+                    videoOn: call.state.callSettings.videoOn
+                )
+                self.cachedValue = cachedValue
+                await call.setIncomingVideoQualitySettings(.disabled(group: .all))
+                if cachedValue.videoOn {
+                    try? await call.camera.disable()
+                }
+            case .far:
+                if let cachedValue {
+                    if let incomingVideoQualitySettings = cachedValue.incomingVideoQualitySettings {
+                        await call.setIncomingVideoQualitySettings(incomingVideoQualitySettings)
+                    }
+
+                    if cachedValue.videoOn {
+                        try? await call.camera.enable()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -527,9 +527,12 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
 
     /// Updates the call settings from the participants update.
     /// - Parameter participants: The participants to update the call settings from.
+    /// - Note: This is used when the localParticipant gets muted remotely by someone else.
     func updateCallSettingsFromParticipants(_ participants: [CallParticipant]) {
         guard
-            let localParticipant = participants.first(where: { $0.sessionId == sessionID })
+            let localParticipant = participants.first(where: { $0.sessionId == sessionID }),
+            /// Skip updates for the initial period while the connection is established.
+            Date().timeIntervalSince(localParticipant.joinedAt) > 5.0
         else {
             return
         }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -108,7 +108,6 @@ open class CallViewModel: ObservableObject {
     @Published public private(set) var callParticipants = [String: CallParticipant]() {
         didSet {
             updateCallStateIfNeeded()
-            checkCallSettingsForCurrentUser()
         }
     }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -108,6 +108,7 @@ open class CallViewModel: ObservableObject {
     @Published public private(set) var callParticipants = [String: CallParticipant]() {
         didSet {
             updateCallStateIfNeeded()
+            checkCallSettingsForCurrentUser()
         }
     }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -108,7 +108,6 @@ open class CallViewModel: ObservableObject {
     @Published public private(set) var callParticipants = [String: CallParticipant]() {
         didSet {
             updateCallStateIfNeeded()
-            checkCallSettingsForCurrentUser()
         }
     }
 
@@ -878,25 +877,6 @@ open class CallViewModel: ObservableObject {
             if shouldGoInCall, callingState != .inCall {
                 setCallingState(.inCall)
             }
-        }
-    }
-
-    private func checkCallSettingsForCurrentUser() {
-        guard let localParticipant = localParticipant,
-              // Skip updates for the initial period while the connection is established.
-              Date().timeIntervalSince(localParticipant.joinedAt) > 5.0 else {
-            return
-        }
-        if localParticipant.hasAudio != callSettings.audioOn
-            || localParticipant.hasVideo != callSettings.videoOn {
-            let previous = callSettings
-            callSettings = CallSettings(
-                audioOn: localParticipant.hasAudio,
-                videoOn: localParticipant.hasVideo,
-                speakerOn: previous.speakerOn,
-                audioOutputOn: previous.audioOutputOn,
-                cameraPosition: previous.cameraPosition
-            )
         }
     }
 

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -222,8 +222,6 @@
 		4051A2732D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4051A2742D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4052BF552DBA830D0085AFA5 /* MockAppStateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */; };
-		4052BF4F2DBA2AC70085AFA5 /* ProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF4E2DBA2AC70085AFA5 /* ProximityPolicy.swift */; };
-		4052BF532DBA2E510085AFA5 /* VideoProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF522DBA2E510085AFA5 /* VideoProximityPolicy.swift */; };
 		405687AE2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		405687AF2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
@@ -486,6 +484,10 @@
 		40AB356D2B73B7A400E465CC /* DemoCallingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */; };
 		40AB356E2B73B7A400E465CC /* DemoCallingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */; };
 		40AC73B42BE0062B00C57517 /* StreamVideoNoiseCancellation in Frameworks */ = {isa = PBXBuildFile; productRef = 40AC73B32BE0062B00C57517 /* StreamVideoNoiseCancellation */; };
+		40AD64C42DC269E60077AE15 /* ProximityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AD64BD2DC269E60077AE15 /* ProximityMonitor.swift */; };
+		40AD64C52DC269E60077AE15 /* VideoProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AD64C12DC269E60077AE15 /* VideoProximityPolicy.swift */; };
+		40AD64C62DC269E60077AE15 /* ProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AD64BF2DC269E60077AE15 /* ProximityPolicy.swift */; };
+		40AD64C72DC269E60077AE15 /* SpeakerProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AD64C02DC269E60077AE15 /* SpeakerProximityPolicy.swift */; };
 		40ADB8582D64AFDE00B06AAF /* PinInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB8572D64AFDE00B06AAF /* PinInfo.swift */; };
 		40ADB85A2D64AFEC00B06AAF /* Stream_Video_Sfu_Models_Participant+CallParticipant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB8592D64AFEC00B06AAF /* Stream_Video_Sfu_Models_Participant+CallParticipant.swift */; };
 		40ADB85C2D64B00E00B06AAF /* CGSize+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB85B2D64B00E00B06AAF /* CGSize+Hashable.swift */; };
@@ -777,8 +779,8 @@
 		40FE5EBF2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
 		40FE5EC02C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
 		40FE5EC12C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
-		40FEA2C62DA4000A00AC523B /* SpeakerProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FEA2C52DA4000A00AC523B /* SpeakerProximityPolicy.swift */; };
-		40FEA2C92DA4015300AC523B /* ProximityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FEA2C82DA4015300AC523B /* ProximityMonitor.swift */; };
+		40FEA2C62DA4000A00AC523B /* (null) in Sources */ = {isa = PBXBuildFile; };
+		40FEA2C92DA4015300AC523B /* (null) in Sources */ = {isa = PBXBuildFile; };
 		40FF825D2D63527D0029AA80 /* Comparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FF825C2D63527D0029AA80 /* Comparator.swift */; };
 		40FF825F2D63532C0029AA80 /* Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FF825E2D63532C0029AA80 /* Participants.swift */; };
 		40FF82612D6353AB0029AA80 /* Presets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FF82602D6353AB0029AA80 /* Presets.swift */; };
@@ -1751,8 +1753,6 @@
 		4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sendable+Extensions.swift"; sourceTree = "<group>"; };
 		4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomStringConvertible+Conformances.swift"; sourceTree = "<group>"; };
 		4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppStateAdapter.swift; sourceTree = "<group>"; };
-		4052BF4E2DBA2AC70085AFA5 /* ProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityPolicy.swift; sourceTree = "<group>"; };
-		4052BF522DBA2E510085AFA5 /* VideoProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoProximityPolicy.swift; sourceTree = "<group>"; };
 		405687AD2D78A0E700093B98 /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
 		405BFFD12DBB8BE8005B2BE4 /* ProximityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityManager.swift; sourceTree = "<group>"; };
@@ -1938,6 +1938,10 @@
 		40AB34E02C5E73F900B5B6B3 /* Publisher+Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Logger.swift"; sourceTree = "<group>"; };
 		40AB353A2B738B5700E465CC /* DemoSnapshotViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoSnapshotViewModel.swift; sourceTree = "<group>"; };
 		40AB356C2B73B7A400E465CC /* DemoCallingViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCallingViewModifier.swift; sourceTree = "<group>"; };
+		40AD64BD2DC269E60077AE15 /* ProximityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityMonitor.swift; sourceTree = "<group>"; };
+		40AD64BF2DC269E60077AE15 /* ProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityPolicy.swift; sourceTree = "<group>"; };
+		40AD64C02DC269E60077AE15 /* SpeakerProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerProximityPolicy.swift; sourceTree = "<group>"; };
+		40AD64C12DC269E60077AE15 /* VideoProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoProximityPolicy.swift; sourceTree = "<group>"; };
 		40ADB8572D64AFDE00B06AAF /* PinInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinInfo.swift; sourceTree = "<group>"; };
 		40ADB8592D64AFEC00B06AAF /* Stream_Video_Sfu_Models_Participant+CallParticipant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream_Video_Sfu_Models_Participant+CallParticipant.swift"; sourceTree = "<group>"; };
 		40ADB85B2D64B00E00B06AAF /* CGSize+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Hashable.swift"; sourceTree = "<group>"; };
@@ -4127,6 +4131,33 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		40AD64BE2DC269E60077AE15 /* Monitor */ = {
+			isa = PBXGroup;
+			children = (
+				40AD64BD2DC269E60077AE15 /* ProximityMonitor.swift */,
+			);
+			path = Monitor;
+			sourceTree = "<group>";
+		};
+		40AD64C22DC269E60077AE15 /* Policies */ = {
+			isa = PBXGroup;
+			children = (
+				40AD64BF2DC269E60077AE15 /* ProximityPolicy.swift */,
+				40AD64C02DC269E60077AE15 /* SpeakerProximityPolicy.swift */,
+				40AD64C12DC269E60077AE15 /* VideoProximityPolicy.swift */,
+			);
+			path = Policies;
+			sourceTree = "<group>";
+		};
+		40AD64C32DC269E60077AE15 /* Proximity */ = {
+			isa = PBXGroup;
+			children = (
+				40AD64BE2DC269E60077AE15 /* Monitor */,
+				40AD64C22DC269E60077AE15 /* Policies */,
+			);
+			path = Proximity;
+			sourceTree = "<group>";
+		};
 		40ADB85D2D65DFB000B06AAF /* CustomStringInterpolation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5735,6 +5766,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				40AD64C32DC269E60077AE15 /* Proximity */,
 				40FF825B2D63523C0029AA80 /* Sorting */,
 				403A4FE92D660E3E00ECD46A /* Swift6Migration */,
 				40ADB85D2D65DFB000B06AAF /* CustomStringInterpolation */,
@@ -7283,7 +7315,6 @@
 				84DC38CD29ADFCFD00946713 /* SendEventRequest.swift in Sources */,
 				84DC38B029ADFCFD00946713 /* MuteUsersRequest.swift in Sources */,
 				406AF2012AF3D98F00ED4D0C /* SimulatorScreenCapturer.swift in Sources */,
-				4052BF4F2DBA2AC70085AFA5 /* ProximityPolicy.swift in Sources */,
 				84A7E18A2883638200526C98 /* URLSessionWebSocketEngine.swift in Sources */,
 				40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */,
 				4157FF912C9AC9EC0093D839 /* RTMPBroadcastRequest.swift in Sources */,
@@ -7353,7 +7384,7 @@
 				84DC38AC29ADFCFD00946713 /* CallAcceptedEvent.swift in Sources */,
 				84FC2C2828AD350100181490 /* WebRTCEvents.swift in Sources */,
 				40E3635D2D0A17C10028C52A /* CameraVideoOutputHandler.swift in Sources */,
-				40FEA2C92DA4015300AC523B /* ProximityMonitor.swift in Sources */,
+				40FEA2C92DA4015300AC523B /* (null) in Sources */,
 				4159F17B2C86FA41002B94D3 /* RTMPSettingsRequest.swift in Sources */,
 				84DC38A129ADFCFD00946713 /* BlockUserResponse.swift in Sources */,
 				40E363362D09E4C80028C52A /* Stream_Video_Sfu_Models_VideoQuality+Convenience.swift in Sources */,
@@ -7417,7 +7448,7 @@
 				8490032529D308A000AD9BB4 /* GetCallResponse.swift in Sources */,
 				841947982886D9CD0007B36E /* BundleExtensions.swift in Sources */,
 				40483CB82C9B1DEE00B4FCA8 /* WebRTCCoordinatorProviding.swift in Sources */,
-				40FEA2C62DA4000A00AC523B /* SpeakerProximityPolicy.swift in Sources */,
+				40FEA2C62DA4000A00AC523B /* (null) in Sources */,
 				401C1EEB2D4900C500304609 /* ClosedCaptionsAdapter.swift in Sources */,
 				842E70D32B91BE1700D2D68B /* CallRecordingReadyEvent.swift in Sources */,
 				40ADB85A2D64AFEC00B06AAF /* Stream_Video_Sfu_Models_Participant+CallParticipant.swift in Sources */,
@@ -7440,7 +7471,6 @@
 				84A7E1922883647200526C98 /* Event.swift in Sources */,
 				84DC38D629ADFCFD00946713 /* GeofenceSettingsRequest.swift in Sources */,
 				84DC38BB29ADFCFD00946713 /* UnblockUserRequest.swift in Sources */,
-				4052BF532DBA2E510085AFA5 /* VideoProximityPolicy.swift in Sources */,
 				4067F3082CDA32FA002E28BD /* StreamAudioSessionAdapterDelegate.swift in Sources */,
 				84D6494429E9AD08002CA428 /* CallIngressResponse.swift in Sources */,
 				40BBC4C32C6373C4002AEF92 /* WebRTCStateAdapter.swift in Sources */,
@@ -7488,6 +7518,10 @@
 				840042C52A6FED2900917B30 /* IntExtensions.swift in Sources */,
 				406B3BDB2C8F346200FC93A1 /* RTCRtpEncodingParameters+Convenience.swift in Sources */,
 				40BBC4D62C6393A4002AEF92 /* WebRTCCoordinator+Joining.swift in Sources */,
+				40AD64C42DC269E60077AE15 /* ProximityMonitor.swift in Sources */,
+				40AD64C52DC269E60077AE15 /* VideoProximityPolicy.swift in Sources */,
+				40AD64C62DC269E60077AE15 /* ProximityPolicy.swift in Sources */,
+				40AD64C72DC269E60077AE15 /* SpeakerProximityPolicy.swift in Sources */,
 				841BAA3D2BD15CDE000C73E4 /* GetCallStatsResponse.swift in Sources */,
 				842E70D92B91BE1700D2D68B /* CallClosedCaption.swift in Sources */,
 				84FC2C2428AD1B5E00181490 /* WebRTCEventDecoder.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -222,9 +222,12 @@
 		4051A2732D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4051A2742D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4052BF552DBA830D0085AFA5 /* MockAppStateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */; };
+		4052BF4F2DBA2AC70085AFA5 /* ProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF4E2DBA2AC70085AFA5 /* ProximityPolicy.swift */; };
+		4052BF532DBA2E510085AFA5 /* VideoProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF522DBA2E510085AFA5 /* VideoProximityPolicy.swift */; };
 		405687AE2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		405687AF2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
+		405BFFD22DBB8BE8005B2BE4 /* ProximityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405BFFD12DBB8BE8005B2BE4 /* ProximityManager.swift */; };
 		406128812CF32FEF007F5CDC /* SDPLineVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406128802CF32FEF007F5CDC /* SDPLineVisitor.swift */; };
 		406128832CF33000007F5CDC /* SDPParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406128822CF33000007F5CDC /* SDPParser.swift */; };
 		406128882CF33029007F5CDC /* RTPMapVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406128872CF33029007F5CDC /* RTPMapVisitor.swift */; };
@@ -503,6 +506,13 @@
 		40B284E32D52423B0064C1FE /* AVAudioSessionCategory+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B284E22D52423B0064C1FE /* AVAudioSessionCategory+Convenience.swift */; };
 		40B31AA82D10594F005FB448 /* PublishOptions+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B31AA72D10594F005FB448 /* PublishOptions+Dummy.swift */; };
 		40B31AA92D10594F005FB448 /* PublishOptions+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B31AA72D10594F005FB448 /* PublishOptions+Dummy.swift */; };
+		40B3E53C2DBBAF9500DE8F50 /* ProximityMonitor_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E53B2DBBAF9500DE8F50 /* ProximityMonitor_Tests.swift */; };
+		40B3E53E2DBBB0AB00DE8F50 /* CurrentDevice+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E53D2DBBB0AB00DE8F50 /* CurrentDevice+Dummy.swift */; };
+		40B3E5402DBBB6D900DE8F50 /* MockProximityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E53F2DBBB6D900DE8F50 /* MockProximityMonitor.swift */; };
+		40B3E5422DBBB83A00DE8F50 /* ProximityManager_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E5412DBBB83A00DE8F50 /* ProximityManager_Tests.swift */; };
+		40B3E5442DBBB99200DE8F50 /* MockProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E5432DBBB99200DE8F50 /* MockProximityPolicy.swift */; };
+		40B3E5472DBBCB2A00DE8F50 /* VideoProximityPolicy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E5462DBBCB2A00DE8F50 /* VideoProximityPolicy_Tests.swift */; };
+		40B3E5492DBBD2CA00DE8F50 /* SpeakerProximityPolicy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3E5482DBBD2CA00DE8F50 /* SpeakerProximityPolicy_Tests.swift */; };
 		40B48C122D14C43F002C4EAB /* PublishOptions_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B48C112D14C43F002C4EAB /* PublishOptions_Tests.swift */; };
 		40B48C152D14C93B002C4EAB /* CGSize_AdaptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B48C142D14C93B002C4EAB /* CGSize_AdaptTests.swift */; };
 		40B48C172D14C97F002C4EAB /* CGSize_DefaultValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B48C162D14C97F002C4EAB /* CGSize_DefaultValuesTests.swift */; };
@@ -767,6 +777,8 @@
 		40FE5EBF2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
 		40FE5EC02C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
 		40FE5EC12C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FE5EBE2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift */; };
+		40FEA2C62DA4000A00AC523B /* SpeakerProximityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FEA2C52DA4000A00AC523B /* SpeakerProximityPolicy.swift */; };
+		40FEA2C92DA4015300AC523B /* ProximityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FEA2C82DA4015300AC523B /* ProximityMonitor.swift */; };
 		40FF825D2D63527D0029AA80 /* Comparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FF825C2D63527D0029AA80 /* Comparator.swift */; };
 		40FF825F2D63532C0029AA80 /* Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FF825E2D63532C0029AA80 /* Participants.swift */; };
 		40FF82612D6353AB0029AA80 /* Presets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FF82602D6353AB0029AA80 /* Presets.swift */; };
@@ -1739,6 +1751,8 @@
 		4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sendable+Extensions.swift"; sourceTree = "<group>"; };
 		4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomStringConvertible+Conformances.swift"; sourceTree = "<group>"; };
 		4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppStateAdapter.swift; sourceTree = "<group>"; };
+		4052BF4E2DBA2AC70085AFA5 /* ProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityPolicy.swift; sourceTree = "<group>"; };
+		4052BF522DBA2E510085AFA5 /* VideoProximityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoProximityPolicy.swift; sourceTree = "<group>"; };
 		405687AD2D78A0E700093B98 /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
 		405BFFD12DBB8BE8005B2BE4 /* ProximityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityManager.swift; sourceTree = "<group>"; };
@@ -7265,9 +7279,11 @@
 				4061288B2CF33088007F5CDC /* SupportedPrefix.swift in Sources */,
 				40BBC4C02C629408002AEF92 /* RTCTemporaryPeerConnection.swift in Sources */,
 				84B0091B2A4C521100CF1FA7 /* Retries.swift in Sources */,
+				405BFFD22DBB8BE8005B2BE4 /* ProximityManager.swift in Sources */,
 				84DC38CD29ADFCFD00946713 /* SendEventRequest.swift in Sources */,
 				84DC38B029ADFCFD00946713 /* MuteUsersRequest.swift in Sources */,
 				406AF2012AF3D98F00ED4D0C /* SimulatorScreenCapturer.swift in Sources */,
+				4052BF4F2DBA2AC70085AFA5 /* ProximityPolicy.swift in Sources */,
 				84A7E18A2883638200526C98 /* URLSessionWebSocketEngine.swift in Sources */,
 				40C4DF492C1C2C210035DBC2 /* Publisher+WeakAssign.swift in Sources */,
 				4157FF912C9AC9EC0093D839 /* RTMPBroadcastRequest.swift in Sources */,
@@ -7337,6 +7353,7 @@
 				84DC38AC29ADFCFD00946713 /* CallAcceptedEvent.swift in Sources */,
 				84FC2C2828AD350100181490 /* WebRTCEvents.swift in Sources */,
 				40E3635D2D0A17C10028C52A /* CameraVideoOutputHandler.swift in Sources */,
+				40FEA2C92DA4015300AC523B /* ProximityMonitor.swift in Sources */,
 				4159F17B2C86FA41002B94D3 /* RTMPSettingsRequest.swift in Sources */,
 				84DC38A129ADFCFD00946713 /* BlockUserResponse.swift in Sources */,
 				40E363362D09E4C80028C52A /* Stream_Video_Sfu_Models_VideoQuality+Convenience.swift in Sources */,
@@ -7400,6 +7417,7 @@
 				8490032529D308A000AD9BB4 /* GetCallResponse.swift in Sources */,
 				841947982886D9CD0007B36E /* BundleExtensions.swift in Sources */,
 				40483CB82C9B1DEE00B4FCA8 /* WebRTCCoordinatorProviding.swift in Sources */,
+				40FEA2C62DA4000A00AC523B /* SpeakerProximityPolicy.swift in Sources */,
 				401C1EEB2D4900C500304609 /* ClosedCaptionsAdapter.swift in Sources */,
 				842E70D32B91BE1700D2D68B /* CallRecordingReadyEvent.swift in Sources */,
 				40ADB85A2D64AFEC00B06AAF /* Stream_Video_Sfu_Models_Participant+CallParticipant.swift in Sources */,
@@ -7422,6 +7440,7 @@
 				84A7E1922883647200526C98 /* Event.swift in Sources */,
 				84DC38D629ADFCFD00946713 /* GeofenceSettingsRequest.swift in Sources */,
 				84DC38BB29ADFCFD00946713 /* UnblockUserRequest.swift in Sources */,
+				4052BF532DBA2E510085AFA5 /* VideoProximityPolicy.swift in Sources */,
 				4067F3082CDA32FA002E28BD /* StreamAudioSessionAdapterDelegate.swift in Sources */,
 				84D6494429E9AD08002CA428 /* CallIngressResponse.swift in Sources */,
 				40BBC4C32C6373C4002AEF92 /* WebRTCStateAdapter.swift in Sources */,
@@ -7667,6 +7686,7 @@
 				406B3C552C92031000FC93A1 /* WebRTCCoordinatorStateMachine_JoiningStageTests.swift in Sources */,
 				40C9E4642C99886900802B28 /* WebRTCCoorindator_Tests.swift in Sources */,
 				40F017772BBEF43B00E89FD1 /* CallSessionParticipantLeftEvent+Dummy.swift in Sources */,
+				40B3E5442DBBB99200DE8F50 /* MockProximityPolicy.swift in Sources */,
 				40B48C2A2D14CF3B002C4EAB /* MockRTCRtpCodecCapability.swift in Sources */,
 				842747FA29EEEC5A00E063AD /* EventLogger.swift in Sources */,
 				843061002D38203D000E14D5 /* SessionSettingsResponse+Dummy.swift in Sources */,
@@ -7727,16 +7747,19 @@
 				40B48C1A2D14C9BE002C4EAB /* CMVideoDimensions_DefaultValuesTests.swift in Sources */,
 				408CF9C32CAE886D00F56833 /* WebRTCIntegrationTests.swift in Sources */,
 				8414081329F28B5700FF2D7C /* RTCConfiguration_Tests.swift in Sources */,
+				40B3E53C2DBBAF9500DE8F50 /* ProximityMonitor_Tests.swift in Sources */,
 				40F017712BBEF24E00E89FD1 /* CallSettingsResponse+Dummy.swift in Sources */,
 				40E18AB42CD522F700A65C9F /* RecursiveQueueTests.swift in Sources */,
 				40AF6A4B2C9369A900BA2935 /* WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift in Sources */,
 				40B31AA92D10594F005FB448 /* PublishOptions+Dummy.swift in Sources */,
 				842747F129EED88800E063AD /* InternetConnection_Tests.swift in Sources */,
 				40C9E4552C988CE100802B28 /* WebRTCJoinRequestFactory_Tests.swift in Sources */,
+				40B3E53E2DBBB0AB00DE8F50 /* CurrentDevice+Dummy.swift in Sources */,
 				84F58B9329EEB53E00010C4C /* EventMiddleware_Mock.swift in Sources */,
 				40B48C2E2D14D15E002C4EAB /* StreamVideoSfuModelsPublishOption_VideoLayersTests.swift in Sources */,
 				40FE5EBF2C9C82CD006B0881 /* CVPixelBuffer+Convenience.swift in Sources */,
 				403793C92D367F6300C752DF /* ApplicationLifecycleVideoMuteAdapter_Tests.swift in Sources */,
+				40B3E5422DBBB83A00DE8F50 /* ProximityManager_Tests.swift in Sources */,
 				40C75BB72CB4044600C167C3 /* MockThermalStateObserver.swift in Sources */,
 				40AAD1872D2D717300D10330 /* SFUEventBucket_Tests.swift in Sources */,
 				842747EC29EED59000E063AD /* JSONDecoder_Tests.swift in Sources */,
@@ -7748,6 +7771,7 @@
 				40F017422BBEC81C00E89FD1 /* CallKitServiceTests.swift in Sources */,
 				4097B3802BF4B0850057992D /* MockCXProvider.swift in Sources */,
 				406B3C2B2C90601600FC93A1 /* MockLocalMediaAdapter.swift in Sources */,
+				40B3E5402DBBB6D900DE8F50 /* MockProximityMonitor.swift in Sources */,
 				404A812E2DA3C45C001F7FA8 /* CallStateMachine_JoinedStageTests.swift in Sources */,
 				40F0175D2BBEF0E200E89FD1 /* BackstageSettings+Dummy.swift in Sources */,
 				8490032F29D6D00C00AD9BB4 /* CallController_Mock.swift in Sources */,
@@ -7785,6 +7809,7 @@
 				4013A8EF2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift in Sources */,
 				40AB31262A49838000C270E1 /* EventTests.swift in Sources */,
 				84F58B7C29EE979F00010C4C /* VirtualTime.swift in Sources */,
+				40B3E5492DBBD2CA00DE8F50 /* SpeakerProximityPolicy_Tests.swift in Sources */,
 				40F0173E2BBEB86800E89FD1 /* TestsAuthenticationProvider.swift in Sources */,
 				401338762BF2489C007318BD /* MockCXCallController.swift in Sources */,
 				842747FC29EEECBA00E063AD /* AssertTestQueue.swift in Sources */,
@@ -7860,6 +7885,7 @@
 				40AAD1832D2816ED00D10330 /* Stream_Video_Sfu_Event_ChangePublishQuality+Dummy.swift in Sources */,
 				84CC05892A530C3F00EE9815 /* SpeakerManager_Tests.swift in Sources */,
 				8251E62B2A17BEB400E7257A /* StreamVideoTestResources.swift in Sources */,
+				40B3E5472DBBCB2A00DE8F50 /* VideoProximityPolicy_Tests.swift in Sources */,
 				406B3C3F2C919BB300FC93A1 /* MockSFUStack.swift in Sources */,
 				403FB14C2BFE14760047A696 /* Publisher_NextTests.swift in Sources */,
 				84A4DCBB2A41DC6E00B1D1BF /* AsyncAssert.swift in Sources */,

--- a/StreamVideoTests/CallSettings/ProximityManager_Tests.swift
+++ b/StreamVideoTests/CallSettings/ProximityManager_Tests.swift
@@ -24,12 +24,14 @@ final class ProximityManager_Tests: XCTestCase, @unchecked Sendable {
         try await super.setUp()
         _ = mockCurrentDevice
         _ = mockCall
+        CurrentDevice.currentValue = mockCurrentDevice
     }
 
     override func tearDown() async throws {
         subject = nil
         mockCall = nil
         mockCurrentDevice = nil
+        CurrentDevice.currentValue = .init()
         try await super.tearDown()
     }
 

--- a/StreamVideoTests/CallSettings/ProximityManager_Tests.swift
+++ b/StreamVideoTests/CallSettings/ProximityManager_Tests.swift
@@ -1,0 +1,140 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+@MainActor
+final class ProximityManager_Tests: XCTestCase, @unchecked Sendable {
+    private nonisolated(unsafe) static var mockStreamVideo: MockStreamVideo! = .init()
+
+    private var mockCurrentDevice: CurrentDevice! = .dummy { .phone }
+    private lazy var mockCall: MockCall! = .init(.dummy())
+    private lazy var subject: ProximityManager! = .init(mockCall)
+
+    override class func setUp() {
+        super.setUp()
+        _ = mockStreamVideo
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        _ = mockCurrentDevice
+        _ = mockCall
+    }
+
+    override func tearDown() async throws {
+        subject = nil
+        mockCall = nil
+        mockCurrentDevice = nil
+        try await super.tearDown()
+    }
+
+    override class func tearDown() {
+        Self.mockStreamVideo = nil
+        super.tearDown()
+    }
+
+    // MARK: - didUpdateActiveCall
+
+    func test_didUpdateActiveCall_anotherCallIsNowActive_noPolicies_startObservationWasNotCalledOnProximityMonitor() async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        Self.mockStreamVideo.state.activeCall = MockCall(.dummy())
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockProximityMonitor.timesCalled(.startObservation), 0)
+    }
+
+    func test_didUpdateActiveCall_ownCallIsNowActive_noPolicies_startObservationWasNotCalledOnProximityMonitor() async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        Self.mockStreamVideo.state.activeCall = mockCall
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockProximityMonitor.timesCalled(.startObservation), 0)
+    }
+
+    func test_didUpdateActiveCall_anotherCallIsNowActive_withPolicies_startObservationWastCalledOnProximityMonitor() async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        await fulfillment { StreamVideoProviderKey.currentValue != nil }
+        try subject.add(MockProximityPolicy())
+
+        Self.mockStreamVideo.state.activeCall = MockCall(.dummy())
+
+        XCTAssertEqual(mockProximityMonitor.timesCalled(.startObservation), 0)
+    }
+
+    func test_didUpdateActiveCall_ownCallIsNowActive_withPolicies_startObservationWastCalledOnProximityMonitor() async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        _ = subject
+        try subject.add(MockProximityPolicy())
+
+        Self.mockStreamVideo.state.activeCall = mockCall
+
+        await fulfilmentInMainActor { mockProximityMonitor.timesCalled(.startObservation) == 1 }
+    }
+
+    func test_didUpdateActiveCall_ownCallIsNowInactiveAfterBeingActive_withoutPolicies_stopObservationWastNotCalledOnProximityMonitor(
+    ) async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        _ = subject
+        Self.mockStreamVideo.state.activeCall = mockCall
+        await wait(for: 0.25)
+
+        Self.mockStreamVideo.state.activeCall = nil
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockProximityMonitor.timesCalled(.stopObservation), 0)
+    }
+
+    func test_didUpdateActiveCall_ownCallIsNowInactiveAfterBeingActive_withPolicies_stopObservationWastCalledOnProximityMonitor(
+    ) async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        _ = subject
+        try subject.add(MockProximityPolicy())
+        Self.mockStreamVideo.state.activeCall = mockCall
+        await fulfilmentInMainActor { mockProximityMonitor.timesCalled(.startObservation) == 1 }
+
+        Self.mockStreamVideo.state.activeCall = nil
+
+        await fulfilmentInMainActor { mockProximityMonitor.timesCalled(.stopObservation) == 1 }
+    }
+
+    // MARK: - didUpdateProximity
+
+    func test_didUpdateProximity_ownCallIsInactive_didUpdateProximityWasNotCalledOnPolicy() async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        let mockSubject = PassthroughSubject<ProximityState, Never>()
+        mockProximityMonitor.stub(for: \.statePublisher, with: mockSubject.eraseToAnyPublisher())
+        _ = subject
+        let policy = MockProximityPolicy()
+        try subject.add(policy)
+
+        mockSubject.send(.near)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(policy.timesCalled(.didUpdateProximity), 0)
+    }
+
+    func test_didUpdateProximity_ownCallIsActive_didUpdateProximityWasCalledOnPolicies() async throws {
+        let mockProximityMonitor = MockProximityMonitor()
+        let mockSubject = PassthroughSubject<ProximityState, Never>()
+        mockProximityMonitor.stub(for: \.statePublisher, with: mockSubject.eraseToAnyPublisher())
+        _ = subject
+        let policyA = MockProximityPolicy()
+        try subject.add(policyA)
+        Self.mockStreamVideo.state.activeCall = mockCall
+        await fulfilmentInMainActor { mockProximityMonitor.timesCalled(.startObservation) == 1 }
+
+        mockSubject.send(.near)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(policyA.recordedInputPayload((ProximityState, Call).self, for: .didUpdateProximity)?.first?.0, .near)
+        XCTAssertEqual(
+            policyA.recordedInputPayload((ProximityState, Call).self, for: .didUpdateProximity)?.first?.1.cId,
+            mockCall.cId
+        )
+    }
+}

--- a/StreamVideoTests/Mock/CurrentDevice+Dummy.swift
+++ b/StreamVideoTests/Mock/CurrentDevice+Dummy.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+
+extension CurrentDevice {
+    static func dummy(
+        currentDeviceProvider: @MainActor @escaping @Sendable() -> DeviceType
+    ) -> CurrentDevice {
+        .init(currentDeviceProvider: currentDeviceProvider)
+    }
+}

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -11,6 +11,7 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         case join
         case setDisconnectionTimeout
         case observeWebRTCStateUpdated
+        case changeVideoState
     }
 
     enum MockFunctionInputKey: Payloadable {
@@ -26,6 +27,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
 
         case observeWebRTCStateUpdated
 
+        case changeVideoState(Bool)
+
         var payload: Any {
             switch self {
             case let .setDisconnectionTimeout(timeout):
@@ -34,6 +37,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 return (create, callSettings, options, ring, notify)
             case .observeWebRTCStateUpdated:
                 return ()
+            case let .changeVideoState(value):
+                return value
             }
         }
     }
@@ -104,5 +109,10 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
     override func observeWebRTCStateUpdated() {
         stubbedFunctionInput[.observeWebRTCStateUpdated]?
             .append(.observeWebRTCStateUpdated)
+    }
+
+    override func changeVideoState(isEnabled: Bool) async throws {
+        stubbedFunctionInput[.changeVideoState]?
+            .append(.changeVideoState(isEnabled))
     }
 }

--- a/StreamVideoTests/Mock/MockProximityMonitor.swift
+++ b/StreamVideoTests/Mock/MockProximityMonitor.swift
@@ -1,0 +1,67 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+@testable import StreamVideo
+
+final class MockProximityMonitor: ProximityProviding, Mockable {
+
+    // MARK: - Mockable
+
+    typealias FunctionKey = MockFunctionKey
+    typealias FunctionInputKey = MockFunctionInputKey
+    var stubbedProperty: [String: Any] = [:]
+    var stubbedFunction: [FunctionKey: Any] = [:]
+    @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey
+        .allCases
+        .reduce(into: [FunctionKey: [FunctionInputKey]]()) { $0[$1] = [] }
+    func stub<T>(for keyPath: KeyPath<MockProximityMonitor, T>, with value: T) {
+        stubbedProperty[propertyKey(for: keyPath)] = value
+    }
+
+    func stub<T>(for function: FunctionKey, with value: T) {}
+
+    enum MockFunctionKey: Hashable, CaseIterable {
+        case startObservation, stopObservation
+    }
+
+    enum MockFunctionInputKey: Hashable, CaseIterable, Payloadable {
+        case startObservation, stopObservation
+
+        var payload: Any {
+            ()
+        }
+    }
+
+    var state: ProximityState {
+        get { self[dynamicMember: \.state] }
+        set { _ = newValue }
+    }
+
+    var statePublisher: AnyPublisher<ProximityState, Never> {
+        get { self[dynamicMember: \.statePublisher] }
+        set { _ = newValue }
+    }
+
+    var isActive: Bool {
+        get { self[dynamicMember: \.isActive] }
+        set { _ = newValue }
+    }
+
+    init() {
+        ProximityProviderKey.currentValue = self
+        stub(for: \.state, with: .far)
+        stub(for: \.statePublisher, with: Just(ProximityState.far).eraseToAnyPublisher())
+        stub(for: \.isActive, with: false)
+    }
+
+    func startObservation() {
+        stubbedFunctionInput[.startObservation]?.append(.startObservation)
+    }
+    
+    func stopObservation() {
+        stubbedFunctionInput[.stopObservation]?.append(.stopObservation)
+    }
+}

--- a/StreamVideoTests/Mock/MockProximityPolicy.swift
+++ b/StreamVideoTests/Mock/MockProximityPolicy.swift
@@ -1,0 +1,53 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+
+final class MockProximityPolicy: ProximityPolicy, Mockable, @unchecked Sendable {
+
+    // MARK: - Mockable
+
+    typealias FunctionKey = MockFunctionKey
+    typealias FunctionInputKey = MockFunctionInputKey
+    var stubbedProperty: [String: Any] = [:]
+    var stubbedFunction: [FunctionKey: Any] = [:]
+    @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey
+        .allCases
+        .reduce(into: [FunctionKey: [FunctionInputKey]]()) { $0[$1] = [] }
+    func stub<T>(for keyPath: KeyPath<MockProximityPolicy, T>, with value: T) {
+        stubbedProperty[propertyKey(for: keyPath)] = value
+    }
+
+    func stub<T>(for function: FunctionKey, with value: T) {}
+
+    enum MockFunctionKey: Hashable, CaseIterable {
+        case didUpdateProximity
+    }
+
+    enum MockFunctionInputKey: Payloadable {
+        case didUpdateProximity(proximityState: ProximityState, call: Call)
+
+        var payload: Any {
+            switch self {
+            case let .didUpdateProximity(proximityState, call):
+                return (proximityState, call)
+            }
+        }
+    }
+
+    static let identifier: ObjectIdentifier = .init(String.unique as NSString)
+
+    func didUpdateProximity(
+        _ proximity: ProximityState,
+        on call: Call
+    ) {
+        stubbedFunctionInput[.didUpdateProximity]?.append(
+            .didUpdateProximity(
+                proximityState: proximity,
+                call: call
+            )
+        )
+    }
+}

--- a/StreamVideoTests/Utils/Proximity/Monitor/ProximityMonitor_Tests.swift
+++ b/StreamVideoTests/Utils/Proximity/Monitor/ProximityMonitor_Tests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamVideo
+import XCTest
+
+final class ProximityMonitor_Tests: XCTestCase, @unchecked Sendable {
+    private lazy var subject: ProximityMonitor! = ProximityMonitor()
+
+    override func tearDown() async throws {
+        subject = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Initialization Tests
+
+    func test_init_initialStateIsFar() {
+        XCTAssertEqual(subject.state, .far)
+    }
+
+    // MARK: - Observation Tests
+
+    // MARK: startObservation
+
+    func test_startObservation_deviceTypeIsUnspecified_isActiveFalse() async {
+        await assertIsActive(for: .unspecified, expected: false)
+    }
+
+    func test_startObservation_deviceTypeIsPhone_isActiveTrue() async {
+        await assertIsActive(for: .phone, expected: true)
+    }
+
+    func test_startObservation_deviceTypeIsPad_isActiveFalse() async {
+        await assertIsActive(for: .pad, expected: false)
+    }
+
+    func test_startObservation_deviceTypeIsTV_isActiveFalse() async {
+        await assertIsActive(for: .tv, expected: false)
+    }
+
+    func test_startObservation_deviceTypeIsCarPlay_isActiveFalse() async {
+        await assertIsActive(for: .carPlay, expected: false)
+    }
+
+    func test_startObservation_deviceTypeIsMac_isActiveFalse() async {
+        await assertIsActive(for: .mac, expected: false)
+    }
+
+    func test_startObservation_deviceTypeIsVision_isActiveFalse() async {
+        await assertIsActive(for: .vision, expected: false)
+    }
+
+    // MARK: stopObservation
+
+    @MainActor
+    func test_stopObservation_isActiveBecomesFalse() async {
+        CurrentDevice.currentValue = .dummy { .phone }
+        await fulfillment { CurrentDevice.currentValue.deviceType == .phone }
+
+        subject.startObservation()
+        XCTAssertTrue(subject.isActive)
+
+        subject.stopObservation()
+
+        XCTAssertFalse(subject.isActive)
+    }
+
+    // MARK: - Private Helpers
+
+    private func assertIsActive(
+        for deviceType: CurrentDevice.DeviceType,
+        expected: Bool,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) async {
+        CurrentDevice.currentValue = .dummy { deviceType }
+        await fulfillment { CurrentDevice.currentValue.deviceType == deviceType }
+        _ = subject
+
+        await subject.startObservation()
+
+        await fulfilmentInMainActor { self.subject.isActive == expected }
+    }
+}

--- a/StreamVideoTests/Utils/Proximity/Policies/SpeakerProximityPolicy_Tests.swift
+++ b/StreamVideoTests/Utils/Proximity/Policies/SpeakerProximityPolicy_Tests.swift
@@ -1,14 +1,11 @@
 //
-//  VideoProximityPolicy_Tests.swift
-//  StreamVideoTests
-//
-//  Created by Ilias Pavlidakis on 25/4/25.
+// Copyright © 2025 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 import Foundation
 @testable import StreamVideo
 import XCTest
-import AVFoundation
 
 @MainActor
 final class SpeakerProximityPolicy_Tests: XCTestCase, @unchecked Sendable {

--- a/StreamVideoTests/Utils/Proximity/Policies/SpeakerProximityPolicy_Tests.swift
+++ b/StreamVideoTests/Utils/Proximity/Policies/SpeakerProximityPolicy_Tests.swift
@@ -1,0 +1,73 @@
+//
+//  VideoProximityPolicy_Tests.swift
+//  StreamVideoTests
+//
+//  Created by Ilias Pavlidakis on 25/4/25.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+import AVFoundation
+
+@MainActor
+final class SpeakerProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
+
+    private lazy var mockAudioSession: MockAudioSession! = .init()
+    private lazy var mockCall: MockCall! = .init(.dummy())
+    private lazy var subject: SpeakerProximityPolicy! = .init()
+
+    override func setUp() async throws {
+        try await super.setUp()
+        _ = mockCall
+        await wait(for: 0.25)
+        StreamAudioSession.currentValue = .init(audioSession: mockAudioSession)
+    }
+
+    override func tearDown() async throws {
+        subject = nil
+        mockCall = nil
+        mockAudioSession = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - didUpdateProximity
+
+    func test_didUpdateProximity_near_currentRouteIsNotExternal_speakerOnTrue_callSettingsUpdatedToSpeakerOnFalse() async {
+        mockCall.state.callSettings = .init(speakerOn: true)
+
+        subject.didUpdateProximity(.near, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertFalse(mockCall.state.callSettings.speakerOn)
+    }
+
+    func test_didUpdateProximity_near_currentRouteIsNotExternal_speakerOnFalse_nothingHappens() async {
+        mockCall.state.callSettings = .init(speakerOn: false)
+
+        subject.didUpdateProximity(.near, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertFalse(mockCall.state.callSettings.speakerOn)
+    }
+
+    func test_didUpdateProximity_far_callSettingsBeforeProximityChangeIsNil_nothingHappens() async {
+        mockCall.state.callSettings = .init(speakerOn: false)
+
+        subject.didUpdateProximity(.far, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertFalse(mockCall.state.callSettings.speakerOn)
+    }
+
+    func test_didUpdateProximity_far_callSettingsBeforeProximityChangeIsNotNil_callSettingsRestored() async {
+        mockCall.state.callSettings = .init(speakerOn: true)
+
+        subject.didUpdateProximity(.near, on: mockCall)
+        await wait(for: 0.25)
+        subject.didUpdateProximity(.far, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertTrue(mockCall.state.callSettings.speakerOn)
+    }
+}

--- a/StreamVideoTests/Utils/Proximity/Policies/VideoProximityPolicy_Tests.swift
+++ b/StreamVideoTests/Utils/Proximity/Policies/VideoProximityPolicy_Tests.swift
@@ -1,0 +1,117 @@
+//
+//  VideoProximityPolicy_Tests.swift
+//  StreamVideoTests
+//
+//  Created by Ilias Pavlidakis on 25/4/25.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+@MainActor
+final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
+
+    private lazy var mockCallController: MockCallController! = .init()
+    private lazy var mockCall: MockCall! = .init(.dummy(callController: mockCallController))
+    private lazy var subject: VideoProximityPolicy! = .init()
+
+    override func setUp() async throws {
+        try await super.setUp()
+        _ = mockCall
+    }
+
+    override func tearDown() async throws {
+        subject = nil
+        mockCall = nil
+        mockCallController = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - didUpdateProximity
+
+    func test_didUpdateProximity_near_videoFalse_incomingVideoQualitySettingsNone_nothingHappens() async {
+        mockCall.state.callSettings = .init(videoOn: false)
+        mockCall.state.incomingVideoQualitySettings = .none
+
+        subject.didUpdateProximity(.near, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 0)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .disabled(group: .all))
+    }
+
+    func test_didUpdateProximity_near_videoTrue_incomingVideoQualitySettingsNone_incomingVideoQualitySettingsAndCameraDisabled() async{
+        mockCall.state.callSettings = .init(videoOn: true)
+        mockCall.state.incomingVideoQualitySettings = .none
+
+        subject.didUpdateProximity(.near, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 1)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .disabled(group: .all))
+    }
+
+    func test_didUpdateProximity_near_videoFalse_incomingVideoQualitySettingsOtherThanNone_incomingVideoQualitySettingsAndCameraDisabled() async{
+        mockCall.state.callSettings = .init(videoOn: false)
+        mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
+
+        subject.didUpdateProximity(.near, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 0)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .disabled(group: .all))
+    }
+
+    func test_didUpdateProximity_far_noCachedValue_nothingHappens() async{
+        mockCall.state.callSettings = .init(videoOn: false)
+        mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
+
+        subject.didUpdateProximity(.far, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 0)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .manual(group: .all, targetSize: .quarter))
+    }
+
+    func test_didUpdateProximity_far_cachedValueWithIncomingQualitySettingsAndVideoOff_incomingVideoQualitySettingsUpdated() async{
+        mockCall.state.callSettings = .init(videoOn: false)
+        mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
+
+        subject.didUpdateProximity(.near, on: mockCall)
+        await wait(for: 0.25)
+        subject.didUpdateProximity(.far, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 0)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .manual(group: .all, targetSize: .quarter))
+    }
+
+    func test_didUpdateProximity_far_cachedValueWithoutIncomingQualitySettingsAndVideoOn_videoWasUpdated() async{
+        mockCall.state.callSettings = .init(videoOn: true)
+        mockCall.state.incomingVideoQualitySettings = .none
+
+        subject.didUpdateProximity(.near, on: mockCall)
+        await wait(for: 0.25)
+        subject.didUpdateProximity(.far, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 2)
+        XCTAssertEqual(mockCallController.recordedInputPayload(Bool.self, for: .changeVideoState)?.last, true)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .none)
+    }
+
+    func test_didUpdateProximity_far_cachedValueWithIncomingQualitySettingsAndVideoOn_incomingVideoQualitySettingsAndVideoWereUpdated() async{
+        mockCall.state.callSettings = .init(videoOn: true)
+        mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
+
+        subject.didUpdateProximity(.near, on: mockCall)
+        await wait(for: 0.25)
+        subject.didUpdateProximity(.far, on: mockCall)
+
+        await wait(for: 0.25)
+        XCTAssertEqual(mockCallController.timesCalled(.changeVideoState), 2)
+        XCTAssertEqual(mockCallController.recordedInputPayload(Bool.self, for: .changeVideoState)?.last, true)
+        XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .manual(group: .all, targetSize: .quarter))
+    }
+}

--- a/StreamVideoTests/Utils/Proximity/Policies/VideoProximityPolicy_Tests.swift
+++ b/StreamVideoTests/Utils/Proximity/Policies/VideoProximityPolicy_Tests.swift
@@ -1,8 +1,5 @@
 //
-//  VideoProximityPolicy_Tests.swift
-//  StreamVideoTests
-//
-//  Created by Ilias Pavlidakis on 25/4/25.
+// Copyright © 2025 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -41,7 +38,8 @@ final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .disabled(group: .all))
     }
 
-    func test_didUpdateProximity_near_videoTrue_incomingVideoQualitySettingsNone_incomingVideoQualitySettingsAndCameraDisabled() async{
+    func test_didUpdateProximity_near_videoTrue_incomingVideoQualitySettingsNone_incomingVideoQualitySettingsAndCameraDisabled(
+    ) async {
         mockCall.state.callSettings = .init(videoOn: true)
         mockCall.state.incomingVideoQualitySettings = .none
 
@@ -52,7 +50,8 @@ final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .disabled(group: .all))
     }
 
-    func test_didUpdateProximity_near_videoFalse_incomingVideoQualitySettingsOtherThanNone_incomingVideoQualitySettingsAndCameraDisabled() async{
+    func test_didUpdateProximity_near_videoFalse_incomingVideoQualitySettingsOtherThanNone_incomingVideoQualitySettingsAndCameraDisabled(
+    ) async {
         mockCall.state.callSettings = .init(videoOn: false)
         mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
 
@@ -63,7 +62,7 @@ final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .disabled(group: .all))
     }
 
-    func test_didUpdateProximity_far_noCachedValue_nothingHappens() async{
+    func test_didUpdateProximity_far_noCachedValue_nothingHappens() async {
         mockCall.state.callSettings = .init(videoOn: false)
         mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
 
@@ -74,7 +73,7 @@ final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .manual(group: .all, targetSize: .quarter))
     }
 
-    func test_didUpdateProximity_far_cachedValueWithIncomingQualitySettingsAndVideoOff_incomingVideoQualitySettingsUpdated() async{
+    func test_didUpdateProximity_far_cachedValueWithIncomingQualitySettingsAndVideoOff_incomingVideoQualitySettingsUpdated() async {
         mockCall.state.callSettings = .init(videoOn: false)
         mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
 
@@ -87,7 +86,7 @@ final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .manual(group: .all, targetSize: .quarter))
     }
 
-    func test_didUpdateProximity_far_cachedValueWithoutIncomingQualitySettingsAndVideoOn_videoWasUpdated() async{
+    func test_didUpdateProximity_far_cachedValueWithoutIncomingQualitySettingsAndVideoOn_videoWasUpdated() async {
         mockCall.state.callSettings = .init(videoOn: true)
         mockCall.state.incomingVideoQualitySettings = .none
 
@@ -101,7 +100,8 @@ final class VideoProximityPolicy_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockCall.state.incomingVideoQualitySettings, .none)
     }
 
-    func test_didUpdateProximity_far_cachedValueWithIncomingQualitySettingsAndVideoOn_incomingVideoQualitySettingsAndVideoWereUpdated() async{
+    func test_didUpdateProximity_far_cachedValueWithIncomingQualitySettingsAndVideoOn_incomingVideoQualitySettingsAndVideoWereUpdated(
+    ) async {
         mockCall.state.callSettings = .init(videoOn: true)
         mockCall.state.incomingVideoQualitySettings = .manual(group: .all, targetSize: .quarter)
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -731,6 +731,54 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - updateCallSettingsFromParticipants
+
+    func test_updateCallSettingsFromParticipants_localParticipantHasNoChanges_callSettingsNotChange() async {
+        let sessionID = await subject.sessionID
+        await subject.set(callSettings: .init(audioOn: true, videoOn: true))
+        let initialParticipants: [String: CallParticipant] = [
+            sessionID: .dummy(id: sessionID, hasVideo: true, hasAudio: true),
+            "2": .dummy(id: "2"),
+            "3": .dummy(id: "3")
+        ]
+
+        await subject.enqueue { _ in initialParticipants }
+
+        await subject.enqueue { _ in
+            [sessionID: .dummy(id: sessionID, hasVideo: true, hasAudio: true)]
+        }
+
+        await fulfillment {
+            let participants = await self.subject.participants
+            return participants.count == 1
+        }
+        await assertTrueAsync(await subject.callSettings.audioOn)
+        await assertTrueAsync(await subject.callSettings.videoOn)
+    }
+
+    func test_updateCallSettingsFromParticipants_localParticipantHasChanges_callSettingsWereUpdatedAsExpected() async {
+        let sessionID = await subject.sessionID
+        await subject.set(callSettings: .init(audioOn: true, videoOn: true))
+        let initialParticipants: [String: CallParticipant] = [
+            sessionID: .dummy(id: sessionID, hasVideo: true, hasAudio: true),
+            "2": .dummy(id: "2"),
+            "3": .dummy(id: "3")
+        ]
+
+        await subject.enqueue { _ in initialParticipants }
+
+        await subject.enqueue { _ in
+            [sessionID: .dummy(id: sessionID, hasVideo: false, hasAudio: true)]
+        }
+
+        await fulfillment {
+            let participants = await self.subject.participants
+            return participants.count == 1
+        }
+        await assertTrueAsync(await subject.callSettings.audioOn)
+        await assertFalseAsync(await subject.callSettings.videoOn)
+    }
+
     // MARK: - Private helpers
 
     private func assertNilAsync<T>(
@@ -760,6 +808,15 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
     ) async rethrows {
         let value = try await expression()
         XCTAssertTrue(value, file: file, line: line)
+    }
+
+    private func assertFalseAsync(
+        _ expression: @autoclosure () async throws -> Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async rethrows {
+        let value = try await expression()
+        XCTAssertFalse(value, file: file, line: line)
     }
 
     private func prepare(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-827/[feature-request]proximity-for-calls

### 🎯 Goal

Provide proximity based operations during a call.

### Documentation

- https://github.com/GetStream/docs-content/pull/321

### 🛠 Implementation

We introduce a new protocol `ProximityPolicy` that can be used to define what will happen when the device's proximity change during a call. You can attach `ProximityPolicy` instances on any Call object.

Out of the box, the SDK ships with the following `ProximityPolicy` implementations:
- `SpeakerProximityPolicy`: If speaker is enabled when proximity changes to `near` the policy will switch to earpiece. It will then restore speaker when proximity changes to `far`.
- `VideoProximityPolicy`: The policy disables all video (remote and local) when proximity changes to `near` and restores everything back when proximity changes to `far`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)