### PR TITLE
[Fix]AudioSession disabling speaker when video is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix an issue causing audio/video misalignment with the server. [#772](https://github.com/GetStream/stream-video-swift/pull/772)
+- Fix an issue causing the speaker to mute when video was off. [#771](https://github.com/GetStream/stream-video-swift/pull/771)
 
 # [1.21.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.21.0)
 _April 22, 2025_

--- a/Sources/StreamVideo/Models/CallSettings.swift
+++ b/Sources/StreamVideo/Models/CallSettings.swift
@@ -72,7 +72,7 @@ public final class CallSettings: ObservableObject, Sendable, Equatable, Reflecti
         }
 
         log.debug(
-            "CallSettings created.",
+            "Created \(self)",
             functionName: function,
             fileName: file,
             lineNumber: line

--- a/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.CategoryOptions+Convenience.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.CategoryOptions+Convenience.swift
@@ -8,13 +8,21 @@ import StreamWebRTC
 extension AVAudioSession.CategoryOptions {
 
     /// Category options for play and record.
-    static func playAndRecord(videoOn: Bool, speakerOn: Bool, appIsInForeground: Bool) -> AVAudioSession.CategoryOptions {
+    static func playAndRecord(
+        videoOn: Bool,
+        speakerOn: Bool,
+        appIsInForeground: Bool
+    ) -> AVAudioSession.CategoryOptions {
         var result: AVAudioSession.CategoryOptions = [
             .allowBluetooth,
             .allowBluetoothA2DP,
             .allowAirPlay
         ]
 
+        /// - Note:We only add the `defaultToSpeaker` if the following are true:
+        /// - It's required (speakerOn = true)
+        /// - The app is foregrounded. The reason is that while in CallKit port overrides are being treated
+        /// as hard overrides and stop CallKit Speaker button from allowing the user to toggle it off.
         if !videoOn, speakerOn, appIsInForeground {
             result.insert(.defaultToSpeaker)
         }

--- a/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.CategoryOptions+Convenience.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.CategoryOptions+Convenience.swift
@@ -23,7 +23,7 @@ extension AVAudioSession.CategoryOptions {
         /// - It's required (speakerOn = true)
         /// - The app is foregrounded. The reason is that while in CallKit port overrides are being treated
         /// as hard overrides and stop CallKit Speaker button from allowing the user to toggle it off.
-        if !videoOn, speakerOn, appIsInForeground {
+        if videoOn == false, speakerOn == true, appIsInForeground == true {
             result.insert(.defaultToSpeaker)
         }
 

--- a/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.CategoryOptions+Convenience.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.CategoryOptions+Convenience.swift
@@ -8,11 +8,19 @@ import StreamWebRTC
 extension AVAudioSession.CategoryOptions {
 
     /// Category options for play and record.
-    static let playAndRecord: AVAudioSession.CategoryOptions = [
-        .allowBluetooth,
-        .allowBluetoothA2DP,
-        .allowAirPlay
-    ]
+    static func playAndRecord(videoOn: Bool, speakerOn: Bool, appIsInForeground: Bool) -> AVAudioSession.CategoryOptions {
+        var result: AVAudioSession.CategoryOptions = [
+            .allowBluetooth,
+            .allowBluetoothA2DP,
+            .allowAirPlay
+        ]
+
+        if !videoOn, speakerOn, appIsInForeground {
+            result.insert(.defaultToSpeaker)
+        }
+
+        return result
+    }
 
     /// Category options for playback.
     static let playback: AVAudioSession.CategoryOptions = []

--- a/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
@@ -7,6 +7,8 @@ import AVFoundation
 /// A default implementation of the `AudioSessionPolicy` protocol.
 public struct DefaultAudioSessionPolicy: AudioSessionPolicy {
 
+    @Injected(\.applicationStateAdapter) private var applicationStateAdapter
+
     /// Initializes a new `DefaultAudioSessionPolicy` instance.
     public init() {}
 
@@ -24,7 +26,11 @@ public struct DefaultAudioSessionPolicy: AudioSessionPolicy {
         .init(
             category: .playAndRecord,
             mode: callSettings.videoOn ? .videoChat : .voiceChat,
-            options: .playAndRecord,
+            options: .playAndRecord(
+                videoOn: callSettings.videoOn,
+                speakerOn: callSettings.speakerOn,
+                appIsInForeground: applicationStateAdapter.state == .foreground
+            ),
             overrideOutputAudioPort: callSettings.speakerOn ? .speaker : AVAudioSession.PortOverride.none
         )
     }

--- a/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
@@ -38,7 +38,7 @@ public struct DefaultAudioSessionPolicy: AudioSessionPolicy {
 
         return .init(
             category: .playAndRecord,
-            mode: callSettings.videoOn ? .videoChat : .voiceChat,
+            mode: callSettings.videoOn && callSettings.speakerOn ? .videoChat : .voiceChat,
             options: .playAndRecord(
                 videoOn: callSettings.videoOn,
                 speakerOn: callSettings.speakerOn,

--- a/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
@@ -23,13 +23,26 @@ public struct DefaultAudioSessionPolicy: AudioSessionPolicy {
         for callSettings: CallSettings,
         ownCapabilities: Set<OwnCapability>
     ) -> AudioSessionConfiguration {
-        .init(
+        guard applicationStateAdapter.state == .foreground else {
+            return .init(
+                category: .playAndRecord,
+                mode: callSettings.videoOn ? .videoChat : .voiceChat,
+                options: .playAndRecord(
+                    videoOn: callSettings.videoOn,
+                    speakerOn: callSettings.speakerOn,
+                    appIsInForeground: false
+                ),
+                overrideOutputAudioPort: nil
+            )
+        }
+
+        return .init(
             category: .playAndRecord,
             mode: callSettings.videoOn ? .videoChat : .voiceChat,
             options: .playAndRecord(
                 videoOn: callSettings.videoOn,
                 speakerOn: callSettings.speakerOn,
-                appIsInForeground: applicationStateAdapter.state == .foreground
+                appIsInForeground: true
             ),
             overrideOutputAudioPort: callSettings.speakerOn ? .speaker : AVAudioSession.PortOverride.none
         )

--- a/Sources/StreamVideo/Utils/AudioSession/Policies/OwnCapabilitiesAudioSessionPolicy.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Policies/OwnCapabilitiesAudioSessionPolicy.swift
@@ -19,6 +19,8 @@ import Foundation
 /// - Otherwise we use `playback` category.
 public struct OwnCapabilitiesAudioSessionPolicy: AudioSessionPolicy {
 
+    @Injected(\.applicationStateAdapter) private var applicationStateAdapter
+
     private let currentDevice = CurrentDevice.currentValue
 
     /// Initializes a new `OwnCapabilitiesAudioSessionPolicy` instance.
@@ -52,11 +54,15 @@ public struct OwnCapabilitiesAudioSessionPolicy: AudioSessionPolicy {
             : .playback
 
         let mode: AVAudioSession.Mode = category == .playAndRecord
-            ? callSettings.videoOn ? .videoChat : .voiceChat
+            ? callSettings.videoOn && callSettings.speakerOn ? .videoChat : .voiceChat
             : .default
 
         let categoryOptions: AVAudioSession.CategoryOptions = category == .playAndRecord
-            ? .playAndRecord
+            ? .playAndRecord(
+                videoOn: callSettings.videoOn,
+                speakerOn: callSettings.speakerOn,
+                appIsInForeground: applicationStateAdapter.state == .foreground
+            )
             : .playback
 
         let overrideOutputAudioPort: AVAudioSession.PortOverride? = category == .playAndRecord

--- a/Sources/StreamVideo/Utils/AudioSession/Policies/OwnCapabilitiesAudioSessionPolicy.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Policies/OwnCapabilitiesAudioSessionPolicy.swift
@@ -65,7 +65,8 @@ public struct OwnCapabilitiesAudioSessionPolicy: AudioSessionPolicy {
             )
             : .playback
 
-        let overrideOutputAudioPort: AVAudioSession.PortOverride? = category == .playAndRecord
+        let overrideOutputAudioPort: AVAudioSession.PortOverride? = category == .playAndRecord && applicationStateAdapter
+            .state == .foreground
             ? callSettings.speakerOn == true ? .speaker : AVAudioSession.PortOverride.none
             : nil
 

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
@@ -11,6 +11,8 @@ import StreamWebRTC
 /// and routing to output devices such as speakers and in-ear speakers.
 final class StreamAudioSession: @unchecked Sendable, ObservableObject {
 
+    @Injected(\.applicationStateAdapter) private var applicationStateAdapter
+
     /// The last applied audio session configuration.
     private var lastUsedConfiguration: AudioSessionConfiguration?
 
@@ -365,7 +367,7 @@ final class StreamAudioSession: @unchecked Sendable, ObservableObject {
                 )
             }
 
-            if let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
+            if applicationStateAdapter.state == .foreground, let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
                 try await audioSession.overrideOutputAudioPort(overrideOutputAudioPort)
             }
 

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
@@ -11,8 +11,6 @@ import StreamWebRTC
 /// and routing to output devices such as speakers and in-ear speakers.
 final class StreamAudioSession: @unchecked Sendable, ObservableObject {
 
-    @Injected(\.applicationStateAdapter) private var applicationStateAdapter
-
     /// The last applied audio session configuration.
     private var lastUsedConfiguration: AudioSessionConfiguration?
 
@@ -367,8 +365,7 @@ final class StreamAudioSession: @unchecked Sendable, ObservableObject {
                 )
             }
 
-            if
-                let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
+            if let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
                 try await audioSession.overrideOutputAudioPort(overrideOutputAudioPort)
             }
 

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
@@ -367,7 +367,8 @@ final class StreamAudioSession: @unchecked Sendable, ObservableObject {
                 )
             }
 
-            if applicationStateAdapter.state == .foreground, let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
+            if
+                let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
                 try await audioSession.overrideOutputAudioPort(overrideOutputAudioPort)
             }
 

--- a/Sources/StreamVideo/Utils/StreamAppStateAdapter/StreamAppStateAdapter.swift
+++ b/Sources/StreamVideo/Utils/StreamAppStateAdapter/StreamAppStateAdapter.swift
@@ -8,14 +8,21 @@ import Foundation
 import UIKit
 #endif
 
-/// An adapter that observes the app's state and publishes changes.
-public final class StreamAppStateAdapter: ObservableObject, @unchecked Sendable {
+public protocol AppStateProviding: Sendable {
+    var state: ApplicationState { get }
 
-    /// Represents the app's state: foreground or background.
-    public enum State: Sendable, Equatable { case foreground, background }
+    var statePublisher: AnyPublisher<ApplicationState, Never> { get }
+}
+
+/// Represents the app's state: foreground or background.
+public enum ApplicationState: Sendable, Equatable { case foreground, background }
+
+/// An adapter that observes the app's state and publishes changes.
+final class StreamAppStateAdapter: AppStateProviding, ObservableObject, @unchecked Sendable {
 
     /// The current state of the app.
-    @Published public private(set) var state: State = .foreground
+    @Published public private(set) var state: ApplicationState = .foreground
+    var statePublisher: AnyPublisher<ApplicationState, Never> { $state.eraseToAnyPublisher() }
 
     private let notificationCenter: NotificationCenter
     private let disposableBag = DisposableBag()
@@ -36,14 +43,14 @@ public final class StreamAppStateAdapter: ObservableObject, @unchecked Sendable 
             /// Observes app state changes to update the `state` property.
             notificationCenter
                 .publisher(for: UIApplication.willEnterForegroundNotification)
-                .map { _ in State.foreground }
+                .map { _ in ApplicationState.foreground }
                 .receive(on: DispatchQueue.main)
                 .assign(to: \.state, onWeak: self)
                 .store(in: disposableBag)
 
             notificationCenter
                 .publisher(for: UIApplication.didEnterBackgroundNotification)
-                .map { _ in State.background }
+                .map { _ in ApplicationState.background }
                 .receive(on: DispatchQueue.main)
                 .assign(to: \.state, onWeak: self)
                 .store(in: disposableBag)
@@ -54,17 +61,17 @@ public final class StreamAppStateAdapter: ObservableObject, @unchecked Sendable 
     }
 }
 
-extension StreamAppStateAdapter: InjectionKey {
-    nonisolated(unsafe) public static var currentValue: StreamAppStateAdapter = .init()
+enum AppStateProviderKey: InjectionKey {
+    nonisolated(unsafe) public static var currentValue: AppStateProviding = StreamAppStateAdapter()
 }
 
 extension InjectedValues {
-    public var applicationStateAdapter: StreamAppStateAdapter {
+    public var applicationStateAdapter: AppStateProviding {
         get {
-            Self[StreamAppStateAdapter.self]
+            Self[AppStateProviderKey.self]
         }
         set {
-            Self[StreamAppStateAdapter.self] = newValue
+            Self[AppStateProviderKey.self] = newValue
         }
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/Utilities/ApplicationLifecycleVideoMuteAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/Utilities/ApplicationLifecycleVideoMuteAdapter.swift
@@ -56,7 +56,7 @@ final class ApplicationLifecycleVideoMuteAdapter {
             return
         }
         applicationStateAdapter
-            .$state
+            .statePublisher
             .filter { $0 == .background }
             .log(.debug, subsystems: .webRTC) { "Application state changed to \($0) and we are going to mute the video track." }
             .sinkTask { [weak sfuAdapter, sessionID] _ in
@@ -69,7 +69,7 @@ final class ApplicationLifecycleVideoMuteAdapter {
             .store(in: disposableBag)
 
         applicationStateAdapter
-            .$state
+            .statePublisher
             .filter { $0 == .foreground }
             .log(.debug, subsystems: .webRTC) { "Application state changed to \($0) and we are going to unmute the video track." }
             .sinkTask { [weak sfuAdapter, sessionID] _ in

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -906,7 +906,7 @@ open class CallViewModel: ObservableObject {
 
     private func subscribeToApplicationLifecycleEvents() {
         applicationLifecycleUpdates = applicationStateAdapter
-            .$state
+            .statePublisher
             .filter { $0 == .foreground }
             .sink { [weak self] _ in self?.applicationDidBecomeActive() }
     }

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureController.swift
@@ -67,7 +67,7 @@ final class PictureInPictureController: @unchecked Sendable {
 
         // Add delay to prevent premature cancellation
         applicationStateAdapter
-            .$state
+            .statePublisher
             .filter { $0 == .foreground }
             .debounce(for: .milliseconds(250), scheduler: RunLoop.main)
             .receive(on: DispatchQueue.main)

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		4051A26F2D665B03000C3167 /* Sendable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */; };
 		4051A2732D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4051A2742D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
+		4052BF552DBA830D0085AFA5 /* MockAppStateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */; };
 		405687AE2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		405687AF2D78A0E700093B98 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405687AD2D78A0E700093B98 /* QRCodeView.swift */; };
 		4059C3422AAF0CE40006928E /* DemoChatViewModel+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */; };
@@ -1735,6 +1736,7 @@
 		404A81372DA3CC0C001F7FA8 /* CallConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallConfiguration.swift; sourceTree = "<group>"; };
 		4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sendable+Extensions.swift"; sourceTree = "<group>"; };
 		4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomStringConvertible+Conformances.swift"; sourceTree = "<group>"; };
+		4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppStateAdapter.swift; sourceTree = "<group>"; };
 		405687AD2D78A0E700093B98 /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		4059C3412AAF0CE40006928E /* DemoChatViewModel+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoChatViewModel+Injection.swift"; sourceTree = "<group>"; };
 		406128802CF32FEF007F5CDC /* SDPLineVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDPLineVisitor.swift; sourceTree = "<group>"; };
@@ -5531,6 +5533,7 @@
 		8492B87629081CE700006649 /* Mock */ = {
 			isa = PBXGroup;
 			children = (
+				4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */,
 				40AAD18E2D2EEAD500D10330 /* MockCaptureDeviceProvider.swift */,
 				40B48C482D14E822002C4EAB /* MockStreamVideoCapturer.swift */,
 				40B48C292D14CF3B002C4EAB /* MockRTCRtpCodecCapability.swift */,
@@ -7800,6 +7803,7 @@
 				404A81362DA3CBF0001F7FA8 /* CallConfigurationTests.swift in Sources */,
 				40F0174F2BBEEFED00E89FD1 /* ThumbnailsSettings+Dummy.swift in Sources */,
 				842747E729EECF9600E063AD /* ErrorPayload_Tests.swift in Sources */,
+				4052BF552DBA830D0085AFA5 /* MockAppStateAdapter.swift in Sources */,
 				401338782BF248B9007318BD /* MockStreamVideo.swift in Sources */,
 				84D114DA29F092E700BCCB0C /* CallController_Tests.swift in Sources */,
 				40AF6A432C93585B00BA2935 /* WebRTCCoordinatorStateMachine_MigratedStageTests.swift in Sources */,

--- a/StreamVideoSwiftUITests/Utils/StreamAppStateAdapter/StreamAppStateAdapter_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/StreamAppStateAdapter/StreamAppStateAdapter_Tests.swift
@@ -39,8 +39,8 @@ final class StreamAppStateAdapter_Tests: XCTestCase, @unchecked Sendable {
     // MARK: - Private Helpers
 
     @MainActor private func assertApplicationState(
-        initial: StreamAppStateAdapter.State,
-        target: StreamAppStateAdapter.State,
+        initial: ApplicationState,
+        target: ApplicationState,
         file: StaticString = #file,
         line: UInt = #line
     ) async {

--- a/StreamVideoTests/Mock/MockAppStateAdapter.swift
+++ b/StreamVideoTests/Mock/MockAppStateAdapter.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+@testable import StreamVideo
+
+final class MockAppStateAdapter: AppStateProviding, @unchecked Sendable {
+    var stubbedState: ApplicationState = .foreground
+
+    var state: ApplicationState { stubbedState }
+    var statePublisher: AnyPublisher<ApplicationState, Never> { Just(state).eraseToAnyPublisher() }
+}

--- a/StreamVideoTests/Utils/AudioSession/Extensions/AVAudioSessionCategoryOptions_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/Extensions/AVAudioSessionCategoryOptions_Tests.swift
@@ -9,14 +9,128 @@ import XCTest
 final class AVAudioSessionCategoryOptionsTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - playAndRecord
-    
-    func test_playAndRecord_whenAccessed_thenReturnsExpectedOptions() {
+
+    func test_playAndRecord_videoOnFalse_speakerOnFalse_appForegroundedFalse_thenReturnsExpectedOptions() {
         XCTAssertEqual(
-            AVAudioSession.CategoryOptions.playAndRecord,
-            [.allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: false,
+                speakerOn: false,
+                appIsInForeground: false
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
         )
     }
-    
+
+    func test_playAndRecord_videoOnTrue_speakerOnFalse_appForegroundedFalse_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: true,
+                speakerOn: false,
+                appIsInForeground: false
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func test_playAndRecord_videoOnTrue_speakerOnTrue_appForegroundedFalse_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: true,
+                speakerOn: true,
+                appIsInForeground: false
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func test_playAndRecord_videoOnTrue_speakerOnTrue_appForegroundedTrue_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: true,
+                speakerOn: true,
+                appIsInForeground: true
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func test_playAndRecord_videoOnFalse_speakerOnTrue_appForegroundedTrue_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: false,
+                speakerOn: true,
+                appIsInForeground: true
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay,
+                .defaultToSpeaker
+            ]
+        )
+    }
+
+    func test_playAndRecord_videoOnFalse_speakerOnFalse_appForegroundedTrue_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: false,
+                speakerOn: false,
+                appIsInForeground: true
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func test_playAndRecord_videoOnTrue_speakerOnFalse_appForegroundedTrue_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: true,
+                speakerOn: false,
+                appIsInForeground: true
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func test_playAndRecord_videoOnFalse_speakerOnTrue_appForegroundedFalse_thenReturnsExpectedOptions() {
+        XCTAssertEqual(
+            AVAudioSession.CategoryOptions.playAndRecord(
+                videoOn: false,
+                speakerOn: true,
+                appIsInForeground: false
+            ),
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
     // MARK: - playback
     
     func test_playback_whenAccessed_thenReturnsEmptyOptions() {

--- a/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
@@ -8,16 +8,24 @@ import XCTest
 
 final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
 
+    private lazy var stubbedAppStateAdapter: MockAppStateAdapter! = .init()
     private lazy var subject: DefaultAudioSessionPolicy! = .init()
-    
+
+    override func setUp() {
+        super.setUp()
+        AppStateProviderKey.currentValue = stubbedAppStateAdapter
+        _ = subject
+    }
+
     override func tearDown() {
         subject = nil
+        stubbedAppStateAdapter = nil
         super.tearDown()
     }
     
     // MARK: - VideoCall
 
-    func testConfiguration_WhenVideoCallWithSpeaker_ReturnsCorrectConfiguration() {
+    func testConfiguration_WhenVideoCallWithSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
         let callSettings = CallSettings(videoOn: true, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
 
@@ -28,11 +36,41 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
 
         XCTAssertEqual(configuration.category, .playAndRecord)
         XCTAssertEqual(configuration.mode, .videoChat)
-        XCTAssertEqual(configuration.options, .playAndRecord)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
         XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
     }
-    
-    func testConfiguration_WhenVideoCallWithoutSpeaker_ReturnsCorrectConfiguration() {
+
+    func testConfiguration_WhenVideoCallWithSpeakerBackgroundTrue_ReturnsCorrectConfiguration() {
+        stubbedAppStateAdapter.stubbedState = .background
+        let callSettings = CallSettings(videoOn: true, speakerOn: true)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
+
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        XCTAssertEqual(configuration.category, .playAndRecord)
+        XCTAssertEqual(configuration.mode, .videoChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+        XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
+    }
+
+    func testConfiguration_WhenVideoCallWithoutSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
         let callSettings = CallSettings(videoOn: true, speakerOn: false)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
 
@@ -43,13 +81,43 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
 
         XCTAssertEqual(configuration.category, .playAndRecord)
         XCTAssertEqual(configuration.mode, .videoChat)
-        XCTAssertEqual(configuration.options, .playAndRecord)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
         XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
     }
-    
+
+    func testConfiguration_WhenVideoCallWithoutSpeakerBackgroundTrue_ReturnsCorrectConfiguration() {
+        stubbedAppStateAdapter.stubbedState = .background
+        let callSettings = CallSettings(videoOn: true, speakerOn: false)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
+
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        XCTAssertEqual(configuration.category, .playAndRecord)
+        XCTAssertEqual(configuration.mode, .videoChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+        XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
+    }
+
     // MARK: - AudioCall
 
-    func testConfiguration_WhenAudioCallWithSpeaker_ReturnsCorrectConfiguration() {
+    func testConfiguration_WhenAudioCallWithSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
         let callSettings = CallSettings(videoOn: false, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio]
 
@@ -60,11 +128,42 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
 
         XCTAssertEqual(configuration.category, .playAndRecord)
         XCTAssertEqual(configuration.mode, .voiceChat)
-        XCTAssertEqual(configuration.options, .playAndRecord)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay,
+                .defaultToSpeaker
+            ]
+        )
         XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
     }
-    
-    func testConfiguration_WhenAudioCallWithoutSpeaker_ReturnsCorrectConfiguration() {
+
+    func testConfiguration_WhenAudioCallWithSpeakerBackgroundTrue_ReturnsCorrectConfiguration() {
+        stubbedAppStateAdapter.stubbedState = .background
+        let callSettings = CallSettings(videoOn: false, speakerOn: true)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio]
+
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        XCTAssertEqual(configuration.category, .playAndRecord)
+        XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+        XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
+    }
+
+    func testConfiguration_WhenAudioCallWithoutSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
         // Δεδομένα
         let callSettings = CallSettings(videoOn: false, speakerOn: false)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio]
@@ -76,7 +175,37 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
         
         XCTAssertEqual(configuration.category, .playAndRecord)
         XCTAssertEqual(configuration.mode, .voiceChat)
-        XCTAssertEqual(configuration.options, .playAndRecord)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+        XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
+    }
+
+    func testConfiguration_WhenAudioCallWithoutSpeakerBackgroundTrue_ReturnsCorrectConfiguration() {
+        stubbedAppStateAdapter.stubbedState = .background
+        let callSettings = CallSettings(videoOn: false, speakerOn: false)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio]
+
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        XCTAssertEqual(configuration.category, .playAndRecord)
+        XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
         XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
     }
 }

--- a/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
@@ -80,7 +80,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
         )
 
         XCTAssertEqual(configuration.category, .playAndRecord)
-        XCTAssertEqual(configuration.mode, .videoChat)
+        XCTAssertEqual(configuration.mode, .voiceChat)
         XCTAssertEqual(
             configuration.options,
             [

--- a/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
@@ -67,7 +67,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
+        XCTAssertNil(configuration.overrideOutputAudioPort)
     }
 
     func testConfiguration_WhenVideoCallWithoutSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
@@ -112,7 +112,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
+        XCTAssertNil(configuration.overrideOutputAudioPort)
     }
 
     // MARK: - AudioCall
@@ -160,7 +160,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
+        XCTAssertNil(configuration.overrideOutputAudioPort)
     }
 
     func testConfiguration_WhenAudioCallWithoutSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
@@ -206,6 +206,6 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
+        XCTAssertNil(configuration.overrideOutputAudioPort)
     }
 }

--- a/StreamVideoTests/Utils/AudioSession/Policies/OwnCapabilitiesAudioSessionPolicyTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/Policies/OwnCapabilitiesAudioSessionPolicyTests.swift
@@ -8,140 +8,242 @@ import XCTest
 
 final class OwnCapabilitiesAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
 
-    private var subject: OwnCapabilitiesAudioSessionPolicy! = .init()
+    private lazy var stubbedAppStateAdapter: MockAppStateAdapter! = .init()
+    private lazy var subject: OwnCapabilitiesAudioSessionPolicy! = .init()
     private var currentDevice: CurrentDevice! = .currentValue
-    
+
+    override func setUp() {
+        super.setUp()
+        AppStateProviderKey.currentValue = stubbedAppStateAdapter
+        _ = subject
+    }
+
     override func tearDown() {
         subject = nil
+        stubbedAppStateAdapter = nil
         currentDevice = nil
         super.tearDown()
     }
-    
+
     // MARK: - Tests for users without sendAudio capability
-    
+
     func testConfiguration_WhenUserCannotSendAudio_ReturnsPlaybackConfiguration() {
         // Given
         let callSettings = CallSettings(audioOn: true, videoOn: true, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.category, .playback)
         XCTAssertEqual(configuration.mode, .default)
         XCTAssertEqual(configuration.options, .playback)
         XCTAssertNil(configuration.overrideOutputAudioPort)
     }
-    
+
     // MARK: - Tests for users with sendAudio capability
-    
+
     func testConfiguration_WhenUserCanSendAudioAndAudioOn_ReturnsPlayAndRecordConfiguration() {
         // Given
         let callSettings = CallSettings(audioOn: true, videoOn: true, speakerOn: false)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.category, .playAndRecord)
-        XCTAssertEqual(configuration.mode, .videoChat)
-        XCTAssertEqual(configuration.options, .playAndRecord)
+        XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
         XCTAssertEqual(configuration.overrideOutputAudioPort, AVAudioSession.PortOverride.none)
     }
-    
+
     func testConfiguration_WhenUserCanSendAudioAndSpeakerOnWithEarpiece_ReturnsPlayAndRecordConfiguration() {
         // Given
         currentDevice.deviceType = .phone
         let callSettings = CallSettings(audioOn: false, videoOn: true, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.category, .playAndRecord)
         XCTAssertEqual(configuration.mode, .videoChat)
-        XCTAssertEqual(configuration.options, .playAndRecord)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
         XCTAssertEqual(configuration.overrideOutputAudioPort, .speaker)
     }
-    
+
     func testConfiguration_WhenUserCanSendAudioAndSpeakerOnWithoutEarpiece_ReturnsPlaybackConfiguration() {
         // Given
         currentDevice.deviceType = .pad
         let callSettings = CallSettings(audioOn: false, videoOn: true, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.category, .playback)
         XCTAssertEqual(configuration.mode, .default)
         XCTAssertEqual(configuration.options, .playback)
         XCTAssertNil(configuration.overrideOutputAudioPort)
     }
-    
+
     func testConfiguration_WhenUserCanSendAudioAndAudioOff_ReturnsPlaybackConfiguration() {
         // Given
         let callSettings = CallSettings(audioOn: false, videoOn: true, speakerOn: false)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.category, .playback)
         XCTAssertEqual(configuration.mode, .default)
         XCTAssertEqual(configuration.options, .playback)
         XCTAssertNil(configuration.overrideOutputAudioPort)
     }
-    
+
     // MARK: - Tests for different video settings
-    
-    func testConfiguration_WhenVideoOn_ReturnsVideoChatMode() {
+
+    func testConfiguration_WhenVideoOnSpeakerOn_ReturnsVideoChatMode() {
         // Given
-        let callSettings = CallSettings(audioOn: true, videoOn: true, speakerOn: false)
+        let callSettings = CallSettings(audioOn: true, videoOn: true, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.mode, .videoChat)
     }
-    
-    func testConfiguration_WhenVideoOff_ReturnsVoiceChatMode() {
+
+    func testConfiguration_WhenVideoOffSpeakerOnBackgroundFalse_ReturnsVoiceChatMode() {
         // Given
-        let callSettings = CallSettings(audioOn: true, videoOn: false, speakerOn: false)
+        let callSettings = CallSettings(audioOn: true, videoOn: false, speakerOn: true)
         let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
-        
+
         // When
         let configuration = subject.configuration(
             for: callSettings,
             ownCapabilities: ownCapabilities
         )
-        
+
         // Then
         XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay,
+                .defaultToSpeaker
+            ]
+        )
+    }
+
+    func testConfiguration_WhenVideoOffSpeakerFalseBackgroundFalse_ReturnsVoiceChatMode() {
+        // Given
+        let callSettings = CallSettings(audioOn: true, videoOn: false, speakerOn: false)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
+
+        // When
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        // Then
+        XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func testConfiguration_WhenVideoOffSpeakerOnBackgroundTrue_ReturnsVoiceChatMode() {
+        // Given
+        stubbedAppStateAdapter.stubbedState = .background
+        let callSettings = CallSettings(audioOn: true, videoOn: false, speakerOn: true)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
+
+        // When
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        // Then
+        XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
+    }
+
+    func testConfiguration_WhenVideoOffSpeakerFalseBackgroundTrue_ReturnsVoiceChatMode() {
+        // Given
+        stubbedAppStateAdapter.stubbedState = .background
+        let callSettings = CallSettings(audioOn: true, videoOn: false, speakerOn: false)
+        let ownCapabilities: Set<OwnCapability> = [.sendAudio, .sendVideo]
+
+        // When
+        let configuration = subject.configuration(
+            for: callSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        // Then
+        XCTAssertEqual(configuration.mode, .voiceChat)
+        XCTAssertEqual(
+            configuration.options,
+            [
+                .allowBluetooth,
+                .allowBluetoothA2DP,
+                .allowAirPlay
+            ]
+        )
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-816/[blink]speaker-turns-off-when-video-is-off

### 📝 Summary

A recent change introduce a regression which is causing the speaker to be disabled when video isn't enabled.

### 🛠 Implementation

The issue is being caused from two parts:
- Our AudioSession policies where wrong (regression introduced in the #762)
- #762 before introducing the regression was trying to fix an issue that was stopping the user from disabling the speaker in CallKit's screen.

In this revision we are trying to solve those issues once an for all. 

By reverting the changes from #762, we get back to the original issue. Strangely the reason why CallKit doesn't allow the turning off of the speaker is because we are using an override.  For some reason CallKit considers that override a hard override and doesn't allow toggling it off.

The solution is to use our ApplicationStateAdapter and use the application state as an input variable when determining the AudioSession configuration. When the app is backgrounded we aren't going to apply any overrides (ports or options) rather than keep whatever the AudioSession.Mode has as default.

### 🧪 Manual Testing Notes

- Join a call
- Ensure that video on/off and speaker on/off combinations work as expected
- Leave the call
- Lock your device
- Receive a ringing call
- Accept
- While in the callKit screen ensure you can turn on/off the speaker

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)