### PR TITLE
[Enhancement]CallKit will report ring timeout as reason when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - When joining a Call, if the user has an external audio device connected, we will ignore the remote `CallSettings.speakerOn = true`. [#819](https://github.com/GetStream/stream-video-swift/pull/819)
+- CallKit will report correctly the rejection reason when ringing timeout is reached. [#820](https://github.com/GetStream/stream-video-swift/pull/820)
 
 ### 🐞 Fixed
 - Fix a retain cycle that was causing StreamVideo to leak in projects using NoiseCancellation. [#814](https://github.com/GetStream/stream-video-swift/pull/814)

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -268,7 +268,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         _ cId: String,
         ringingTimedOut: Bool
     ) {
-        guard var callEndedEntry = callEntry(for: cId) else {
+        guard let callEndedEntry = callEntry(for: cId) else {
             return
         }
         callEndedEntry.ringingTimedOut = ringingTimedOut

--- a/Sources/StreamVideo/Utils/RejectionReasonProvider/RejectionReasonProvider.swift
+++ b/Sources/StreamVideo/Utils/RejectionReasonProvider/RejectionReasonProvider.swift
@@ -59,11 +59,11 @@ final class StreamRejectionReasonProvider: RejectionReasonProviding, @unchecked 
         if isUserBusy {
             return RejectCallRequest.Reason.busy
         } else if isUserRejectingOutgoingCall {
+            return RejectCallRequest.Reason.cancel
+        } else {
             return ringTimeout
                 ? RejectCallRequest.Reason.timeout
-                : RejectCallRequest.Reason.cancel
-        } else {
-            return RejectCallRequest.Reason.decline
+                : RejectCallRequest.Reason.decline
         }
     }
 }

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -11,10 +11,9 @@ import XCTest
 
 final class MicrophoneChecker_Tests: XCTestCase, @unchecked Sendable {
 
-    private nonisolated(unsafe) static var originalCallAudioRecorder: StreamCallAudioRecorder! = StreamCallAudioRecorderKey.currentValue
     private lazy var mockStreamVideo: MockStreamVideo! = .init()
     private lazy var subject: MicrophoneChecker! = .init(valueLimit: 3)
-    private lazy var mockAudioRecorder: MockStreamCallAudioRecorder! = MockStreamCallAudioRecorder(filename: "test.wav")
+    private lazy var mockAudioRecorder: MockStreamCallAudioRecorder! = .init(filename: "test.wav")
 
     override func setUp() {
         super.setUp()
@@ -24,16 +23,11 @@ final class MicrophoneChecker_Tests: XCTestCase, @unchecked Sendable {
 
     override func tearDown() async throws {
         await subject.stopListening()
-        InjectedValues[\.callAudioRecorder] = Self.originalCallAudioRecorder
+        InjectedValues[\.callAudioRecorder] = StreamCallAudioRecorder(filename: "test.wav")
         mockAudioRecorder = nil
         mockStreamVideo = nil
         subject = nil
         try await super.tearDown()
-    }
-
-    override class func tearDown() {
-        Self.originalCallAudioRecorder = nil
-        super.tearDown()
     }
 
     // MARK: - init

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -12,6 +12,7 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
     enum MockCallFunctionKey: Hashable, CaseIterable {
         case get
         case accept
+        case reject
         case join
         case updateTrackSize
         case callKitActivated
@@ -30,6 +31,8 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
         case callKitActivated(audioSession: AVAudioSessionProtocol)
 
+        case reject(reason: String?)
+
         var payload: Any {
             switch self {
             case let .join(create, options, ring, notify, callSettings):
@@ -40,6 +43,9 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
             case let .callKitActivated(audioSession):
                 return audioSession
+
+            case let .reject(reason):
+                return reason ?? ""
             }
         }
     }
@@ -89,6 +95,11 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
     override func accept() async throws -> AcceptCallResponse {
         stubbedFunction[.accept] as! AcceptCallResponse
+    }
+
+    override func reject(reason: String? = nil) async throws -> RejectCallResponse {
+        stubbedFunctionInput[.reject]?.append(.reject(reason: reason))
+        return stubbedFunction[.reject] as! RejectCallResponse
     }
 
     override func join(

--- a/StreamVideoTests/Utils/RejectionReasonProvider/RejectionReasonProvider_Tests.swift
+++ b/StreamVideoTests/Utils/RejectionReasonProvider/RejectionReasonProvider_Tests.swift
@@ -32,7 +32,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase, @unchecked Sendable 
     }
 
     @MainActor
-    func test_rejectionReason_givenRingingCallWithMatchingCidAndRingTimeout_whenUserIsRejectingOutgoingCall_thenReturnsTimeoutReason(
+    func test_rejectionReason_givenRingingCallWithMatchingCidAndRingTimeout_whenUserIsRejectingOutgoingCall_thenReturnsCancelReason(
     ) async {
         let ringingCall = MockCall(.dummy())
         mockStreamVideo.state.ringingCall = ringingCall
@@ -43,7 +43,7 @@ final class StreamRejectionReasonProviderTests: XCTestCase, @unchecked Sendable 
             ringTimeout: true
         )
 
-        XCTAssertEqual(reason, RejectCallRequest.Reason.timeout)
+        XCTAssertEqual(reason, RejectCallRequest.Reason.cancel)
     }
 
     @MainActor
@@ -74,6 +74,21 @@ final class StreamRejectionReasonProviderTests: XCTestCase, @unchecked Sendable 
         )
 
         XCTAssertEqual(reason, RejectCallRequest.Reason.decline)
+    }
+
+    @MainActor
+    func test_rejectionReason_givenRingingCallWithMatchingCidAndRingTimeout_whenUserIsNotBusyAndNotRejectingOutgoingCall_thenReturnsTimeoutReason(
+    ) async {
+        let ringingCall = MockCall(.dummy())
+        mockStreamVideo.state.ringingCall = ringingCall
+        ringingCall.state.createdBy = .dummy()
+
+        let reason = await subject.reason(
+            for: ringingCall.cId,
+            ringTimeout: true
+        )
+
+        XCTAssertEqual(reason, RejectCallRequest.Reason.timeout)
     }
 
     @MainActor


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-876/when-ringing-timeouts-callkit-should-be-reporting-reject-with-reason

### 📝 Summary

CallKit will report correctly the reason `timeout` when the call ringing timeout is reached.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)