### PR TITLE
[Fix]Issue causing speaker to not be respected when joining

### DIFF
--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -129,7 +129,6 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         // to ensure it's uniqueness.
         _ = stateMachine
         subscribeToOwnCapabilitiesChanges()
-        subscribeToLocalCallSettingsChanges()
     }
 
     /// Joins the current call.
@@ -1511,58 +1510,6 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
                 }
                 .store(in: disposableBag)
         }
-    }
-
-    private func subscribeToLocalCallSettingsChanges() {
-        speaker.$status.dropFirst().sink { [weak self] status in
-            guard let self else { return }
-            Task(disposableBag: disposableBag) { @MainActor [weak self] in
-                guard let self else { return }
-                let newState = self.state.callSettings.withUpdatedSpeakerState(status.boolValue)
-                self.state.update(callSettings: newState)
-            }
-        }
-        .store(in: disposableBag)
-
-        speaker.$audioOutputStatus.dropFirst().sink { [weak self] status in
-            guard let self else { return }
-            Task(disposableBag: disposableBag) { @MainActor [weak self] in
-                guard let self else { return }
-                let newState = self.state.callSettings.withUpdatedAudioOutputState(status.boolValue)
-                self.state.update(callSettings: newState)
-            }
-        }
-        .store(in: disposableBag)
-
-        camera.$status.dropFirst().sink { [weak self] status in
-            guard let self else { return }
-            Task(disposableBag: disposableBag) { @MainActor [weak self] in
-                guard let self else { return }
-                let newState = self.state.callSettings.withUpdatedVideoState(status.boolValue)
-                self.state.update(callSettings: newState)
-            }
-        }
-        .store(in: disposableBag)
-
-        camera.$direction.dropFirst().sink { [weak self] position in
-            guard let self else { return }
-            Task(disposableBag: disposableBag) { @MainActor [weak self] in
-                guard let self else { return }
-                let newState = self.state.callSettings.withUpdatedCameraPosition(position)
-                self.state.update(callSettings: newState)
-            }
-        }
-        .store(in: disposableBag)
-
-        microphone.$status.dropFirst().sink { [weak self] status in
-            guard let self else { return }
-            Task(disposableBag: disposableBag) { @MainActor [weak self] in
-                guard let self else { return }
-                let newState = self.state.callSettings.withUpdatedAudioState(status.boolValue)
-                self.state.update(callSettings: newState)
-            }
-        }
-        .store(in: disposableBag)
     }
 
     private func subscribeToNoiseCancellationSettingsChanges() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-962/blinkorjuleoploudspeaker-enabled-when-it-shouldnt

### 📝 Summary

This revision removes an unnecessary path that updates the Call.CallState.CallSettings causing components to go out of sync.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)