### PR TITLE
[Fix]CallKit AudioSession speaker sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Synchronize CallKit audioSession with the audioSession in the app. [#807](https://github.com/GetStream/stream-video-swift/pull/807)
 
 # [1.22.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.22.1)
 _May 08, 2025_

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1428,6 +1428,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         )
     }
 
+    internal func callKitActivated(_ audioSession: AVAudioSession) throws {
+        try callController.callKitActivated(audioSession)
+    }
+
     // MARK: - private
 
     private func updatePermissions(

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1428,6 +1428,16 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         )
     }
 
+    /// Notifies the `Call` instance that CallKit has activated the system audio
+    /// session.
+    ///
+    /// This method should be called when the system activates the `AVAudioSession`
+    /// as a result of an incoming or outgoing CallKit-managed call. It allows the
+    /// call to update the provided CallKit AVAudioSession based on the internal CallSettings.
+    ///
+    /// - Parameter audioSession: The active `AVAudioSession` instance provided by
+    ///   CallKit.
+    /// - Throws: An error if the call controller fails to handle the activation.
     internal func callKitActivated(_ audioSession: AVAudioSession) throws {
         try callController.callKitActivated(audioSession)
     }

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1438,7 +1438,7 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     /// - Parameter audioSession: The active `AVAudioSession` instance provided by
     ///   CallKit.
     /// - Throws: An error if the call controller fails to handle the activation.
