### PR TITLE
[Fix]CallKit leaving the call while user reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix an issue where while reconnecting, `CallKitService` would leave the call after received the `Coordinator.participant_left` event. [#811](https://github.com/GetStream/stream-video-swift/pull/811)
 
 # [1.22.2](https://github.com/GetStream/stream-video-swift/releases/tag/1.22.2)
 _May 13, 2025_


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-861/bugcallkitservice-leaving-the-call-when-user-reconnects

### 📝 Summary

During a call, if the current user reconnects, during reconnection is possible that the user's device receive the `participant_left` event. The event would be wrongly intercepted from CallKitService and trigger leaving the call, if there is only one participant currently in the call (which is common in 1:1 calls and while one of the user reconnects).

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

- Ring a user
- Once they join
- Trigger a rejoin or migration
- The reconnection flow should complete without any of the users being kicked out from the call

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)