### PR TITLE
[Enhancement]Remove IdleTimer handling from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `UIApplication.shared.isIdleTimerDisabled` handling is now happening on the SDK, removing the need to do it on UI level. [#853](https://github.com/GetStream/stream-video-swift/pull/853)
+
 ### 🐞 Fixed
 - CallKit ending 1:1 calls prematurely. [#850](https://github.com/GetStream/stream-video-swift/pull/850)
 

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -102,6 +102,8 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     private let environment: Environment
     private let pushNotificationsConfig: PushNotificationsConfig
 
+    private lazy var idleTimerAdapter = IdleTimerAdapter(self)
+
     /// Initializes a new instance of `StreamVideo` with the specified parameters.
     /// - Parameters:
     ///   - apiKey: The API key.
@@ -195,6 +197,7 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
 
         // Warm up
         _ = eventNotificationCenter
+        _ = idleTimerAdapter
 
         if user.type != .anonymous {
             let userAuth = UserAuth { [weak self] in

--- a/Sources/StreamVideo/Utils/IdleTimerAdapter/IdleTimerAdapter.swift
+++ b/Sources/StreamVideo/Utils/IdleTimerAdapter/IdleTimerAdapter.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+final class IdleTimerAdapter: @unchecked Sendable {
+
+    private(set) var isIdleTimerDisabled: Bool = false
+    private let disposableBag = DisposableBag()
+
+    init(_ activeCallProvider: StreamActiveCallProviding) {
+        #if canImport(UIKit)
+        Task { @MainActor in
+            self.isIdleTimerDisabled = UIApplication.shared.isIdleTimerDisabled
+        }
+        activeCallProvider
+            .hasActiveCallPublisher
+            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in self?.didUpdate(hasActiveCall: $0) }
+            .store(in: disposableBag)
+        #endif
+    }
+
+    // MARK: - Private helpers
+
+    @MainActor
+    private func didUpdate(hasActiveCall: Bool) {
+        #if canImport(UIKit)
+        UIApplication.shared.isIdleTimerDisabled = hasActiveCall
+        isIdleTimerDisabled = hasActiveCall
+        #endif
+    }
+}

--- a/Sources/StreamVideoSwiftUI/CallView/CallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallView.swift
@@ -43,12 +43,6 @@ public struct CallView<Factory: ViewFactory>: View {
         }
         .background(Color(colors.callBackground).edgesIgnoringSafeArea(.all))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-            UIApplication.shared.isIdleTimerDisabled = true
-        }
-        .onDisappear {
-            UIApplication.shared.isIdleTimerDisabled = false
-        }
         .enablePictureInPicture(viewModel.isPictureInPictureEnabled)
         .presentParticipantListView(viewModel: viewModel, viewFactory: viewFactory)
     }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -251,6 +251,8 @@
 		406303422AD848000091AE77 /* CallParticipant_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406303412AD848000091AE77 /* CallParticipant_Mock.swift */; };
 		406303462AD9432D0091AE77 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 406303442AD942ED0091AE77 /* GoogleSignInSwift */; };
 		406303472AD943B60091AE77 /* GoogleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADA682AD3F78F00769F6A /* GoogleHelper.swift */; };
+		406568872E0426FD00A67EAC /* IdleTimerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406568862E0426FD00A67EAC /* IdleTimerAdapter.swift */; };
+		4065688A2E04275F00A67EAC /* IdleTimerAdapter_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406568892E04275F00A67EAC /* IdleTimerAdapter_Tests.swift */; };
 		4065838A2B87695500B4F979 /* BlurBackgroundVideoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406583852B87694B00B4F979 /* BlurBackgroundVideoFilter.swift */; };
 		4065838B2B87695500B4F979 /* VideoFilters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406583872B87694B00B4F979 /* VideoFilters.swift */; };
 		406583902B877A0500B4F979 /* ImageBackgroundVideoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4065838E2B877A0000B4F979 /* ImageBackgroundVideoFilter.swift */; };
@@ -1831,6 +1833,8 @@
 		4061288A2CF33088007F5CDC /* SupportedPrefix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedPrefix.swift; sourceTree = "<group>"; };
 		4063033E2AD847EC0091AE77 /* CallState_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallState_Tests.swift; sourceTree = "<group>"; };
 		406303412AD848000091AE77 /* CallParticipant_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipant_Mock.swift; sourceTree = "<group>"; };
+		406568862E0426FD00A67EAC /* IdleTimerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleTimerAdapter.swift; sourceTree = "<group>"; };
+		406568892E04275F00A67EAC /* IdleTimerAdapter_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleTimerAdapter_Tests.swift; sourceTree = "<group>"; };
 		406583852B87694B00B4F979 /* BlurBackgroundVideoFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurBackgroundVideoFilter.swift; sourceTree = "<group>"; };
 		406583872B87694B00B4F979 /* VideoFilters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoFilters.swift; sourceTree = "<group>"; };
 		4065838E2B877A0000B4F979 /* ImageBackgroundVideoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackgroundVideoFilter.swift; sourceTree = "<group>"; };
@@ -3690,6 +3694,22 @@
 				4063033E2AD847EC0091AE77 /* CallState_Tests.swift */,
 			);
 			path = CallState;
