### PR TITLE
[Fix]Ringing flow issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix ringing flow issues. [#792](https://github.com/GetStream/stream-video-swift/pull/792)
 
 # [1.21.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.21.1)
 _April 25, 2025_

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -848,16 +848,6 @@ open class CallViewModel: ObservableObject {
                 return
             }
 
-            if isCallCreatorRejection, !isCurrentUserRejection {
-                /// If the call that was rejected is the incoming call we are presenting, then we reject
-                /// and set the activeCall to the current one in order to reset the callingState to
-                /// inCall or idle.
-                Task {
-                    _ = try? await streamVideo
-                        .call(callType: incomingCall.type, callId: incomingCall.id)
-                        .reject()
-                }
-            }
             setActiveCall(call)
         case .outgoing where call?.cId == event.callCid:
             guard let outgoingCall = call else {

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -764,6 +764,9 @@ open class CallViewModel: ObservableObject {
                             // TODO: implement holding a call.
                             if callingState == .idle && isAppActive {
                                 setCallingState(.incoming(incomingCall))
+                                /// We start the ringing timer, so we can cancel when the timeout
+                                /// is over.
+                                startTimer(timeout: incomingCall.timeout)
                             }
                         }
                     case .accepted:
@@ -836,15 +839,26 @@ open class CallViewModel: ObservableObject {
 
         switch callingState {
         case let .incoming(incomingCall) where event.callCid == callCid(from: incomingCall.id, callType: incomingCall.type):
-            /// If the call that was rejected is the incoming call we are presenting, then we reject
-            /// and set the activeCall to the current one in order to reset the callingState to
-            /// inCall or idle.
-            Task {
-                _ = try? await streamVideo
-                    .call(callType: incomingCall.type, callId: incomingCall.id)
-                    .reject()
-                setActiveCall(call)
+            let isCurrentUserRejection = event.user?.id == streamVideo.user.id
+            let isCallCreatorRejection = event.user?.id == incomingCall.caller.id
+
+            guard
+                (isCurrentUserRejection || isCallCreatorRejection)
+            else {
+                return
             }
+
+            if isCallCreatorRejection, !isCurrentUserRejection {
+                /// If the call that was rejected is the incoming call we are presenting, then we reject
+                /// and set the activeCall to the current one in order to reset the callingState to
+                /// inCall or idle.
+                Task {
+                    _ = try? await streamVideo
+                        .call(callType: incomingCall.type, callId: incomingCall.id)
+                        .reject()
+                }
+            }
+            setActiveCall(call)
         case .outgoing where call?.cId == event.callCid:
             guard let outgoingCall = call else {
                 return


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-835/ringing-flow-issues-when-callviewmodel-is-involved

### 📝 Summary

In the scenario where, one Android user calls 1 android user and 1 iOS, if the Android callee rejects the call, iOS (wrongly) will also reject causing the caller also to be dropped from the call.

### 🛠 Implementation

- Align CallViewModel handleReject logic with CallKitService
- Start the ringing timer from CallKit so CallViewModel can auto-cancel the call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)