### PR TITLE
[Fix]Add team to the CallViewModel and CallViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - `CallViewController` was updated to accept the `video` flag when starting a call. [#811](https://github.com/GetStream/stream-video-swift/pull/811)
+- `team` property when creating calls through `CallViewModel` and/or `CallViewController` [#817](https://github.com/GetStream/stream-video-swift/pull/817)
 
 ### 🐞 Fixed
 - Fix a retain cycle that was causing StreamVideo to leak in projects using NoiseCancellation. [#814](https://github.com/GetStream/stream-video-swift/pull/814)

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -335,6 +335,7 @@ open class CallViewModel: ObservableObject {
         callType: String,
         callId: String,
         members: [Member],
+        team: String? = nil,
         ring: Bool = false,
         maxDuration: Int? = nil,
         maxParticipants: Int? = nil,
@@ -353,6 +354,7 @@ open class CallViewModel: ObservableObject {
                 callType: callType,
                 callId: callId,
                 members: membersRequest ?? [],
+                team: team,
                 ring: ring,
                 maxDuration: maxDuration,
                 maxParticipants: maxParticipants,
@@ -372,6 +374,7 @@ open class CallViewModel: ObservableObject {
                     let callData = try await call.create(
                         members: membersRequest,
                         custom: customData,
+                        team: team,
                         ring: ring,
                         maxDuration: maxDuration,
                         maxParticipants: maxParticipants,
@@ -636,6 +639,7 @@ open class CallViewModel: ObservableObject {
         callType: String,
         callId: String,
         members: [MemberRequest],
+        team: String? = nil,
         ring: Bool = false,
         maxDuration: Int? = nil,
         maxParticipants: Int? = nil,
@@ -664,7 +668,8 @@ open class CallViewModel: ObservableObject {
                     members: members,
                     custom: customData,
                     settings: settingsRequest,
-                    startsAt: startsAt
+                    startsAt: startsAt,
+                    team: team
                 )
                 let settings = localCallSettingsChange ? callSettings : nil
 

--- a/Sources/StreamVideoUIKit/CallViewController.swift
+++ b/Sources/StreamVideoUIKit/CallViewController.swift
@@ -58,6 +58,7 @@ open class CallViewController: UIViewController {
         callType: String,
         callId: String,
         members: [Member],
+        team: String? = nil,
         ring: Bool = false,
         video: Bool? = nil
     ) {
@@ -65,6 +66,7 @@ open class CallViewController: UIViewController {
             callType: callType,
             callId: callId,
             members: members,
+            team: team,
             ring: ring,
             video: video
         )


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-878/add-teamfield-when-creating-a-call-from-callviewmodel-and

### 🎯 Goal

Allow passing the `team` parameter when creating a call from CallViewModel and CallViewController.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)