### PR TITLE
[Fix]CallSettings during reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix an issue that was causing CallSettings misalignment during reconnection [#810](https://github.com/GetStream/stream-video-swift/pull/810)
 
 # [1.22.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.22.1)
 _May 08, 2025_

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -340,6 +340,10 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
         audioTracks = [:]
         videoTracks = [:]
         screenShareTracks = [:]
+
+        /// We set the initialCallSettings to the last activated CallSettings, in order to maintain the state
+        /// during reconnects.
+        initialCallSettings = callSettings
     }
 
     /// Restores screen sharing if an active session exists.

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -516,6 +516,30 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await assertEqualAsync(await subject.participantPins, pins)
     }
 
+    func test_cleanUpForReconnection_setsInitialCallSettingsToCallSettings() async throws {
+        let sfuStack = MockSFUStack()
+        let ownCapabilities = Set([OwnCapability.blockUsers])
+        let pins = [PinInfo(isLocal: true, pinnedAt: .init())]
+        let userId = String.unique
+        let currentParticipant = await CallParticipant.dummy(id: subject.sessionID)
+        let participants = [
+            userId: CallParticipant.dummy(id: userId),
+            currentParticipant.sessionId: currentParticipant
+        ]
+        try await prepare(
+            sfuStack: sfuStack,
+            ownCapabilities: ownCapabilities,
+            participants: participants,
+            participantPins: pins
+        )
+        await subject.set(callSettings: .init(cameraPosition: .back))
+
+        let sessionId = await subject.sessionID
+        await subject.cleanUpForReconnection()
+
+        await assertEqualAsync(await subject.callSettings.cameraPosition, .back)
+    }
+
     // MARK: - didAddTrack
 
     func test_didAddTrack_videoOfExistingParticipant_shouldAddTrack() async throws {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-858/bugcallsettings-misalignment-during-reconnections

### 📝 Summary

During reconnections we should maintain CallSettings and published tracks.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)