### PR TITLE
[Fix]Picture-in-Picture store thread access

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureStore.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureStore.swift
@@ -106,6 +106,7 @@ final class PictureInPictureStore: ObservableObject, @unchecked Sendable {
     func publisher<Value>(for keyPath: KeyPath<State, Value>) -> AnyPublisher<Value, Never> {
         subject
             .map(keyPath)
+            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-836/fix-pictureinpicturestore-thread-access-warning

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)