### PR TITLE
[CI] Bump snapshot version after every release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,15 +26,15 @@ GEM
     ast (2.4.3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1111.0)
-    aws-sdk-core (3.225.0)
+    aws-partitions (1.1112.0)
+    aws-sdk-core (3.225.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.102.0)
+    aws-sdk-kms (1.103.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-s3 (1.189.0)
@@ -210,7 +210,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.3.82)
+    fastlane-plugin-stream_actions (0.3.83)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-sirp (1.0.0)
@@ -424,7 +424,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-create_xcframework
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.3.82)
+  fastlane-plugin-stream_actions (= 0.3.83)
   fastlane-plugin-versioning
   json
   plist

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ lane :merge_main do
   update_release_version_to_snapshot(file_path: swift_environment_path)
   ensure_git_branch(branch: 'develop')
   sh("git add #{swift_environment_path}")
-  sh("git commit -m 'Update release version to snapshot")
+  sh("git commit -m 'Update release version to snapshot'")
   sh('git push')
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,7 +40,6 @@ end
 
 desc "Release a new version"
 lane :release do |options|
-  previous_version_number = last_git_tag
   artifacts_path = File.absolute_path('../StreamVideoArtifacts.json')
   extra_changes = lambda do |release_version|
     # Set the framework version on the artifacts
@@ -49,7 +48,9 @@ lane :release do |options|
     File.write(artifacts_path, JSON.dump(artifacts))
 
     # Set the framework version in SystemEnvironment+Version.swift
-    new_content = File.read(swift_environment_path).gsub!(previous_version_number, release_version).gsub('-SNAPSHOT', '')
+    old_content = File.read(swift_environment_path)
+    current_version = old_content[/version: String = "([^"]+)"/, 1]
+    new_content = old_content.gsub(current_version, release_version)
     File.open(swift_environment_path, 'w') { |f| f.puts(new_content) }
 
     # Update sdk sizes
@@ -75,11 +76,10 @@ end
 
 lane :merge_main do
   merge_main_to_develop
-  current_version = get_sdk_version_from_environment
-  add_snapshot_to_current_version(file_path: swift_environment_path)
+  update_release_version_to_snapshot(file_path: swift_environment_path)
   ensure_git_branch(branch: 'develop')
   sh("git add #{swift_environment_path}")
-  sh("git commit -m 'Add snapshot postfix to v#{current_version}'")
+  sh("git commit -m 'Update release version to snapshot")
   sh('git push')
 end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,3 +1,3 @@
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-create_xcframework'
-gem 'fastlane-plugin-stream_actions', '0.3.82'
+gem 'fastlane-plugin-stream_actions', '0.3.83'


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-891

### 🎯 Goal

To avoid an issue when AppStore version locks a TestFlight version

### 📝 Summary

|  Before  |  After  |
| -------- | ------- |
|  We used to add a `-SNAPSHOT` postfix to already released version and push it to `develop`.   |  This PR introduces a new approach -  to bump a minor version of an already released version, add a `-SNAPSHOT` postfix and push it to `develop`.  |

### ⚠️ Warning

One time `bundle install` from this branch (or from develop after this PR is merged) is required to be able to release locally next time.

### 🎁 Meme

![gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXRoZDYxa2hnMHFwYWppaHVienFiYzg3MDA4YTYyNmpoY2drY3k0aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mFoCzfWhZmMmf0HMsQ/giphy.gif)
