### PR TITLE
Add video renderer pool prewarming API

### DIFF
--- a/Sources/StreamVideoSwiftUI/VideoRendererConfiguration.swift
+++ b/Sources/StreamVideoSwiftUI/VideoRendererConfiguration.swift
@@ -1,0 +1,29 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Configuration options for video rendering performance optimization.
+public enum VideoRendererConfiguration {
+    
+    /// Prewarms video renderers to avoid UI blocking when video views are first created.
+    /// This should be called early in your app lifecycle, before any video views appear.
+    /// Safe to call from any thread - will never block the caller.
+    ///
+    /// - Parameter count: The number of video renderers to pre-create (default is 2).
+    ///
+    /// ## Usage
+    /// ```swift
+    /// // Early in app lifecycle - simple call, never blocks
+    /// VideoRendererConfiguration.prewarm(count: 5)
+    ///
+    /// // Then later initialize StreamVideo as usual
+    /// let streamVideo = StreamVideo(apiKey: apiKey, user: user, token: token)
+    /// ```
+    public static func prewarm(count: Int = 2) {
+        Task.detached {
+            await VideoRendererPool.configure(initialCapacity: count)
+        }
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Eliminate UI blocking when video renderers are first created during video calls, improving user experience by preventing 150-200ms hangs.

### 📝 Summary

- Add `VideoRendererConfiguration.prewarm()` public API for creating video renderers proactively
- Implement yielding mechanism to prevent continuous UI thread blocking during prewarming
- Fix critical thread safety race condition in `ReusePool` initialization
- Add internal pool configuration method with proper async/await handling

### 🛠 Implementation

**New Public API:**
```swift
// In AppDelegate or early app lifecycle - simple, never blocks
VideoRendererConfiguration.prewarm(count: 4)
```

**Key Implementation Details:**
- **VideoRendererConfiguration**: New public enum providing `prewarm(count:)` method that can be called from any thread
- **Yielding Strategy**: Creates video renderers one at a time with `await Task.yield()` between each creation to prevent blocking the UI thread for extended periods
- **Thread Safety Fix**: Fixed race condition in `ReusePool.init()` where initial elements were created outside of the thread-safe `queue.sync` block
- **Pool Management**: Added `addToAvailable()` method to `ReusePool` for adding pre-created elements beyond initial capacity

**Technical Approach:**
- Video renderers must be created on the main thread (UIView requirement), but prewarming spreads the work across multiple runloop cycles
- Default pool capacity remains 0 (no behavior change without explicit prewarming)
- Frame size during creation is irrelevant as it gets overwritten when renderers are acquired for actual use

### 🧪 Manual Testing Notes

1. **Without Prewarming**: Create a video call and observe ~150-200ms delay when first video view appears
2. **With Prewarming**: Call `VideoRendererConfiguration.prewarm(count: 2)` early in app lifecycle, then create video call - should see immediate video appearance
3. **UI Responsiveness**: During prewarming, verify UI remains responsive (no continuous blocking)
4. **Thread Safety**: Call prewarming from background threads to ensure no crashes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (tutorial, CMS)