-    internal func callKitActivated(_ audioSession: AVAudioSession) throws {
+    internal func callKitActivated(_ audioSession: AVAudioSessionProtocol) throws {
         try callController.callKitActivated(audioSession)
     }
 

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -327,6 +327,16 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             """,
             subsystems: .callKit
         )
+
+        if
+            let active,
+            let call = callEntry(for: active)?.call {
+            do {
+                try call.callKitActivated(audioSession)
+            } catch {
+                log.error(error, subsystems: .callKit)
+            }
+        }
     }
 
     public func provider(

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -495,6 +495,10 @@ class CallController: @unchecked Sendable {
             .sink { [weak self] in self?.webRTCClientDidUpdateStage($0) }
     }
 
+    internal func callKitActivated(_ audioSession: AVAudioSession) throws {
+        try webRTCCoordinator.callKitActivated(audioSession)
+    }
+
     // MARK: - private
 
     private func handleParticipantsUpdated() {

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -495,7 +495,7 @@ class CallController: @unchecked Sendable {
             .sink { [weak self] in self?.webRTCClientDidUpdateStage($0) }
     }
 
-    internal func callKitActivated(_ audioSession: AVAudioSession) throws {
+    internal func callKitActivated(_ audioSession: AVAudioSessionProtocol) throws {
         try webRTCCoordinator.callKitActivated(audioSession)
     }
 

--- a/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Policies/DefaultAudioSessionPolicy.swift
@@ -32,7 +32,9 @@ public struct DefaultAudioSessionPolicy: AudioSessionPolicy {
                     speakerOn: callSettings.speakerOn,
                     appIsInForeground: false
                 ),
-                overrideOutputAudioPort: nil
+                overrideOutputAudioPort: callSettings.speakerOn
+                    ? .speaker
+                    : AVAudioSession.PortOverride.none
             )
         }
 

--- a/Sources/StreamVideo/Utils/AudioSession/Protocols/AVAudioSessionProtocol.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Protocols/AVAudioSessionProtocol.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Foundation
+
+protocol AVAudioSessionProtocol {
+
+    /// Configures the audio session category and options.
+    /// - Parameters:
+    ///   - category: The audio category (e.g., `.playAndRecord`).
+    ///   - mode: The audio mode (e.g., `.videoChat`).
+    ///   - categoryOptions: The options for the category (e.g., `.allowBluetooth`).
+    /// - Throws: An error if setting the category fails.
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        with categoryOptions: AVAudioSession.CategoryOptions
+    ) throws
+
+    /// Overrides the audio output port (e.g., to speaker).
+    /// - Parameter port: The output port override.
+    /// - Throws: An error if overriding fails.
+    func setOverrideOutputAudioPort(
+        _ port: AVAudioSession.PortOverride
+    ) throws
+}
+
+extension AVAudioSession: AVAudioSessionProtocol {
+    func setCategory(
+        _ category: Category,
+        mode: Mode,
+        with categoryOptions: CategoryOptions
+    ) throws {
+        try setCategory(
+            category,
+            mode: mode,
+            options: categoryOptions
+        )
+    }
+    
+    func setOverrideOutputAudioPort(_ port: PortOverride) throws {
+        try overrideOutputAudioPort(port)
+    }
+}

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
@@ -133,6 +133,25 @@ final class StreamAudioSession: @unchecked Sendable, ObservableObject {
         }
     }
 
+    func callKitActivated(_ audioSession: AVAudioSession) throws {
+        let configuration = policy.configuration(
+            for: activeCallSettings,
+            ownCapabilities: ownCapabilities
+        )
+
+        try audioSession.setCategory(
+            configuration.category,
+            mode: configuration.mode,
+            options: configuration.options
+        )
+
+        if let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
+            try audioSession.overrideOutputAudioPort(overrideOutputAudioPort)
+        } else {
+            try audioSession.overrideOutputAudioPort(.none)
+        }
+    }
+
     // MARK: - OwnCapabilities
 
     /// Updates the audio session with new call settings.

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSession.swift
@@ -133,7 +133,7 @@ final class StreamAudioSession: @unchecked Sendable, ObservableObject {
         }
     }
 
-    func callKitActivated(_ audioSession: AVAudioSession) throws {
+    func callKitActivated(_ audioSession: AVAudioSessionProtocol) throws {
         let configuration = policy.configuration(
             for: activeCallSettings,
             ownCapabilities: ownCapabilities
@@ -142,13 +142,13 @@ final class StreamAudioSession: @unchecked Sendable, ObservableObject {
         try audioSession.setCategory(
             configuration.category,
             mode: configuration.mode,
-            options: configuration.options
+            with: configuration.options
         )
 
         if let overrideOutputAudioPort = configuration.overrideOutputAudioPort {
-            try audioSession.overrideOutputAudioPort(overrideOutputAudioPort)
+            try audioSession.setOverrideOutputAudioPort(overrideOutputAudioPort)
         } else {
-            try audioSession.overrideOutputAudioPort(.none)
+            try audioSession.setOverrideOutputAudioPort(.none)
         }
     }
 

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -432,6 +432,10 @@ final class WebRTCCoordinator: @unchecked Sendable {
         try await stateAdapter.audioSession.didUpdatePolicy(policy)
     }
 
+    internal func callKitActivated(_ audioSession: AVAudioSession) throws {
+        try stateAdapter.audioSession.callKitActivated(audioSession)
+    }
+
     // MARK: - Private
 
     /// Creates the state machine for managing WebRTC stages.

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -432,7 +432,7 @@ final class WebRTCCoordinator: @unchecked Sendable {
         try await stateAdapter.audioSession.didUpdatePolicy(policy)
     }
 
-    internal func callKitActivated(_ audioSession: AVAudioSession) throws {
+    internal func callKitActivated(_ audioSession: AVAudioSessionProtocol) throws {
         try stateAdapter.audioSession.callKitActivated(audioSession)
     }
 

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -330,6 +330,8 @@
 		407E67592DC101DF00878FFC /* CallCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407E67582DC101DF00878FFC /* CallCRUDTests.swift */; };
 		407F29FF2AA6011500C3EAF8 /* MemoryLogViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4093861E2AA0A21800FF5AF4 /* MemoryLogViewer.swift */; };
 		407F2A002AA6011B00C3EAF8 /* LogQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4093861B2AA0A11500FF5AF4 /* LogQueue.swift */; };
+		40802AE92DD2A7C700B9F970 /* AVAudioSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40802AE82DD2A7C700B9F970 /* AVAudioSessionProtocol.swift */; };
+		40802AEB2DD2A92E00B9F970 /* MockAVAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40802AEA2DD2A92E00B9F970 /* MockAVAudioSession.swift */; };
 		408521E52D661C7600F012B8 /* RawJSON+Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408521E42D661C7500F012B8 /* RawJSON+Double.swift */; };
 		408521E72D661CA700F012B8 /* ThermalState+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408521E62D661CA700F012B8 /* ThermalState+Comparable.swift */; };
 		408679F72BD12F1000D027E0 /* AudioFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408679F62BD12F1000D027E0 /* AudioFilter.swift */; };
@@ -1839,6 +1841,8 @@
 		407AF7192B6163DD00E9E3E7 /* StreamMediaDurationFormatter_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamMediaDurationFormatter_Tests.swift; sourceTree = "<group>"; };
 		407D5D3C2ACEF0C500B5044E /* VisibilityThresholdModifier_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityThresholdModifier_Tests.swift; sourceTree = "<group>"; };
 		407E67582DC101DF00878FFC /* CallCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCRUDTests.swift; sourceTree = "<group>"; };
+		40802AE82DD2A7C700B9F970 /* AVAudioSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAudioSessionProtocol.swift; sourceTree = "<group>"; };
+		40802AEA2DD2A92E00B9F970 /* MockAVAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAVAudioSession.swift; sourceTree = "<group>"; };
 		408521E42D661C7500F012B8 /* RawJSON+Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RawJSON+Double.swift"; sourceTree = "<group>"; };
 		408521E62D661CA700F012B8 /* ThermalState+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThermalState+Comparable.swift"; sourceTree = "<group>"; };
 		408679F62BD12F1000D027E0 /* AudioFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFilter.swift; sourceTree = "<group>"; };
@@ -3575,6 +3579,7 @@
 		4067F3062CDA32F0002E28BD /* AudioSession */ = {
 			isa = PBXGroup;
 			children = (
+				40802AE72DD2A7BA00B9F970 /* Protocols */,
 				40F101632D5A322E00C49481 /* Policies */,
 				4067F3092CDA330E002E28BD /* Extensions */,
 				40149DCA2B7E813500473176 /* AudioRecorder */,
@@ -3714,6 +3719,14 @@
 				40C9E4412C943DC000802B28 /* WebRTCCoordinatorStateMachine_ErrorStageTests.swift */,
 			);
 			path = Stages;
+			sourceTree = "<group>";
+		};
+		40802AE72DD2A7BA00B9F970 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				40802AE82DD2A7C700B9F970 /* AVAudioSessionProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		408679F52BD12EFC00D027E0 /* AudioFilter */ = {
@@ -5640,6 +5653,7 @@
 				40B48C292D14CF3B002C4EAB /* MockRTCRtpCodecCapability.swift */,
 				40B48C2F2D14D308002C4EAB /* MockRTCRtpEncodingParameters.swift */,
 				4067F3182CDA469C002E28BD /* MockAudioSession.swift */,
+				40802AEA2DD2A92E00B9F970 /* MockAVAudioSession.swift */,
 				409774AD2CC1979F00E0D3EE /* MockCallController.swift */,
 				404A81302DA3C5F0001F7FA8 /* MockDefaultAPI.swift */,
 				40C75BB62CB4044600C167C3 /* MockThermalStateObserver.swift */,
@@ -7353,6 +7367,7 @@
 				40BBC4C42C638789002AEF92 /* RTCPeerConnectionCoordinator.swift in Sources */,
 				4067F3152CDA4094002E28BD /* StreamRTCAudioSession.swift in Sources */,
 				40BBC4C62C638915002AEF92 /* WebRTCCoordinator.swift in Sources */,
+				40802AE92DD2A7C700B9F970 /* AVAudioSessionProtocol.swift in Sources */,
 				841BAA392BD15CDE000C73E4 /* UserSessionStats.swift in Sources */,
 				406B3BD72C8F332200FC93A1 /* RTCVideoTrack+Sendable.swift in Sources */,
 				406128812CF32FEF007F5CDC /* SDPLineVisitor.swift in Sources */,
@@ -7869,6 +7884,7 @@
 				40AB34BA2C5D2F6200B5B6B3 /* Task_TimeoutTests.swift in Sources */,
 				40AAD1972D2EFED200D10330 /* Stream_Video_Sfu_Event_VideoSender+Dummy.swift in Sources */,
 				40A0E9642B88DE830089E8D3 /* SerialActor_Tests.swift in Sources */,
+				40802AEB2DD2A92E00B9F970 /* MockAVAudioSession.swift in Sources */,
 				40F017692BBEF1DA00E89FD1 /* EgressHLSResponse+Dummy.swift in Sources */,
 				40382F3F2C89C14300C2D00F /* RTCMediaStreamTrack+dummy.swift in Sources */,
 				40AAD18C2D2EC82700D10330 /* StreamRTCStatisticsReport+Dummy.swift in Sources */,

--- a/StreamVideoTests/Mock/MockAVAudioSession.swift
+++ b/StreamVideoTests/Mock/MockAVAudioSession.swift
@@ -1,0 +1,106 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+import Combine
+@testable import StreamVideo
+import StreamWebRTC
+
+final class MockAVAudioSession: AVAudioSessionProtocol, Mockable, @unchecked Sendable {
+
+    // MARK: - Mockable
+
+    typealias FunctionKey = MockFunctionKey
+    typealias FunctionInputKey = MockFunctionInputKey
+
+    /// Defines the "functions" or property accesses we want to track or stub.
+    enum MockFunctionKey: CaseIterable {
+        case setCategory
+        case setOverrideOutputAudioPort
+    }
+
+    /// Defines typed payloads passed along with tracked function calls.
+    enum MockFunctionInputKey: Payloadable {
+        case setCategory(
+            category: AVAudioSession.Category,
+            mode: AVAudioSession.Mode,
+            options: AVAudioSession.CategoryOptions
+        )
+        case setOverrideOutputAudioPort(value: AVAudioSession.PortOverride)
+
+        // Return an untyped payload for storage in the base Mockable dictionary.
+        var payload: Any {
+            switch self {
+            case let .setCategory(category, mode, options):
+                return (category, mode, options)
+
+            case let .setOverrideOutputAudioPort(value):
+                return value
+            }
+        }
+    }
+
+    // MARK: - Mockable Storage
+
+    var stubbedProperty: [String: Any] = [:]
+    var stubbedFunction: [FunctionKey: Any] = [:]
+    @Atomic
+    var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey.allCases
+        .reduce(into: [FunctionKey: [MockFunctionInputKey]]()) { $0[$1] = [] }
+
+    func stub<T>(for keyPath: KeyPath<MockAVAudioSession, T>, with value: T) {
+        stubbedProperty[propertyKey(for: keyPath)] = value
+    }
+
+    func stub<T>(for function: FunctionKey, with value: T) {
+        stubbedFunction[function] = value
+    }
+
+    // MARK: - AVAudioSessionProtocol
+
+    /// Sets the audio category, mode, and options.
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        with categoryOptions: AVAudioSession.CategoryOptions
+    ) throws {
+        record(
+            .setCategory,
+            input: .setCategory(
+                category: category,
+                mode: mode,
+                options: categoryOptions
+            )
+        )
+        if let error = stubbedFunction[.setCategory] as? Error {
+            throw error
+        }
+    }
+
+    /// Overrides the audio output port.
+    func setOverrideOutputAudioPort(_ port: AVAudioSession.PortOverride) throws {
+        record(
+            .setOverrideOutputAudioPort,
+            input: .setOverrideOutputAudioPort(value: port)
+        )
+        if let error = stubbedFunction[.setOverrideOutputAudioPort] as? Error {
+            throw error
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Tracks calls to a specific function/property in the mock.
+    private func record(
+        _ function: FunctionKey,
+        input: FunctionInputKey? = nil
+    ) {
+        if let input {
+            stubbedFunctionInput[function]?.append(input)
+        } else {
+            // Still record the call, but with no input
+            stubbedFunctionInput[function]?.append(contentsOf: [])
+        }
+    }
+}

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -14,6 +14,7 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
         case accept
         case join
         case updateTrackSize
+        case callKitActivated
     }
 
     enum MockCallFunctionInputKey: Payloadable {
@@ -27,6 +28,8 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
         case updateTrackSize(trackSize: CGSize, participant: CallParticipant)
 
+        case callKitActivated(audioSession: AVAudioSessionProtocol)
+
         var payload: Any {
             switch self {
             case let .join(create, options, ring, notify, callSettings):
@@ -34,6 +37,9 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
             case let .updateTrackSize(trackSize, participant):
                 return (trackSize, participant)
+
+            case let .callKitActivated(audioSession):
+                return audioSession
             }
         }
     }
@@ -120,6 +126,14 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
     ) async {
         stubbedFunctionInput[.updateTrackSize]?.append(
             .updateTrackSize(trackSize: trackSize, participant: participant)
+        )
+    }
+
+    override func callKitActivated(
+        _ audioSession: AVAudioSessionProtocol
+    ) throws {
+        stubbedFunctionInput[.callKitActivated]?.append(
+            .callKitActivated(audioSession: audioSession)
         )
     }
 }

--- a/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/Policies/DefaultAudioSessionPolicyTests.swift
@@ -67,7 +67,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertNil(configuration.overrideOutputAudioPort)
+        XCTAssertNotNil(configuration.overrideOutputAudioPort)
     }
 
     func testConfiguration_WhenVideoCallWithoutSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
@@ -112,7 +112,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertNil(configuration.overrideOutputAudioPort)
+        XCTAssertNotNil(configuration.overrideOutputAudioPort)
     }
 
     // MARK: - AudioCall
@@ -160,7 +160,7 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertNil(configuration.overrideOutputAudioPort)
+        XCTAssertNotNil(configuration.overrideOutputAudioPort)
     }
 
     func testConfiguration_WhenAudioCallWithoutSpeakerBackgroundFalse_ReturnsCorrectConfiguration() {
@@ -206,6 +206,6 @@ final class DefaultAudioSessionPolicyTests: XCTestCase, @unchecked Sendable {
                 .allowAirPlay
             ]
         )
-        XCTAssertNil(configuration.overrideOutputAudioPort)
+        XCTAssertNotNil(configuration.overrideOutputAudioPort)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-859/blinkcallkit-audiosession-speaker-state

### 📝 Summary

CallKit reconfigures the AudioSession using a minimum set of configuration. As the SDK also takes control of the AVAudioSession management, align the CallKit AudioSession configuration with the CallSettings during the call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)