+			sourceTree = "<group>";
+		};
+		406568852E0426F600A67EAC /* IdleTimerAdapter */ = {
+			isa = PBXGroup;
+			children = (
+				406568862E0426FD00A67EAC /* IdleTimerAdapter.swift */,
+			);
+			path = IdleTimerAdapter;
+			sourceTree = "<group>";
+		};
+		406568882E04275700A67EAC /* IdleTimerAdapter */ = {
+			isa = PBXGroup;
+			children = (
+				406568892E04275F00A67EAC /* IdleTimerAdapter_Tests.swift */,
+			);
+			path = IdleTimerAdapter;
 			sourceTree = "<group>";
 		};
 		406583832B87694B00B4F979 /* VideoFilters */ = {
@@ -5584,6 +5604,7 @@
 		842747F429EEDACB00E063AD /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				406568882E04275700A67EAC /* IdleTimerAdapter */,
 				40FAAC872DDC9F83007BF93A /* ConsumableBucket */,
 				40FAAC852DDC9B2D007BF93A /* AnyEncodable.swift */,
 				40B3E5392DBBAF8B00DE8F50 /* Proximity */,
@@ -6091,6 +6112,7 @@
 		84AF64D3287C79220012A503 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				406568852E0426F600A67EAC /* IdleTimerAdapter */,
 				404098C72DDF45DA00D7BEC5 /* SelectiveEncodable */,
 				4028FEA72DC536BB001F9DC3 /* AnyEncodable.swift */,
 				4028FE962DC4F62A001F9DC3 /* ConsumableBucket */,
@@ -7611,6 +7633,7 @@
 				84DC38DB29ADFCFD00946713 /* JSONDataEncoding.swift in Sources */,
 				40FB15112BF77D5800D5E580 /* StreamStateMachineStage.swift in Sources */,
 				8496A9A629CC500F00F15FF1 /* StreamVideoCaptureHandler.swift in Sources */,
+				406568872E0426FD00A67EAC /* IdleTimerAdapter.swift in Sources */,
 				84CD12162C73831000056640 /* CallRtmpBroadcastStartedEvent.swift in Sources */,
 				8411925E28C5E5D00074EF88 /* RTCConfiguration+Default.swift in Sources */,
 				8409465929AF4EEC007AF5BF /* SendReactionResponse.swift in Sources */,
@@ -8207,6 +8230,7 @@
 				40382F3D2C89C11D00C2D00F /* MockRTCPeerConnectionCoordinatorFactory.swift in Sources */,
 				4013A8EF2D81E98C00F81C15 /* WebRTCCoordinatorStateMachine_BlockedStageTests.swift in Sources */,
 				40AB31262A49838000C270E1 /* EventTests.swift in Sources */,
+				4065688A2E04275F00A67EAC /* IdleTimerAdapter_Tests.swift in Sources */,
 				84F58B7C29EE979F00010C4C /* VirtualTime.swift in Sources */,
 				40B3E5492DBBD2CA00DE8F50 /* SpeakerProximityPolicy_Tests.swift in Sources */,
 				40F0173E2BBEB86800E89FD1 /* TestsAuthenticationProvider.swift in Sources */,

--- a/StreamVideoTests/Utils/IdleTimerAdapter/IdleTimerAdapter_Tests.swift
+++ b/StreamVideoTests/Utils/IdleTimerAdapter/IdleTimerAdapter_Tests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class IdleTimerAdapter_Tests: XCTestCase, @unchecked Sendable {
+
+    private var mockActiveCallProvider: MockActiveCallProvider! = .init()
+    private lazy var subject: IdleTimerAdapter! = .init(mockActiveCallProvider)
+
+    override func setUp() {
+        super.setUp()
+        _ = subject
+    }
+
+    override func tearDown() {
+        subject = nil
+        mockActiveCallProvider = nil
+        super.tearDown()
+    }
+
+    // MARK: - hasActiveCall
+
+    func test_hasActiveCall_isTrue_IdleTimerIsDisabled() async {
+        mockActiveCallProvider.subject.send(true)
+
+        await fulfilmentInMainActor { self.subject.isIdleTimerDisabled == true }
+    }
+
+    func test_hasActiveCall_isFalse_IdleTimerIsEnabled() async {
+        mockActiveCallProvider.subject.send(false)
+
+        await fulfilmentInMainActor { self.subject.isIdleTimerDisabled == false }
+    }
+
+    func test_hasActiveCall_changesFromFalseToTrue_firstIsEnabledThenDisabled() async {
+        mockActiveCallProvider.subject.send(false)
+        await fulfilmentInMainActor { self.subject.isIdleTimerDisabled == false }
+
+        mockActiveCallProvider.subject.send(true)
+        await fulfilmentInMainActor { self.subject.isIdleTimerDisabled == true }
+    }
+
+    func test_hasActiveCall_changesFromTrueToFalse_firstIsDisabledThenEnabled() async {
+        mockActiveCallProvider.subject.send(true)
+        await fulfilmentInMainActor { self.subject.isIdleTimerDisabled == true }
+
+        mockActiveCallProvider.subject.send(false)
+        await fulfilmentInMainActor { self.subject.isIdleTimerDisabled == false }
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

This PR removes the `UIApplication.shared.isIdleTimerDisabled` handling from UI and makes it an SDK responsibility. That should make UI creation simpler and less error prone.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)