### PR TITLE
[Fix]`video` parameter when creating a call should be respected

### DIFF
--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -324,7 +324,10 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
                 video: video
             ),
             notify: notify,
-            ring: ring
+            ring: ring,
+            // This parameter is required for setting the video/audio in the
+            // CallKit VoIP notifications.
+            video: video
         )
         let response = try await coordinatorClient.getOrCreateCall(
             type: callType,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-882/video-parameter-when-creating-a-call-should-be-respected

### 🛠 Implementation

There seem to be 2 places where `video` parameter is required when creating a Call. This revisions makes sure that both places are being set as expected.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)