### PR TITLE
[Performance]Break async stream memory leaks

### DIFF
--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1403,17 +1403,17 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         }
     }
 
-    internal func onEvent(_ event: WrappedEvent) {
+    internal func onEvent(_ event: WrappedEvent) async {
         guard case let .coordinatorEvent(videoEvent) = event else {
             return
         }
         guard videoEvent.forCall(cid: cId) else {
             return
         }
-        executeOnMain { [weak self] in
+        await Task { @MainActor [weak self] in
             guard let self else { return }
             self.state.updateState(from: videoEvent)
-        }
+        }.value
 
         eventSubject.send(event)
     }

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -17,6 +17,8 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     @Injected(\.callCache) private var callCache
     @Injected(\.timers) private var timers
 
+    private enum DisposableKey: String { case ringEventReceived }
+
     public final class State: ObservableObject, @unchecked Sendable {
         @Published public internal(set) var connection: ConnectionStatus
         @Published public internal(set) var user: User
@@ -62,6 +64,8 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     /// A protocol that provides a method to determine the rejection reason for a call.
     public lazy var rejectionReasonProvider: RejectionReasonProviding = StreamRejectionReasonProvider(self)
 
+    private let eventSubject: PassthroughSubject<WrappedEvent, Never> = .init()
+
     var token: UserToken
 
     private var tokenProvider: UserTokenProvider
@@ -78,7 +82,7 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     private let eventsMiddleware = WSEventsMiddleware()
     private var cachedLocation: String?
     private var connectTask: Task<Void, Error>?
-    private var eventHandlers = [EventHandler]()
+    private let disposableBag = DisposableBag()
 
     /// The notification center used to send and receive notifications about incoming events.
     private(set) lazy var eventNotificationCenter: EventNotificationCenter = {
@@ -216,6 +220,8 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         if autoConnectOnInit {
             initialConnectIfRequired(apiKey: apiKey)
         }
+
+        observeCallRingEvents()
     }
 
     deinit {
@@ -314,9 +320,6 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     
     /// Disconnects the current `StreamVideo` client.
     public func disconnect() async {
-        eventHandlers.forEach { $0.cancel() }
-        eventHandlers.removeAll()
-
         await withCheckedContinuation { [webSocketClient] continuation in
             if let webSocketClient = webSocketClient {
                 webSocketClient.disconnect {
@@ -327,35 +330,50 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
             }
         }
     }
-    
+
+    /// Publishes all received video events coming from the coordinator.
+    ///
+    /// Use this method to observe all incoming `VideoEvent`s regardless of
+    /// specific type. Events are filtered to only include those classified as
+    /// `coordinatorEvent` cases.
+    ///
+    /// - Returns: A publisher emitting `VideoEvent` instances.
+    public func eventPublisher() -> AnyPublisher<VideoEvent, Never> {
+        eventSubject
+            .compactMap {
+                guard case let .coordinatorEvent(event) = $0 else {
+                    return nil
+                }
+                return event
+            }
+            .eraseToAnyPublisher()
+    }
+
+    /// Publishes specific typed WebSocket events.
+    ///
+    /// Use this method to subscribe only to a specific type of event emitted by
+    /// the coordinator. The `WSEvent` must conform to `Event`.
+    ///
+    /// - Parameter event: The type of WebSocket event to observe.
+    /// - Returns: A publisher emitting events of the specified `WSEvent` type.
+    public func eventPublisher<WSEvent: Event>(
+        for event: WSEvent.Type
+    ) -> AnyPublisher<WSEvent, Never> {
+        eventSubject
+            .compactMap { $0.unwrap()?.rawValue as? WSEvent }
+            .eraseToAnyPublisher()
+    }
+
     /// Subscribes to all video events.
     /// - Returns: `AsyncStream` of `VideoEvent`s.
     public func subscribe() -> AsyncStream<VideoEvent> {
-        AsyncStream(VideoEvent.self) { [weak self] continuation in
-            let eventHandler = EventHandler(handler: { event in
-                guard case let .coordinatorEvent(event) = event else {
-                    return
-                }
-                continuation.yield(event)
-            }, cancel: { continuation.finish() })
-            self?.eventHandlers.append(eventHandler)
-        }
+        eventPublisher().eraseAsAsyncStream()
     }
 
     /// Subscribes to a particular WS event.
     /// - Returns: `AsyncStream` of the requested WS event.
     public func subscribe<WSEvent: Event>(for event: WSEvent.Type) -> AsyncStream<WSEvent> {
-        AsyncStream(event) { [weak self] continuation in
-            let eventHandler = EventHandler(handler: { event in
-                guard let coordinatorEvent = event.unwrap() else {
-                    return
-                }
-                if let event = coordinatorEvent.unwrap() as? WSEvent {
-                    continuation.yield(event)
-                }
-            }, cancel: { continuation.finish() })
-            self?.eventHandlers.append(eventHandler)
-        }
+        eventPublisher(for: event).eraseAsAsyncStream()
     }
     
     public func queryCalls(
@@ -489,17 +507,6 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         } else {
             throw ClientError.Unknown()
         }
-        var connected = false
-        var timeout = false
-        let control = DefaultTimer.schedule(timeInterval: 30, queue: .sdk) {
-            timeout = true
-        }
-        log.debug("Listening for WS connection")
-        webSocketClient?.onConnected = {
-            control.cancel()
-            connected = true
-            log.debug("WS connected")
-        }
 
         do {
             log.debug("Listening for WS connection")
@@ -560,12 +567,6 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
             || webSocketClient?.connectionState == .authenticating else {
             return ""
         }
-        
-        var timeout = false
-        let control = DefaultTimer.schedule(timeInterval: 5, queue: .sdk) {
-            timeout = true
-        }
-        log.debug("Waiting for connection id")
 
         do {
             return try await timers
@@ -744,24 +745,55 @@ extension StreamVideo: ConnectionStateDelegate {
                     connectionRecoveryHandler?.webSocketClient(client, didUpdateConnectionState: state)
                 }
             }
-            eventHandlers.forEach { $0.handler(.internalEvent(WSDisconnected())) }
+            eventSubject.send(.internalEvent(WSDisconnected()))
         case .connected(healthCheckInfo: _):
-            eventHandlers.forEach { $0.handler(.internalEvent(WSConnected())) }
+            eventSubject.send(.internalEvent(WSConnected()))
         default:
             log.debug("Web socket connection state update \(state)")
         }
+    }
+
+    /// Observes incoming call ring events from the coordinator.
+    ///
+    /// This method subscribes to `typeCallRingEvent` messages from the internal
+    /// event stream. When such an event is received, it attempts to retrieve or
+    /// create a `Call` object matching the event's call ID and type. Once the
+    /// call is found, it updates the call's state with the event data and sets it
+    /// as the current `ringingCall`.
+    ///
+    /// The resulting subscription is stored in `disposableBag` under a specific
+    /// key to allow later cancellation or cleanup.
+    private func observeCallRingEvents() {
+        eventSubject
+            .eraseToAnyPublisher()
+            .compactMap { (source: WrappedEvent) -> CallRingEvent? in
+                guard
+                    case let .typeCallRingEvent(event) = source.unwrap()
+                else {
+                    return nil
+                }
+                return event
+            }
+            .compactMap { [weak self] (source: CallRingEvent) -> (event: CallRingEvent, call: Call)? in
+                guard let call = self?.call(callType: source.call.type, callId: source.call.id) else {
+                    return nil
+                }
+                return (event: source, call: call)
+            }
+            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in
+                guard let self else { return }
+                $0.call.state.update(from: $0.event)
+                self.state.ringingCall = $0.call
+            }
+            .store(in: disposableBag, key: DisposableKey.ringEventReceived.rawValue)
     }
 }
 
 extension StreamVideo: WSEventsSubscriber {
     
     func onEvent(_ event: WrappedEvent) {
-        for eventHandler in eventHandlers {
-            eventHandler.handler(event)
-        }
-        Task { @MainActor [weak self] in
-            self?.checkRingEvent(event)
-        }
+        eventSubject.send(event)
+        checkRingEvent(event)
     }
 
     private func checkRingEvent(_ event: WrappedEvent) {

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -791,7 +791,7 @@ extension StreamVideo: ConnectionStateDelegate {
 
 extension StreamVideo: WSEventsSubscriber {
     
-    func onEvent(_ event: WrappedEvent) {
+    func onEvent(_ event: WrappedEvent) async {
         eventSubject.send(event)
         checkRingEvent(event)
     }

--- a/Sources/StreamVideo/Utils/ClosedCaptionsAdapter/ClosedCaptionsAdapter.swift
+++ b/Sources/StreamVideo/Utils/ClosedCaptionsAdapter/ClosedCaptionsAdapter.swift
@@ -74,7 +74,8 @@ final class ClosedCaptionsAdapter {
      - Parameter call: The call instance to subscribe for closed caption events.
      */
     private func configure(with call: Call) {
-        cancellable = AsyncStreamPublisher(call.subscribe(for: ClosedCaptionEvent.self))
+        cancellable = call
+            .eventPublisher(for: ClosedCaptionEvent.self)
             .map(\.closedCaption)
             .removeDuplicates()
             .log(.debug) { "Processing closedCaption for speakerId:\($0.speakerId) text:\($0.text)." }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -102,7 +102,11 @@ open class CallViewModel: ObservableObject {
     @Published public var moreControlsShown = false
 
     /// List of the outgoing call members.
-    @Published public var outgoingCallMembers = [Member]()
+    @Published public var outgoingCallMembers = [Member]() {
+        willSet {
+            _ = 0
+        }
+    }
 
     /// Dictionary of the call participants.
     @Published public private(set) var callParticipants = [String: CallParticipant]() {
@@ -169,9 +173,9 @@ open class CallViewModel: ObservableObject {
 
     private var lastLayoutChange = Date()
     private var enteringCallTask: Task<Void, Never>?
-    private var callEventsSubscriptionTask: Task<Void, Never>?
     private var participantsSortComparators = defaultSortPreset
     private let callEventsHandler = CallEventsHandler()
+    private let disposableBag = DisposableBag()
 
     /// The variable is `true` if CallSettings have been set on the CallViewModel instance (directly or indirectly).
     /// The variable will be reset to `false` when `leaveCall` will be invoked.
@@ -211,7 +215,7 @@ open class CallViewModel: ObservableObject {
 
     /// A simple value, signalling that the viewModel has been subscribed to receive callEvents from
     /// `StreamVideo`.
-    var isSubscribedToCallEvents: Bool { callEventsSubscriptionTask != nil }
+    private(set) var isSubscribedToCallEvents: Bool = false
 
     public init(
         participantsLayout: ParticipantsLayout = .grid,
@@ -232,7 +236,7 @@ open class CallViewModel: ObservableObject {
 
     deinit {
         enteringCallTask?.cancel()
-        callEventsSubscriptionTask?.cancel()
+        disposableBag.removeAll()
     }
 
     /// Toggles the state of the camera (visible vs non-visible).
@@ -757,8 +761,10 @@ open class CallViewModel: ObservableObject {
     }
 
     private func subscribeToCallEvents() {
-        callEventsSubscriptionTask = Task {
-            for await event in streamVideo.subscribe() {
+        streamVideo
+            .eventPublisher()
+            .sink { [weak self] event in
+                guard let self else { return }
                 if let callEvent = callEventsHandler.checkForCallEvents(from: event) {
                     switch callEvent {
                     case let .incoming(incomingCall):
@@ -793,12 +799,15 @@ open class CallViewModel: ObservableObject {
                         return
                     }
 
-                    self.participantEvent = participantEvent
-                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                    self.participantEvent = nil
+                    Task { @MainActor in
+                        self.participantEvent = participantEvent
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        self.participantEvent = nil
+                    }
                 }
             }
-        }
+            .store(in: disposableBag)
+        isSubscribedToCallEvents = true
     }
 
     private func handleAcceptedEvent(_ callEvent: CallEvent) {
@@ -857,7 +866,13 @@ open class CallViewModel: ObservableObject {
                 return
             }
             let outgoingMembersCount = outgoingCallMembers.filter { $0.id != streamVideo.user.id }.count
-            let rejections = outgoingCall.state.session?.rejectedBy.count ?? 0
+            let rejections = {
+                if outgoingMembersCount == 1, event.user?.id != streamVideo.user.id {
+                    return 1
+                } else {
+                    return outgoingCall.state.session?.rejectedBy.count ?? 0
+                }
+            }()
             let accepted = outgoingCall.state.session?.acceptedBy.count ?? 0
             if accepted == 0, rejections >= outgoingMembersCount {
                 Task {

--- a/StreamVideoSwiftUITests/CallingViews/LobbyViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/LobbyViewModel_Tests.swift
@@ -17,9 +17,9 @@ final class LobbyViewModelTests: XCTestCase, @unchecked Sendable {
         mockStreamVideo = nil
         try await super.tearDown()
     }
-    
+
     // MARK: - Join Events Tests
-    
+
     func test_subscribeForCallJoinUpdates_addsNewParticipant() async throws {
         let mockCall = MockCall()
         mockCall.stub(
@@ -36,7 +36,7 @@ final class LobbyViewModelTests: XCTestCase, @unchecked Sendable {
         // we wait for loadCurrentMembers to complete
         try await Task.sleep(nanoseconds: 500_000_000)
 
-        mockCall.onEvent(
+        await mockCall.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantJoinedEvent(
                     .init(
@@ -51,9 +51,9 @@ final class LobbyViewModelTests: XCTestCase, @unchecked Sendable {
 
         await fulfilmentInMainActor { self.subject.participants.count == 1 }
     }
-    
+
     // MARK: - Leave Events Tests
-    
+
     func test_subscribeForCallLeaveUpdates_removesParticipant() async throws {
         let mockCall = MockCall()
         mockCall.stub(
@@ -69,7 +69,7 @@ final class LobbyViewModelTests: XCTestCase, @unchecked Sendable {
         _ = subject
         await fulfilmentInMainActor { self.subject.participants.count == 1 }
 
-        mockCall.onEvent(
+        await mockCall.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantLeftEvent(
                     .init(
@@ -85,7 +85,7 @@ final class LobbyViewModelTests: XCTestCase, @unchecked Sendable {
 
         await fulfilmentInMainActor { self.subject.participants.isEmpty }
     }
-    
+
     func test_subscribeForCallLeaveUpdates_doesNotRemoveWrongParticipant() async throws {
         let mockCall = MockCall()
         mockCall.stub(
@@ -108,7 +108,7 @@ final class LobbyViewModelTests: XCTestCase, @unchecked Sendable {
         _ = subject
         await fulfilmentInMainActor { self.subject.participants.count == 2 }
 
-        mockCall.onEvent(
+        await mockCall.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantLeftEvent(
                     .init(

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -552,7 +552,7 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
 
         for step in steps {
             if step.onEventUpdate {
-                call.onEvent(.coordinatorEvent(step.event))
+                await call.onEvent(.coordinatorEvent(step.event))
                 await fulfillment(timeout: 2) { step.validation(call) }
             } else {
                 call.state.updateState(from: step.event)

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -526,7 +526,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
             .transition(MockTestOnlyStage())
 
         await assertTransitionToStage(.blocked) {
-            call.onEvent(
+            await call.onEvent(
                 .coordinatorEvent(
                     .typeBlockedUserEvent(
                         .init(
@@ -550,7 +550,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         subject.call = nil
         await wait(for: 0.5)
 
-        call.onEvent(
+        await call.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantCountsUpdatedEvent(
                     .init(
@@ -574,7 +574,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         let call = Call.dummy(callController: subject)
         await wait(for: 0.5)
 
-        call.onEvent(
+        await call.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantCountsUpdatedEvent(
                     .init(
@@ -601,7 +601,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         let call = Call.dummy(callController: subject)
         await wait(for: 0.5)
 
-        call.onEvent(
+        await call.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantCountsUpdatedEvent(
                     .init(
@@ -628,7 +628,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         let call = Call.dummy(callController: subject)
         await wait(for: 0.5)
 
-        call.onEvent(
+        await call.onEvent(
             .coordinatorEvent(
                 .typeCallSessionParticipantCountsUpdatedEvent(
                     .init(

--- a/StreamVideoTests/StreamVideo_Tests.swift
+++ b/StreamVideoTests/StreamVideo_Tests.swift
@@ -318,7 +318,7 @@ final class StreamVideo_Tests: StreamVideoTestCase, @unchecked Sendable {
 
         // When
         Task {
-            await withThrowingTaskGroup { group in
+            await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
                     for await value in streamVideo.subscribe() {
                         XCTAssertEqual(value, event)
@@ -352,7 +352,7 @@ final class StreamVideo_Tests: StreamVideoTestCase, @unchecked Sendable {
 
         // When
         Task {
-            await withThrowingTaskGroup { group in
+            await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
                     for await value in streamVideo.subscribe(for: CallAcceptedEvent.self) {
                         XCTAssertEqual(value, content)


### PR DESCRIPTION
### 🎯 Goal

AsyncStreams are causing leaks on continuations. This revision attempts to fix that by backing AsyncStream on StreamVideo, by Combine Publishers

### 🧪 Manual Testing Notes

| ✅ | Given               | When                                                   | Then                                                                 |
|----|---------------------|--------------------------------------------------------|----------------------------------------------------------------------|
| 🟠 | In a call alone     | I enable the camera                                    | The camera has a flipping animation                                 |
| 🟠 | In a call           | I rotate the device                                    | The app freezes and then kills the phone                            |
| 🟠 | In a call           | I set a background filter                              | My video track gets stuck and I get disconnected, but UI is frozen  |
| 🟢 | In a call with 4+ participants | I raise a hand                            | It does not show for me, but it does for web participants           |
| 🟠 | In a call with >2 participants | I move app to background and then foreground | All video tracks appear frozen                                      |
| 🟠 | In a call with >2 participants | I move app to background and then foreground | Camera and mic buttons do not work                                  |

### ✅ Call Test Summary

#### Scenario
`1:1 call` for **5 minutes**  
- `noise-cancellation: active`  
- `background-filter: inactive`  
- `profiler: connected`  
- `debugger: disconnected`  

---

#### 🧵 Tasks
| Created | Average Active | Average Alive |
|------------------|----------------|--------------|
| 29309           | 3                 | 13,000    |

#### 🌡️ Thermal State Degradation 
| Start        | End          | Thermal State         |
|--------------|--------------|------------------------|
| 00:00.000    | 00:55.710    | Nominal thermal state  |
| 00:55.710    | 01:25.708    | Fair thermal state     |
| 01:25.708    | 05:16.416    | Serious thermal state  |

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)