### PR TITLE
[Fix]CallKitService ending calls wrongly in 1:1

### DIFF
--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -527,12 +527,21 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             return false
         }
 
+        var allMembers = callState.members.map(\.user.toUser)
+        let creator = callState.call.createdBy.toUser
+        let isUserInMembersArray = allMembers.filter { $0.id == creator.id }.isEmpty == false
+        if !isUserInMembersArray {
+            allMembers.append(creator)
+        }
+        let allCallees = allMembers.filter { $0.id != creator.id }
+
         let currentUserId = streamVideo.user.id
         let acceptedBy = callState.call.session?.acceptedBy ?? [:]
         let rejectedBy = callState.call.session?.rejectedBy ?? [:]
         let isAccepted = acceptedBy[currentUserId] != nil
         let isRejected = rejectedBy[currentUserId] != nil
-        let isRejectedByEveryoneElse = rejectedBy.keys.filter { $0 != currentUserId }.count == (callState.members.count - 1)
+        let isRejectedByEveryoneElse = (allCallees.endIndex > 1)
+            && rejectedBy.keys.filter { $0 != currentUserId }.count == (allCallees.endIndex - 1)
         return isAccepted || isRejected || isRejectedByEveryoneElse
     }
 

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -201,6 +201,31 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         try await assertCallWasHandled(wasRejectedByEveryoneElse: true)
     }
 
+    func test_reportIncomingCall_streamVideoReconnectsCallerDidNotReject_callWasNotEnded() async throws {
+        stubConnectionState(to: .disconnected(error: nil))
+        await stubCall(
+            response: .dummy(
+                call: .dummy(
+                    session: .dummy(
+                        acceptedBy: [:],
+                        rejectedBy: [:]
+                    )
+                ),
+                members: [.dummy(userId: user.id)]
+            )
+        )
+        subject.streamVideo = mockedStreamVideo
+
+        try await assertNotRequestTransaction(CXEndCallAction.self) {
+            subject.reportIncomingCall(
+                cid,
+                localizedCallerName: localizedCallerName,
+                callerId: callerId,
+                hasVideo: false
+            ) { _ in }
+        }
+    }
+
     func test_reportIncomingCall_streamVideoConnectedAndCallIsAccepted_callWasEnded() async throws {
         stubConnectionState(to: .connected)
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-940/callkit-ending-a-11-call-wrongly

### 📝 Summary

In some cases, CallKitService was ending a 1:1 call prematurely.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)