### PR TITLE
[Fix]Respect dashboard callSettings for outgoing calls when no local settings provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- The CallViewModel will now respecting the dashboard's `CallSettings` when starting a `Call` with `ring:true` and without provided `CallSettings`. [#841](https://github.com/GetStream/stream-video-swift/pull/841)
 
 # [1.24.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.24.0)
 _June 02, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
-- The CallViewModel will now respecting the dashboard's `CallSettings` when starting a `Call` with `ring:true` and without provided `CallSettings`. [#841](https://github.com/GetStream/stream-video-swift/pull/841)
+- The CallViewModel will now respect the dashboard's `CallSettings` when starting a `Call` with `ring:true` and without provided `CallSettings`. [#841](https://github.com/GetStream/stream-video-swift/pull/841)
 
 # [1.24.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.24.0)
 _June 02, 2025_

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -363,6 +363,9 @@ open class CallViewModel: ObservableObject {
                 customData: customData
             )
         } else {
+            /// If no CallSettings have been provided, we skip passing the default ones, in order to
+            /// respect any dashboard changes.
+            let callSettings = localCallSettingsChange ? callSettings : nil
             let call = streamVideo.call(
                 callType: callType,
                 callId: callId,

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -56,7 +56,14 @@ final class CallViewModel_Tests: StreamVideoTestCase, @unchecked Sendable {
 
         // Then
         XCTAssertEqual(mockStreamVideo.timesCalled(.call), 1)
-        let (recordedCallType, recordedCallId, recordedCallSettings) = try XCTUnwrap(mockStreamVideo.recordedInputPayload((String, String, CallSettings?).self, for: .call)?.first)
+        let (
+            recordedCallType,
+            recordedCallId,
+            recordedCallSettings
+        ) = try XCTUnwrap(
+            mockStreamVideo
+                .recordedInputPayload((String, String, CallSettings?).self, for: .call)?.first
+        )
         XCTAssertEqual(recordedCallType, callType)
         XCTAssertEqual(recordedCallId, callId)
         XCTAssertNil(recordedCallSettings)
@@ -82,7 +89,14 @@ final class CallViewModel_Tests: StreamVideoTestCase, @unchecked Sendable {
 
         // Then
         XCTAssertEqual(mockStreamVideo.timesCalled(.call), 1)
-        let (recordedCallType, recordedCallId, recordedCallSettings) = try XCTUnwrap(mockStreamVideo.recordedInputPayload((String, String, CallSettings?).self, for: .call)?.first)
+        let (
+            recordedCallType,
+            recordedCallId,
+            recordedCallSettings
+        ) = try XCTUnwrap(
+            mockStreamVideo
+                .recordedInputPayload((String, String, CallSettings?).self, for: .call)?.first
+        )
         XCTAssertEqual(recordedCallType, callType)
         XCTAssertEqual(recordedCallId, callId)
         XCTAssertFalse(recordedCallSettings?.audioOn ?? true)

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -37,6 +37,59 @@ final class CallViewModel_Tests: StreamVideoTestCase, @unchecked Sendable {
     }
 
     @MainActor
+    func test_startCall_withoutLocalCallSettingsAndRingTrue_respectsDashboardSettings() async throws {
+        // Given
+        let mockCall = MockCall(.dummy(callType: .default, callId: callId))
+        await streamVideo?.disconnect()
+        streamVideo = nil
+        let mockStreamVideo = MockStreamVideo()
+        mockStreamVideo.stub(for: .call, with: mockCall)
+        let callViewModel = CallViewModel()
+
+        // When
+        callViewModel.startCall(
+            callType: .default,
+            callId: callId,
+            members: participants,
+            ring: true
+        )
+
+        // Then
+        XCTAssertEqual(mockStreamVideo.timesCalled(.call), 1)
+        let (recordedCallType, recordedCallId, recordedCallSettings) = try XCTUnwrap(mockStreamVideo.recordedInputPayload((String, String, CallSettings?).self, for: .call)?.first)
+        XCTAssertEqual(recordedCallType, callType)
+        XCTAssertEqual(recordedCallId, callId)
+        XCTAssertNil(recordedCallSettings)
+    }
+
+    @MainActor
+    func test_startCall_withLocalCallSettingsAndRingTrue_respectsLocalSettings() async throws {
+        // Given
+        let mockCall = MockCall(.dummy(callType: .default, callId: callId))
+        await streamVideo?.disconnect()
+        streamVideo = nil
+        let mockStreamVideo = MockStreamVideo()
+        mockStreamVideo.stub(for: .call, with: mockCall)
+        let callViewModel = CallViewModel(callSettings: .init(audioOn: false, audioOutputOn: false))
+
+        // When
+        callViewModel.startCall(
+            callType: .default,
+            callId: callId,
+            members: participants,
+            ring: true
+        )
+
+        // Then
+        XCTAssertEqual(mockStreamVideo.timesCalled(.call), 1)
+        let (recordedCallType, recordedCallId, recordedCallSettings) = try XCTUnwrap(mockStreamVideo.recordedInputPayload((String, String, CallSettings?).self, for: .call)?.first)
+        XCTAssertEqual(recordedCallType, callType)
+        XCTAssertEqual(recordedCallId, callId)
+        XCTAssertFalse(recordedCallSettings?.audioOn ?? true)
+        XCTAssertFalse(recordedCallSettings?.audioOutputOn ?? true)
+    }
+
+    @MainActor
     func test_startCall_joiningState() {
         // Given
         let callViewModel = CallViewModel()

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -8,6 +8,7 @@ import Foundation
 final class MockCall: Call, Mockable, @unchecked Sendable {
 
     typealias FunctionKey = MockCallFunctionKey
+    typealias FunctionInputKey = MockCallFunctionInputKey
 
     enum MockCallFunctionKey: Hashable, CaseIterable {
         case get
@@ -52,9 +53,8 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
     var stubbedProperty: [String: Any]
     var stubbedFunction: [FunctionKey: Any] = [:]
-    @Atomic var stubbedFunctionInput: [FunctionKey: [MockCallFunctionInputKey]] = MockCallFunctionKey
-        .allCases
-        .reduce(into: [FunctionKey: [MockCallFunctionInputKey]]()) { $0[$1] = [] }
+    @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey.allCases
+        .reduce(into: [FunctionKey: [FunctionInputKey]]()) { $0[$1] = [] }
 
     override var state: CallState {
         get { self[dynamicMember: \.state] }

--- a/StreamVideoTests/Mock/MockStreamVideo.swift
+++ b/StreamVideoTests/Mock/MockStreamVideo.swift
@@ -29,7 +29,6 @@ final class MockStreamVideo: StreamVideo, Mockable, @unchecked Sendable {
         }
     }
 
-
     var stubbedProperty: [String: Any] = [:]
     var stubbedFunction: [FunctionKey: Any] = [:]
     @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey.allCases


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-918/loudspeaker-on-for-caller-when-remote-callsettings-have-speakerfalse

### 📝 Summary

This revision changes the CallViewModel's behaviour when starting a Call with `ring:true`. If no CallSettings have been provided, then the CallViewModel will respect the CallSettings from the dashboard rather than enforcing it's default ones.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)