### PR TITLE
[Fix]Break StreamVideo memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - `CallViewController` was updated to accept the `video` flag when starting a call. [#811](https://github.com/GetStream/stream-video-swift/pull/811)
 
+### 🐞 Fixed
+- Fix a retain cycle that was causing StreamVideo to leak in projects using NoiseCancellation. [#814](https://github.com/GetStream/stream-video-swift/pull/814)
+
 # [1.22.2](https://github.com/GetStream/stream-video-swift/releases/tag/1.22.2)
 _May 13, 2025_
 

--- a/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
+++ b/Sources/StreamVideo/WebRTC/AudioFilter/Filters/NoiseCancellationFilter.swift
@@ -26,7 +26,7 @@ public final class NoiseCancellationFilter: AudioFilter, @unchecked Sendable, Ob
         didSet { didUpdateActiveCall(activeCall, oldValue: oldValue) }
     }
 
-    var streamVideo: StreamVideo? {
+    weak var streamVideo: StreamVideo? {
         didSet { didUpdate(streamVideo) }
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-871/break-streamvideo-memory-leak

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)