### PR TITLE
[Fix]MicrophoneChecker occasional crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix a retain cycle that was causing StreamVideo to leak in projects using NoiseCancellation. [#814](https://github.com/GetStream/stream-video-swift/pull/814)
+- Fix occasional crash caused inside `MicrophoneChecker`. [#813](https://github.com/GetStream/stream-video-swift/pull/813)
 
 # [1.22.2](https://github.com/GetStream/stream-video-swift/releases/tag/1.22.2)
 _May 13, 2025_

--- a/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Publisher+TaskSink.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Publisher+TaskSink.swift
@@ -87,12 +87,13 @@ extension Publisher where Output: Sendable {
                 // Skip processing if the queue is unavailable.
                 return
             }
+            let capturedInput = input
             // Schedule the task on the provided serial actor queue.
             queue.async {
                 do {
                     // Check for task cancellation and process the value.
                     try Task.checkCancellation()
-                    try await receiveValue(input)
+                    try await receiveValue(capturedInput)
                 } catch let error as Failure {
                     // Handle specific failure cases.
                     receiveCompletion(.failure(error))

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -66,13 +66,12 @@ final class MicrophoneChecker_Tests: XCTestCase, @unchecked Sendable {
 
         for value in inputs {
             mockAudioRecorder.mockMetersPublisher.send(Float(value))
-            try? await Task.sleep(nanoseconds: 100_000)
+            await wait(for: 0.1)
         }
 
         let values = try await subject
             .$audioLevels
             .filter { $0 == [0.5, 0.8, 0.0] }
-            .log(.debug) { "Received audioLevels: \($0)" }
             .nextValue(timeout: defaultTimeout)
 
         XCTAssertEqual(values, [0.5, 0.8, 0.0])

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -49,7 +49,6 @@ final class MicrophoneChecker_Tests: XCTestCase, @unchecked Sendable {
     // MARK: - audioLevels
 
     func test_startListeningAndPostAudioLevels_microphoneCheckerHasExpectedValues() async throws {
-        LogConfig.level = .debug
         await subject.startListening()
 
         let inputs = [


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-869/tasksink-causes-occasional-crash-on-microphonechecker

### 📝 Summary

`TaskSink` causes an occasional crash on MicrophoneChecker. This revision attempts to fix this by holding a reference to the input value inside TaskSync and then use the hold value inside the async operation.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)