### PR TITLE
[Fix]Update OutgoingCallScreen from the ringingCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ _May 05, 2025_
 - Fix ringing flow issues. [#792](https://github.com/GetStream/stream-video-swift/pull/792)
 - Fix a few points that were negatively affecting Picture-in-Picture lifecycle. [#796](https://github.com/GetStream/stream-video-swift/pull/796)
 
+### 🔄 Changed
+- Update OutgoingCallView to get updates from ringing call [#798](https://github.com/GetStream/stream-video-swift/pull/798)
+
 # [1.21.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.21.1)
 _April 25, 2025_
 

--- a/Sources/StreamVideoSwiftUI/CallView/CallControls/Stateful/CallControlsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallControls/Stateful/CallControlsView.swift
@@ -12,19 +12,21 @@ public struct CallControlsView: View {
     @Injected(\.colors) var colors
 
     @ObservedObject var viewModel: CallViewModel
+    @State var ownCapabilities: [OwnCapability]
 
     /// Initializes the call controls view with a view model.
     /// - Parameter viewModel: The view model for the call controls.
     public init(viewModel: CallViewModel) {
         self.viewModel = viewModel
+        ownCapabilities = viewModel.call?.state.ownCapabilities ?? []
     }
 
     public var body: some View {
         HStack {
-            if call?.state.ownCapabilities.contains(.sendVideo) == true {
+            if ownCapabilities.contains(.sendVideo) == true {
                 VideoIconView(viewModel: viewModel)
             }
-            if call?.state.ownCapabilities.contains(.sendAudio) == true {
+            if ownCapabilities.contains(.sendAudio) == true {
                 MicrophoneIconView(viewModel: viewModel)
             }
 
@@ -37,6 +39,8 @@ public struct CallControlsView: View {
         .padding(.horizontal, 16)
         .padding(.vertical)
         .frame(maxWidth: .infinity)
+        .onReceive(viewModel.call?.state.$ownCapabilities.receive(on: DispatchQueue.main)) { ownCapabilities = $0 }
+        .onReceive(streamVideo.state.ringingCall?.state.$ownCapabilities.receive(on: DispatchQueue.main)) { ownCapabilities = $0 }
     }
 
     private var call: Call? {

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
@@ -14,7 +14,7 @@ public struct CallConnectingView<CallControls: View, CallTopView: View, Factory:
     @Injected(\.utils) var utils
 
     var viewFactory: Factory
-    public var outgoingCallMembers: [Member]
+    @State public var outgoingCallMembers: [Member]
     public var title: String
     public var callControls: CallControls
     public var callTopView: CallTopView
@@ -75,5 +75,8 @@ public struct CallConnectingView<CallControls: View, CallTopView: View, Factory:
         .background(
             OutgoingCallBackground(outgoingCallMembers: outgoingCallMembers)
         )
+        .onReceive(streamVideo.state.ringingCall?.state.$members) { members in
+            outgoingCallMembers = members.filter { $0.id != streamVideo.user.id }
+        }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/CallConnectingView.swift
@@ -75,7 +75,7 @@ public struct CallConnectingView<CallControls: View, CallTopView: View, Factory:
         .background(
             OutgoingCallBackground(outgoingCallMembers: outgoingCallMembers)
         )
-        .onReceive(streamVideo.state.ringingCall?.state.$members) { members in
+        .onReceive(streamVideo.state.ringingCall?.state.$members.receive(on: DispatchQueue.main)) { members in
             outgoingCallMembers = members.filter { $0.id != streamVideo.user.id }
         }
     }

--- a/StreamVideoSwiftUITests/CallView/CallControls/Stateful/CallControlsView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallControls/Stateful/CallControlsView_Tests.swift
@@ -23,6 +23,7 @@ final class CallControlsView_Tests: StreamVideoUITestCase, @unchecked Sendable {
     func test_callControlsView_activeCall_snapshot() throws {
         let call = streamVideoUI?.streamVideo.call(callType: .default, callId: .unique)
         call?.state.ownCapabilities = [.sendAudio, .sendVideo]
+        streamVideoUI?.streamVideo.state.ringingCall = call
         let viewModel = CallViewModel()
         viewModel.setActiveCall(call)
 
@@ -39,6 +40,7 @@ final class CallControlsView_Tests: StreamVideoUITestCase, @unchecked Sendable {
         call.state.ownCapabilities = [.sendAudio, .sendVideo]
         streamVideoUI?.streamVideo.state.ringingCall = call
         let viewModel = CallViewModel()
+        viewModel.setActiveCall(call)
         viewModel.callingState = .outgoing
 
         let view = CallControlsView(viewModel: viewModel)

--- a/StreamVideoSwiftUITests/CallingViews/CallConnectingView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/CallConnectingView_Tests.swift
@@ -25,6 +25,7 @@ final class CallConnectingView_Tests: StreamVideoUITestCase, @unchecked Sendable
         call.state.ownCapabilities.append(.sendAudio)
         call.state.ownCapabilities.append(.sendVideo)
         streamVideoUI?.streamVideo.state.ringingCall = call
+        viewModel.setActiveCall(call)
         viewModel.callingState = .outgoing
 
         let view = CallConnectingView(

--- a/StreamVideoSwiftUITests/CallingViews/OutgoingCallView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/OutgoingCallView_Tests.swift
@@ -29,8 +29,9 @@ final class OutgoingCallView_Tests: StreamVideoUITestCase, @unchecked Sendable {
             .init(user: viewModel.streamVideo.user),
             .init(userId: "test-user")
         ]
-        viewModel.callingState = .outgoing
         viewModel.streamVideo.state.ringingCall = call
+        viewModel.setActiveCall(call)
+        viewModel.callingState = .outgoing
 
         let view = factory.makeOutgoingCallView(viewModel: viewModel)
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-845/blinkoutgoingcallview-issues

### 🎯 Goal

Update OutgoingCallView to receive updates from the `StreamVideo.state.ringingCall` to cover cases where the Call instance may be created remotely (e.g. from the backend).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)