### PR TITLE
[Fix]Reconnection loop when trying to join an ended call without required permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Reconnection loop when a user tries to rejoin an ended call but they don't have permissions to join ended calls. [#864](https://github.com/GetStream/stream-video-swift/pull/864)
 - When receiving calls while the app is not running, the Call layout may appear wrong for 1:1 calls. [#863](https://github.com/GetStream/stream-video-swift/pull/863)
 
 # [1.27.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.27.0)

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
@@ -69,6 +69,11 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     subsystems: .webRTC
                 )
             } else if let error = context.flowError {
+                // If we got here from an unrecoverable error, we won't attempt
+                // any reconnection and instead we will disconnect.
+                if let apiError = error as? APIError, apiError.unrecoverable == true {
+                    context.reconnectionStrategy = .disconnected
+                }
                 log.error(
                     "Disconnected from \(previousStage.id) due to \(error).",
                     subsystems: .webRTC

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift
@@ -119,6 +119,23 @@ final class WebRTCCoordinatorStateMachine_DisconnectedStageTests: XCTestCase, @u
         }
     }
 
+    func test_transition_flowErrorIsUnrecoverable_reconnectionStrategyChangesToDisconnected() {
+        subject.context.reconnectionStrategy = .rejoin
+        subject.context.flowError = APIError(
+            code: 0,
+            details: [],
+            duration: "0",
+            message: .unique,
+            moreInfo: .unique,
+            statusCode: 401,
+            unrecoverable: true
+        )
+
+        _ = subject.transition(from: .connected(subject.context))
+
+        XCTAssertEqual(subject.context.reconnectionStrategy, .disconnected)
+    }
+
     // MARK: observeInternetConnection
 
     func test_transition_connectionRestoresWithDisconnectedStrategy_landsOnLeaving() async {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-942/patreonnon-ending-tries-to-join-ended-livestream

### 🛠 Implementation

The WebRTC state machine stages now respect the `unrecoverable` flag on the APIEError object.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)