### PR TITLE
Add the 'team' option to CallViewModel

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -341,7 +341,8 @@ open class CallViewModel: ObservableObject {
         startsAt: Date? = nil,
         backstage: BackstageSettingsRequest? = nil,
         customData: [String: RawJSON]? = nil,
-        video: Bool? = nil
+        video: Bool? = nil,
+        team: String? = nil
     ) {
         outgoingCallMembers = members
         setCallingState(ring ? .outgoing : .joining)
@@ -358,7 +359,8 @@ open class CallViewModel: ObservableObject {
                 maxParticipants: maxParticipants,
                 startsAt: startsAt,
                 backstage: backstage,
-                customData: customData
+                customData: customData,
+                team: team
             )
         } else {
             let call = streamVideo.call(
@@ -372,6 +374,7 @@ open class CallViewModel: ObservableObject {
                     let callData = try await call.create(
                         members: membersRequest,
                         custom: customData,
+                        team: team,
                         ring: ring,
                         maxDuration: maxDuration,
                         maxParticipants: maxParticipants,
@@ -641,7 +644,8 @@ open class CallViewModel: ObservableObject {
         maxParticipants: Int? = nil,
         startsAt: Date? = nil,
         backstage: BackstageSettingsRequest? = nil,
-        customData: [String: RawJSON]? = nil
+        customData: [String: RawJSON]? = nil,
+        team: String? = nil
     ) {
         if enteringCallTask != nil || callingState == .inCall {
             return
@@ -664,7 +668,8 @@ open class CallViewModel: ObservableObject {
                     members: members,
                     custom: customData,
                     settings: settingsRequest,
-                    startsAt: startsAt
+                    startsAt: startsAt,
+                    team: team
                 )
                 let settings = localCallSettingsChange ? callSettings : nil
 


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

This PR adds the "team" option to `CallViewModel`

### 🛠 Implementation

1. Modified `startCall` to include `team`. Also, put it in call creation when ringing
2. Added the option to `enterCall` as well. Modified `enterCall` to support the new option

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)
