### PR TITLE
[Enhancement]Incoming video pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- `ClientCapabilities` have been added to support remote subscriber track pause. [#888](https://github.com/GetStream/stream-video-swift/pull/888)
 
 # [1.28.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.28.1)
 _July 11, 2025_

--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -620,6 +620,20 @@ extension AppEnvironment {
     }()
 }
 
+extension AppEnvironment {
+
+    static var clientCapabilities: Set<ClientCapability> = []
+}
+
+extension ClientCapability: Debuggable {
+    var title: String {
+        switch self {
+        case .subscriberVideoPause:
+            "Subscriber video pause"
+        }
+    }
+}
+
 extension String: Debuggable {
     var title: String {
         self

--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -622,7 +622,7 @@ extension AppEnvironment {
 
 extension AppEnvironment {
 
-    static var clientCapabilities: Set<ClientCapability> = []
+    static var clientCapabilities: Set<ClientCapability>?
 }
 
 extension ClientCapability: Debuggable {

--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -198,8 +198,7 @@ struct SimpleCallingView: View {
     }
 
     private func setClientCapabilities(for callId: String) async {
-        let clientCapabilities = AppEnvironment.clientCapabilities
-        guard !clientCapabilities.isEmpty else {
+        guard let clientCapabilities = AppEnvironment.clientCapabilities else {
             return
         }
         let call = streamVideo.call(callType: callType, callId: callId)

--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -197,6 +197,15 @@ struct SimpleCallingView: View {
         try policies.forEach { try call.addProximityPolicy($0) }
     }
 
+    private func setClientCapabilities(for callId: String) async {
+        let clientCapabilities = AppEnvironment.clientCapabilities
+        guard !clientCapabilities.isEmpty else {
+            return
+        }
+        let call = streamVideo.call(callType: callType, callId: callId)
+        await call.updateClientCapabilities(clientCapabilities)
+    }
+
     private func parseURLIfRequired(_ text: String) {
         let adapter = DeeplinkAdapter()
         guard
@@ -234,6 +243,7 @@ struct SimpleCallingView: View {
             await setPreferredVideoCodec(for: text)
             try? await setAudioSessionPolicyOverride(for: text)
             try? setProximityPolicies(for: text)
+            await setClientCapabilities(for: text)
             viewModel.enterLobby(
                 callType: callType,
                 callId: text,
@@ -243,11 +253,13 @@ struct SimpleCallingView: View {
             await setPreferredVideoCodec(for: text)
             try? await setAudioSessionPolicyOverride(for: text)
             try? setProximityPolicies(for: text)
+            await setClientCapabilities(for: text)
             viewModel.joinCall(callType: callType, callId: text)
         case let .start(callId):
             await setPreferredVideoCodec(for: callId)
             try? await setAudioSessionPolicyOverride(for: callId)
             try? setProximityPolicies(for: callId)
+            await setClientCapabilities(for: callId)
             viewModel.startCall(
                 callType: callType,
                 callId: callId,

--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -202,7 +202,7 @@ struct SimpleCallingView: View {
             return
         }
         let call = streamVideo.call(callType: callType, callId: callId)
-        await call.updateClientCapabilities(clientCapabilities)
+        await call.enableClientCapabilities(clientCapabilities)
     }
 
     private func parseURLIfRequired(_ text: String) {

--- a/DemoApp/Sources/Views/Login/DebugMenu.swift
+++ b/DemoApp/Sources/Views/Login/DebugMenu.swift
@@ -129,6 +129,10 @@ struct DebugMenu: View {
         didSet { AppEnvironment.proximityPolicies = proximityPolicies }
     }
 
+    @State private var clientCapabilities = AppEnvironment.clientCapabilities {
+        didSet { AppEnvironment.clientCapabilities = clientCapabilities }
+    }
+
     var body: some View {
         Menu {
             makeMenu(
@@ -187,6 +191,18 @@ struct DebugMenu: View {
                 currentValue: closedCaptionsIntegration,
                 label: "ClosedCaptions Integration"
             ) { self.closedCaptionsIntegration = $0 }
+
+            makeMultipleSelectMenu(
+                for: ClientCapability.allCases,
+                currentValues: clientCapabilities,
+                label: "Client Capabilities"
+            ) { item, isSelected in
+                if isSelected {
+                    clientCapabilities = clientCapabilities.filter { item != $0 }
+                } else {
+                    clientCapabilities.insert(item)
+                }
+            }
 
             makeMenu(
                 for: [.default, .ownCapabilities],

--- a/DemoApp/Sources/Views/Reactions/ReactionOverlayView.swift
+++ b/DemoApp/Sources/Views/Reactions/ReactionOverlayView.swift
@@ -57,7 +57,8 @@ struct ReactionOverlayView_Previews: PreviewProvider {
                 joinedAt: Date(),
                 audioLevel: 0,
                 audioLevels: [],
-                pin: nil
+                pin: nil,
+                pausedTracks: []
             )
         )
     }

--- a/DemoApp/Sources/Views/Reactions/ReactionsViewModifier.swift
+++ b/DemoApp/Sources/Views/Reactions/ReactionsViewModifier.swift
@@ -55,7 +55,8 @@ struct ReactionsViewModifier_Previews: PreviewProvider {
                         joinedAt: Date(),
                         audioLevel: 0,
                         audioLevels: [],
-                        pin: nil
+                        pin: nil,
+                        pausedTracks: []
                     )
                 )
             )

--- a/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
+++ b/DocumentationTests/DocumentationTests/DocumentationTests.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		4029E95E2CB94EAE00E1D571 /* 22-manual-quality-selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4029E95D2CB94EA700E1D571 /* 22-manual-quality-selection.swift */; };
 		404CAED82B8E3874007087BC /* 06-apply-video-filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404CAED72B8E3874007087BC /* 06-apply-video-filters.swift */; };
 		4068C1252B67C056006B0BEE /* 03-callkit-integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */; };
+		40895E622E264BB000D3049D /* 25-incoming-video-state.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40895E612E264BB000D3049D /* 25-incoming-video-state.swift */; };
 		408CE0F52BD91B490052EC3A /* 19-transcriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408CE0F42BD91B490052EC3A /* 19-transcriptions.swift */; };
 		409774B02CC19F5500E0D3EE /* 23-network-disruption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409774AF2CC19F4900E0D3EE /* 23-network-disruption.swift */; };
 		409C39692B67CC5C0090044C /* 04-screensharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C39682B67CC5C0090044C /* 04-screensharing.swift */; };
@@ -102,6 +103,7 @@
 		4029E95D2CB94EA700E1D571 /* 22-manual-quality-selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "22-manual-quality-selection.swift"; sourceTree = "<group>"; };
 		404CAED72B8E3874007087BC /* 06-apply-video-filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "06-apply-video-filters.swift"; sourceTree = "<group>"; };
 		4068C1242B67C056006B0BEE /* 03-callkit-integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-callkit-integration.swift"; sourceTree = "<group>"; };
+		40895E612E264BB000D3049D /* 25-incoming-video-state.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "25-incoming-video-state.swift"; sourceTree = "<group>"; };
 		408CE0F42BD91B490052EC3A /* 19-transcriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "19-transcriptions.swift"; sourceTree = "<group>"; };
 		409774AF2CC19F4900E0D3EE /* 23-network-disruption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "23-network-disruption.swift"; sourceTree = "<group>"; };
 		409C39682B67CC5C0090044C /* 04-screensharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-screensharing.swift"; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				4029E95D2CB94EA700E1D571 /* 22-manual-quality-selection.swift */,
 				409774AF2CC19F4900E0D3EE /* 23-network-disruption.swift */,
 				401C1EF32D494CED00304609 /* 24-closed-captions.swift */,
+				40895E612E264BB000D3049D /* 25-incoming-video-state.swift */,
 			);
 			path = "05-ui-cookbook";
 			sourceTree = "<group>";
@@ -487,6 +490,7 @@
 				40FFDC442B63E95D004DA7A2 /* 14-swiftui-vs-uikit.swift in Sources */,
 				40FFDC872B63FEAE004DA7A2 /* 05-incoming-call.swift in Sources */,
 				4029E95E2CB94EAE00E1D571 /* 22-manual-quality-selection.swift in Sources */,
+				40895E622E264BB000D3049D /* 25-incoming-video-state.swift in Sources */,
 				40FFDC942B6401CC004DA7A2 /* 07-video-fallback.swift in Sources */,
 				400D91C72B63D96800EBA47D /* 03-quickstart.swift in Sources */,
 				40FFDC9E2B64063D004DA7A2 /* 12-connection-unstable.swift in Sources */,

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/25-incoming-video-state.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/25-incoming-video-state.swift
@@ -7,7 +7,7 @@ import Combine
 fileprivate func content() {
     asyncContainer {
         let call = streamVideo.call(callType: "default", callId: "my-call-id")
-        await call.updateClientCapabilities([.subscriberVideoPause])
+        await call.updateClientCapabilities([])
     }
 
     container {
@@ -24,5 +24,145 @@ fileprivate func content() {
 
         // Cancel when no longer needed:
         cancellable.cancel()
+    }
+
+    viewContainer {
+        if participant.pausedTracks.contains(.video) {
+            Image(systemName: "video.slash.fill")
+                .foregroundColor(.yellow)
+                .padding(4)
+        }
+    }
+
+    container {
+        struct ParticipantInfoView: View {
+            @Injected(\.images) var images
+            @Injected(\.fonts) var fonts
+            @Injected(\.colors) var colors
+
+            var participant: CallParticipant
+            var isPinned: Bool
+            var maxHeight: CGFloat
+
+            public init(
+                participant: CallParticipant,
+                isPinned: Bool,
+                maxHeight: Float = 14
+            ) {
+                self.participant = participant
+                self.isPinned = isPinned
+                self.maxHeight = CGFloat(maxHeight)
+            }
+
+            public var body: some View {
+                HStack(spacing: 4) {
+                    if isPinned {
+                        Image(systemName: "pin.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: maxHeight)
+                            .foregroundColor(.white)
+                            .padding(.trailing, 4)
+                    }
+                    Text(participant.name.isEmpty ? participant.id : participant.name)
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(1)
+                        .font(fonts.caption1)
+                        .minimumScaleFactor(0.7)
+                        .accessibility(identifier: "participantName")
+
+                    if participant.pausedTracks.contains(.video) {
+                        Image(systemName: "wifi.slash")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: maxHeight)
+                            .foregroundColor(.white)
+                            .padding(.trailing, 4)
+                    }
+
+                    SoundIndicator(participant: participant)
+                        .frame(maxHeight: maxHeight)
+                }
+                .padding(.all, 2)
+                .padding(.horizontal, 4)
+                .frame(height: 28)
+                .cornerRadius(
+                    8,
+                    corners: [.topRight],
+                    backgroundColor: colors.participantInfoBackgroundColor
+                )
+            }
+        }
+    }
+
+    container {
+        struct VideoCallParticipantModifier: ViewModifier {
+
+            var participant: CallParticipant
+            var call: Call?
+            var availableFrame: CGRect
+            var ratio: CGFloat
+            var showAllInfo: Bool
+            var decorations: Set<VideoCallParticipantDecoration>
+
+            public init(
+                participant: CallParticipant,
+                call: Call?,
+                availableFrame: CGRect,
+                ratio: CGFloat,
+                showAllInfo: Bool,
+                decorations: [VideoCallParticipantDecoration] = VideoCallParticipantDecoration.allCases
+            ) {
+                self.participant = participant
+                self.call = call
+                self.availableFrame = availableFrame
+                self.ratio = ratio
+                self.showAllInfo = showAllInfo
+                self.decorations = .init(decorations)
+            }
+
+            public func body(content: Content) -> some View {
+                content
+                    .adjustVideoFrame(to: availableFrame.size.width, ratio: ratio)
+                    .overlay(
+                        ZStack {
+                            BottomView(content: {
+                                HStack {
+                                    ParticipantInfoView(
+                                        participant: participant,
+                                        isPinned: participant.isPinned
+                                    )
+
+                                    Spacer()
+
+                                    if showAllInfo {
+                                        ConnectionQualityIndicator(
+                                            connectionQuality: participant.connectionQuality
+                                        )
+                                    }
+                                }
+                            })
+                        }
+                    )
+                    .applyDecorationModifierIfRequired(
+                        VideoCallParticipantOptionsModifier(participant: participant, call: call),
+                        decoration: .options,
+                        availableDecorations: decorations
+                    )
+                    .applyDecorationModifierIfRequired(
+                        VideoCallParticipantSpeakingModifier(participant: participant, participantCount: participantCount),
+                        decoration: .speaking,
+                        availableDecorations: decorations
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .clipped()
+            }
+
+            @MainActor
+            private var participantCount: Int {
+                call?.state.participants.count ?? 0
+            }
+        }
     }
 }

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/25-incoming-video-state.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/25-incoming-video-state.swift
@@ -1,0 +1,28 @@
+import StreamVideo
+import StreamVideoSwiftUI
+import SwiftUI
+import Combine
+
+@MainActor
+fileprivate func content() {
+    asyncContainer {
+        let call = streamVideo.call(callType: "default", callId: "my-call-id")
+        await call.updateClientCapabilities([.subscriberVideoPause])
+    }
+
+    container {
+        let cancellable = call
+            .state
+            .$participants
+            .sink { participants in
+                let pausedVideoParticipants = participants.filter {
+                    $0.pausedTracks.contains(.video)
+                }
+
+                print("Participants with paused video tracks: \(pausedVideoParticipants)")
+            }
+
+        // Cancel when no longer needed:
+        cancellable.cancel()
+    }
+}

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/25-incoming-video-state.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/25-incoming-video-state.swift
@@ -7,7 +7,7 @@ import Combine
 fileprivate func content() {
     asyncContainer {
         let call = streamVideo.call(callType: "default", callId: "my-call-id")
-        await call.updateClientCapabilities([])
+        await call.disableClientCapabilities([.subscriberVideoPause])
     }
 
     container {

--- a/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/GloballyUsedVariables.swift
@@ -37,7 +37,8 @@ var participant = CallParticipant(
     joinedAt: .init(),
     audioLevel: 0,
     audioLevels: [],
-    pin: nil
+    pin: nil,
+    pausedTracks: []
 )
 var contentMode = UIView.ContentMode.scaleAspectFit
 var id = ""
@@ -421,7 +422,8 @@ var otherParticipant = CallParticipant(
     joinedAt: .init(),
     audioLevel: 0,
     audioLevels: [],
-    pin: nil
+    pin: nil,
+    pausedTracks: []
 )
 
 final class UserManager {

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1389,14 +1389,32 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         proximity.remove(policy)
     }
 
-    // MARK: - ClientCapabilities
+    // MARK: - Client Capabilities
 
-    /// Updates the set of client capabilities for the call.
+    /// Enables a set of client capabilities for the call.
     ///
-    /// - Parameter clientCapabilities: A set of client capabilities that influence
-    ///     subscription logic (e.g., support for paused tracks).
-    public func updateClientCapabilities(_ clientCapabilities: Set<ClientCapability>) async {
-        await callController.updateClientCapabilities(clientCapabilities)
+    /// Use this to activate one or more client capabilities for the current call
+    /// session. Enabling capabilities may affect how features such as paused tracks,
+    /// bandwidth management, or other optional behaviors work for this call.
+    ///
+    /// - Parameter capabilities: The set of capabilities to enable.
+    public func enableClientCapabilities(
+        _ capabilities: Set<ClientCapability>
+    ) async {
+        await callController.enableClientCapabilities(capabilities)
+    }
+
+    /// Disables a set of client capabilities for the call.
+    ///
+    /// Use this to deactivate one or more client capabilities for the current call
+    /// session. Disabling capabilities can limit or remove optional features
+    /// associated with those capabilities.
+    ///
+    /// - Parameter capabilities: The set of capabilities to disable.
+    public func disableClientCapabilities(
+        _ capabilities: Set<ClientCapability>
+    ) async {
+        await callController.disableClientCapabilities(capabilities)
     }
 
     // MARK: - Internal

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -1389,6 +1389,16 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         proximity.remove(policy)
     }
 
+    // MARK: - ClientCapabilities
+
+    /// Updates the set of client capabilities for the call.
+    ///
+    /// - Parameter clientCapabilities: A set of client capabilities that influence
+    ///     subscription logic (e.g., support for paused tracks).
+    public func updateClientCapabilities(_ clientCapabilities: Set<ClientCapability>) async {
+        await callController.updateClientCapabilities(clientCapabilities)
+    }
+
     // MARK: - Internal
 
     internal func update(reconnectionStatus: ReconnectionStatus) {

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -505,6 +505,10 @@ class CallController: @unchecked Sendable {
         try webRTCCoordinator.callKitActivated(audioSession)
     }
 
+    func updateClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        await webRTCCoordinator.updateClientCapabilities(capabilities)
+    }
+
     // MARK: - private
 
     private func handleParticipantsUpdated() {

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -505,8 +505,14 @@ class CallController: @unchecked Sendable {
         try webRTCCoordinator.callKitActivated(audioSession)
     }
 
-    func updateClientCapabilities(_ capabilities: Set<ClientCapability>) async {
-        await webRTCCoordinator.updateClientCapabilities(capabilities)
+    // MARK: - Client Capabilities
+
+    func enableClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        await webRTCCoordinator.enableClientCapabilities(capabilities)
+    }
+
+    func disableClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        await webRTCCoordinator.disableClientCapabilities(capabilities)
     }
 
     // MARK: - private

--- a/Sources/StreamVideo/Models/CallParticipant.swift
+++ b/Sources/StreamVideo/Models/CallParticipant.swift
@@ -43,7 +43,17 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
     public var audioLevel: Float
     /// List of the last 10 audio levels.
     public var audioLevels: [Float]
+    /// Pinning metadata used to keep this participant visible across layouts.
+    ///
+    /// If set, the participant is considered pinned either locally or remotely.
+    /// SDK integrators can use this to reflect UI state (e.g., always visible).
     public var pin: PinInfo?
+
+    /// The set of media track types currently paused for this participant.
+    ///
+    /// This is used to control bandwidth or presentation. SDK integrators can
+    /// rely on it to know when a participant's track has been paused remotely.
+    public var pausedTracks: Set<TrackType>
 
     /// The user's id. This is not necessarily unique, since a user can join from multiple devices.
     public var userId: String {
@@ -81,7 +91,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
         joinedAt: Date,
         audioLevel: Float,
         audioLevels: [Float],
-        pin: PinInfo?
+        pin: PinInfo?,
+        pausedTracks: Set<TrackType>
     ) {
         user = User(
             id: userId,
@@ -106,6 +117,7 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
         self.audioLevel = audioLevel
         self.audioLevels = audioLevels
         self.pin = pin
+        self.pausedTracks = pausedTracks
     }
 
     public static func == (lhs: CallParticipant, rhs: CallParticipant) -> Bool {
@@ -127,7 +139,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             lhs.audioLevels == rhs.audioLevels &&
             lhs.pin == rhs.pin &&
             lhs.track === rhs.track &&
-            lhs.screenshareTrack === rhs.screenshareTrack
+            lhs.screenshareTrack === rhs.screenshareTrack &&
+            lhs.pausedTracks == rhs.pausedTracks
     }
 
     public var isPinned: Bool {
@@ -141,7 +154,7 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
 
     /// Determines whether the track of the participant should be displayed.
     public var shouldDisplayTrack: Bool {
-        hasVideo && showTrack && track != nil
+        hasVideo && showTrack && track != nil && pausedTracks.contains(.video) == false
     }
 
     public func withUpdated(trackSize: CGSize) -> CallParticipant {
@@ -166,7 +179,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -192,7 +206,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -218,7 +233,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -244,7 +260,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -270,7 +287,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -296,7 +314,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -322,7 +341,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -348,7 +368,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -383,7 +404,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: levels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -409,7 +431,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -435,7 +458,8 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 
@@ -461,7 +485,66 @@ public struct CallParticipant: Identifiable, Sendable, Hashable {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
+        )
+    }
+
+    public func withPausedTrack(_ trackType: TrackType) -> CallParticipant {
+        var updatedPausedTracks = pausedTracks
+        updatedPausedTracks.insert(trackType)
+        return CallParticipant(
+            id: id,
+            userId: userId,
+            roles: roles,
+            name: name,
+            profileImageURL: profileImageURL,
+            trackLookupPrefix: trackLookupPrefix,
+            hasVideo: hasVideo,
+            hasAudio: hasAudio,
+            isScreenSharing: isScreensharing,
+            showTrack: showTrack,
+            track: track,
+            trackSize: trackSize,
+            screenshareTrack: screenshareTrack,
+            isSpeaking: isSpeaking,
+            isDominantSpeaker: isDominantSpeaker,
+            sessionId: sessionId,
+            connectionQuality: connectionQuality,
+            joinedAt: joinedAt,
+            audioLevel: audioLevel,
+            audioLevels: audioLevels,
+            pin: pin,
+            pausedTracks: updatedPausedTracks
+        )
+    }
+
+    public func withUnpausedTrack(_ trackType: TrackType) -> CallParticipant {
+        var updatedPausedTracks = pausedTracks
+        updatedPausedTracks.remove(trackType)
+        return CallParticipant(
+            id: id,
+            userId: userId,
+            roles: roles,
+            name: name,
+            profileImageURL: profileImageURL,
+            trackLookupPrefix: trackLookupPrefix,
+            hasVideo: hasVideo,
+            hasAudio: hasAudio,
+            isScreenSharing: isScreensharing,
+            showTrack: showTrack,
+            track: track,
+            trackSize: trackSize,
+            screenshareTrack: screenshareTrack,
+            isSpeaking: isSpeaking,
+            isDominantSpeaker: isDominantSpeaker,
+            sessionId: sessionId,
+            connectionQuality: connectionQuality,
+            joinedAt: joinedAt,
+            audioLevel: audioLevel,
+            audioLevels: audioLevels,
+            pin: pin,
+            pausedTracks: updatedPausedTracks
         )
     }
 }

--- a/Sources/StreamVideo/Models/ClientCapability.swift
+++ b/Sources/StreamVideo/Models/ClientCapability.swift
@@ -1,0 +1,42 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Describes the capabilities that the client supports.
+///
+/// This type is used by SDK integrators to declare specific functionality
+/// their client is capable of handling. These capabilities may affect how
+/// the backend or SFU behaves during a call.
+public enum ClientCapability: Hashable, Sendable, CaseIterable {
+
+    /// Indicates that the client supports pausing and resuming video for
+    /// individual subscribers. When enabled, the backend can pause a
+    /// participant’s video for a specific subscriber to save bandwidth.
+    case subscriberVideoPause
+
+    /// Initializes a `ClientCapability` from the backend protobuf value.
+    ///
+    /// - Parameter source: The raw protobuf capability value.
+    /// - Returns: A `ClientCapability` or `nil` if the value is unrecognized
+    ///   or unspecified.
+    init?(_ source: Stream_Video_Sfu_Models_ClientCapability) {
+        switch source {
+        case .subscriberVideoPause:
+            self = .subscriberVideoPause
+        case .unspecified:
+            return nil
+        case .UNRECOGNIZED:
+            return nil
+        }
+    }
+
+    /// Returns the backend-compatible representation of this capability.
+    var rawValue: Stream_Video_Sfu_Models_ClientCapability {
+        switch self {
+        case .subscriberVideoPause:
+            return .subscriberVideoPause
+        }
+    }
+}

--- a/Sources/StreamVideo/Models/Extensions/Stream_Video_Sfu_Models_Participant+CallParticipant.swift
+++ b/Sources/StreamVideo/Models/Extensions/Stream_Video_Sfu_Models_Participant+CallParticipant.swift
@@ -27,7 +27,8 @@ extension Stream_Video_Sfu_Models_Participant {
             joinedAt: joinedAt.date,
             audioLevel: audioLevel,
             audioLevels: [audioLevel],
-            pin: pin
+            pin: pin,
+            pausedTracks: []
         )
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/Models/TrackType.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/Models/TrackType.swift
@@ -5,32 +5,45 @@
 import Foundation
 
 /// Represents the type of media track in a WebRTC communication.
-struct TrackType: RawRepresentable, Codable, Hashable, ExpressibleByStringLiteral {
+public struct TrackType: RawRepresentable, Codable, Hashable, ExpressibleByStringLiteral, Sendable {
     /// The raw string value of the track type.
-    let rawValue: String
+    public let rawValue: String
 
     /// Initializes a TrackType with the given raw value.
     ///
     /// - Parameter rawValue: The string representation of the track type.
-    init(rawValue: String) {
+    public init(rawValue: String) {
         self.rawValue = rawValue
     }
 
     /// Initializes a TrackType with a string literal.
     ///
     /// - Parameter value: The string literal representation of the track type.
-    init(stringLiteral value: String) {
+    public init(stringLiteral value: String) {
         self.init(rawValue: value)
+    }
+
+    init(_ source: Stream_Video_Sfu_Models_TrackType) {
+        switch source {
+        case .audio:
+            self = .audio
+        case .video:
+            self = .video
+        case .screenShare:
+            self = .screenshare
+        default:
+            self = .unknown
+        }
     }
 }
 
 extension TrackType {
     /// Represents an audio track.
-    static let audio: Self = "audio"
+    public static let audio: Self = "audio"
     /// Represents a video track.
-    static let video: Self = "video"
+    public static let video: Self = "video"
     /// Represents a screen sharing track.
-    static let screenshare: Self = "screenshare"
+    public static let screenshare: Self = "screenshare"
     /// Represents an unknown track type.
     static let unknown: Self = "unknown"
 }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/Protocols/RTCPeerConnectionCoordinatorProviding.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/Protocols/RTCPeerConnectionCoordinatorProviding.swift
@@ -25,6 +25,10 @@ protocol RTCPeerConnectionCoordinatorProviding: Sendable {
     ///   - sfuAdapter: The adapter for interacting with the Selective Forwarding Unit.
     ///   - videoCaptureSessionProvider: Provider for video capturing functionality.
     ///   - screenShareSessionProvider: Provider for screen sharing functionality.
+    ///   - clientCapabilities: A set of client capabilities that affect how the
+    ///     coordinator behaves (e.g., enabling paused tracks support).
+    ///
+    /// This parameter affects features such as support for paused tracks.
     /// - Returns: An initialized `RTCPeerConnectionCoordinator` instance.
     func buildCoordinator(
         sessionId: String,
@@ -38,7 +42,8 @@ protocol RTCPeerConnectionCoordinatorProviding: Sendable {
         publishOptions: PublishOptions,
         sfuAdapter: SFUAdapter,
         videoCaptureSessionProvider: VideoCaptureSessionProvider,
-        screenShareSessionProvider: ScreenShareSessionProvider
+        screenShareSessionProvider: ScreenShareSessionProvider,
+        clientCapabilities: Set<ClientCapability>
     ) -> RTCPeerConnectionCoordinator
 }
 
@@ -62,6 +67,10 @@ final class StreamRTCPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordina
     ///   - sfuAdapter: The adapter for interacting with the Selective Forwarding Unit.
     ///   - videoCaptureSessionProvider: Provider for video capturing functionality.
     ///   - screenShareSessionProvider: Provider for screen sharing functionality.
+    ///   - clientCapabilities: A set of client capabilities that affect how the
+    ///     coordinator behaves (e.g., enabling paused tracks support).
+    ///
+    /// This parameter affects features such as support for paused tracks.
     /// - Returns: A newly created `RTCPeerConnectionCoordinator` instance.
     func buildCoordinator(
         sessionId: String,
@@ -75,7 +84,8 @@ final class StreamRTCPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordina
         publishOptions: PublishOptions,
         sfuAdapter: SFUAdapter,
         videoCaptureSessionProvider: VideoCaptureSessionProvider,
-        screenShareSessionProvider: ScreenShareSessionProvider
+        screenShareSessionProvider: ScreenShareSessionProvider,
+        clientCapabilities: Set<ClientCapability>
     ) -> RTCPeerConnectionCoordinator {
         RTCPeerConnectionCoordinator(
             sessionId: sessionId,
@@ -89,7 +99,8 @@ final class StreamRTCPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordina
             publishOptions: publishOptions,
             sfuAdapter: sfuAdapter,
             videoCaptureSessionProvider: videoCaptureSessionProvider,
-            screenShareSessionProvider: screenShareSessionProvider
+            screenShareSessionProvider: screenShareSessionProvider,
+            clientCapabilities: clientCapabilities
         )
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joined.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joined.swift
@@ -572,7 +572,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     .$incomingVideoQualitySettings
                     .eraseToAnyPublisher(),
                 sfuAdapter: sfuAdapter,
-                sessionID: await stateAdapter.sessionID
+                sessionID: await stateAdapter.sessionID,
+                clientCapabilities: await stateAdapter.clientCapabilities
             )
         }
     }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -95,25 +95,27 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     try Task.checkCancellation()
 
                     await sfuAdapter.sendJoinRequest(
-                        WebRTCJoinRequestFactory()
-                            .buildRequest(
-                                with: isFastReconnecting ? .fastReconnect : .default,
+                        WebRTCJoinRequestFactory(
+                            capabilities: coordinator.stateAdapter.clientCapabilities.map(\.rawValue)
+                        )
+                        .buildRequest(
+                            with: isFastReconnecting ? .fastReconnect : .default,
+                            coordinator: coordinator,
+                            publisherSdp: try await buildSessionDescription(
+                                peerConnectionType: .publisher,
                                 coordinator: coordinator,
-                                publisherSdp: try await buildSessionDescription(
-                                    peerConnectionType: .publisher,
-                                    coordinator: coordinator,
-                                    sfuAdapter: sfuAdapter,
-                                    isFastReconnecting: isFastReconnecting
-                                ),
-                                subscriberSdp: try await buildSessionDescription(
-                                    peerConnectionType: .subscriber,
-                                    coordinator: coordinator,
-                                    sfuAdapter: sfuAdapter,
-                                    isFastReconnecting: isFastReconnecting
-                                ),
-                                reconnectAttempt: context.reconnectAttempts,
-                                publisher: await coordinator.stateAdapter.publisher
-                            )
+                                sfuAdapter: sfuAdapter,
+                                isFastReconnecting: isFastReconnecting
+                            ),
+                            subscriberSdp: try await buildSessionDescription(
+                                peerConnectionType: .subscriber,
+                                coordinator: coordinator,
+                                sfuAdapter: sfuAdapter,
+                                isFastReconnecting: isFastReconnecting
+                            ),
+                            reconnectAttempt: context.reconnectAttempts,
+                            publisher: await coordinator.stateAdapter.publisher
+                        )
                     )
 
                     try Task.checkCancellation()
@@ -158,25 +160,27 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     try Task.checkCancellation()
 
                     await sfuAdapter.sendJoinRequest(
-                        WebRTCJoinRequestFactory()
-                            .buildRequest(
-                                with: .migration(fromHostname: context.migratingFromSFU),
+                        WebRTCJoinRequestFactory(
+                            capabilities: coordinator.stateAdapter.clientCapabilities.map(\.rawValue)
+                        )
+                        .buildRequest(
+                            with: .migration(fromHostname: context.migratingFromSFU),
+                            coordinator: coordinator,
+                            publisherSdp: try await buildSessionDescription(
+                                peerConnectionType: .publisher,
                                 coordinator: coordinator,
-                                publisherSdp: try await buildSessionDescription(
-                                    peerConnectionType: .publisher,
-                                    coordinator: coordinator,
-                                    sfuAdapter: sfuAdapter,
-                                    isFastReconnecting: false
-                                ),
-                                subscriberSdp: try await buildSessionDescription(
-                                    peerConnectionType: .subscriber,
-                                    coordinator: coordinator,
-                                    sfuAdapter: sfuAdapter,
-                                    isFastReconnecting: false
-                                ),
-                                reconnectAttempt: context.reconnectAttempts,
-                                publisher: context.previousSessionPublisher
-                            )
+                                sfuAdapter: sfuAdapter,
+                                isFastReconnecting: false
+                            ),
+                            subscriberSdp: try await buildSessionDescription(
+                                peerConnectionType: .subscriber,
+                                coordinator: coordinator,
+                                sfuAdapter: sfuAdapter,
+                                isFastReconnecting: false
+                            ),
+                            reconnectAttempt: context.reconnectAttempts,
+                            publisher: context.previousSessionPublisher
+                        )
                     )
 
                     context.reconnectAttempts += 1
@@ -216,25 +220,27 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     try Task.checkCancellation()
 
                     await sfuAdapter.sendJoinRequest(
-                        WebRTCJoinRequestFactory()
-                            .buildRequest(
-                                with: .rejoin(fromSessionID: isRejoiningFromSessionID),
+                        WebRTCJoinRequestFactory(
+                            capabilities: coordinator.stateAdapter.clientCapabilities.map(\.rawValue)
+                        )
+                        .buildRequest(
+                            with: .rejoin(fromSessionID: isRejoiningFromSessionID),
+                            coordinator: coordinator,
+                            publisherSdp: try await buildSessionDescription(
+                                peerConnectionType: .publisher,
                                 coordinator: coordinator,
-                                publisherSdp: try await buildSessionDescription(
-                                    peerConnectionType: .publisher,
-                                    coordinator: coordinator,
-                                    sfuAdapter: sfuAdapter,
-                                    isFastReconnecting: false
-                                ),
-                                subscriberSdp: try await buildSessionDescription(
-                                    peerConnectionType: .subscriber,
-                                    coordinator: coordinator,
-                                    sfuAdapter: sfuAdapter,
-                                    isFastReconnecting: false
-                                ),
-                                reconnectAttempt: context.reconnectAttempts,
-                                publisher: context.previousSessionPublisher
-                            )
+                                sfuAdapter: sfuAdapter,
+                                isFastReconnecting: false
+                            ),
+                            subscriberSdp: try await buildSessionDescription(
+                                peerConnectionType: .subscriber,
+                                coordinator: coordinator,
+                                sfuAdapter: sfuAdapter,
+                                isFastReconnecting: false
+                            ),
+                            reconnectAttempt: context.reconnectAttempts,
+                            publisher: context.previousSessionPublisher
+                        )
                     )
                     context.reconnectAttempts += 1
 

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -436,8 +436,12 @@ final class WebRTCCoordinator: @unchecked Sendable {
         try stateAdapter.audioSession.callKitActivated(audioSession)
     }
 
-    func updateClientCapabilities(_ capabilities: Set<ClientCapability>) async {
-        await stateAdapter.set(clientCapabilities: capabilities)
+    func enableClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        await stateAdapter.enableClientCapabilities(capabilities)
+    }
+
+    func disableClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        await stateAdapter.disableClientCapabilities(capabilities)
     }
 
     // MARK: - Private

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -436,6 +436,10 @@ final class WebRTCCoordinator: @unchecked Sendable {
         try stateAdapter.audioSession.callKitActivated(audioSession)
     }
 
+    func updateClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        await stateAdapter.set(clientCapabilities: capabilities)
+    }
+
     // MARK: - Private
 
     /// Creates the state machine for managing WebRTC stages.

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCJoinRequestFactory.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCJoinRequestFactory.swift
@@ -25,6 +25,8 @@ struct WebRTCJoinRequestFactory {
         }
     }
 
+    var capabilities: [Stream_Video_Sfu_Models_ClientCapability]
+
     /// Builds a join request for WebRTC.
     /// - Parameters:
     ///   - connectionType: The type of connection for the join request.
@@ -59,7 +61,8 @@ struct WebRTCJoinRequestFactory {
             coordinator: coordinator,
             publisherSdp: publisherSdp
         )
-        
+        result.capabilities = capabilities
+
         if let reconnectDetails = await buildReconnectDetails(
             for: connectionType,
             coordinator: coordinator,

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -76,6 +76,8 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
     @Published private(set) var incomingVideoQualitySettings: IncomingVideoQualitySettings = .none
     @Published private(set) var isTracingEnabled: Bool = false
 
+    private(set) var clientCapabilities: Set<ClientCapability> = []
+
     // Various private and internal properties.
     private(set) var initialCallSettings: CallSettings?
 
@@ -216,6 +218,10 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
         statsAdapter?.isTracingEnabled = value
     }
 
+    func set(clientCapabilities value: Set<ClientCapability>) {
+        self.clientCapabilities = value
+    }
+
     // MARK: - Session Management
 
     /// Refreshes the session by setting a new session ID.
@@ -260,7 +266,8 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
             publishOptions: publishOptions,
             sfuAdapter: sfuAdapter,
             videoCaptureSessionProvider: videoCaptureSessionProvider,
-            screenShareSessionProvider: screenShareSessionProvider
+            screenShareSessionProvider: screenShareSessionProvider,
+            clientCapabilities: clientCapabilities
         )
 
         let subscriber = rtcPeerConnectionCoordinatorFactory.buildCoordinator(
@@ -278,7 +285,8 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
             publishOptions: publishOptions,
             sfuAdapter: sfuAdapter,
             videoCaptureSessionProvider: videoCaptureSessionProvider,
-            screenShareSessionProvider: screenShareSessionProvider
+            screenShareSessionProvider: screenShareSessionProvider,
+            clientCapabilities: clientCapabilities
         )
 
         publisher

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -76,7 +76,9 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
     @Published private(set) var incomingVideoQualitySettings: IncomingVideoQualitySettings = .none
     @Published private(set) var isTracingEnabled: Bool = false
 
-    private(set) var clientCapabilities: Set<ClientCapability> = []
+    private(set) var clientCapabilities: Set<ClientCapability> = [
+        .subscriberVideoPause
+    ]
 
     // Various private and internal properties.
     private(set) var initialCallSettings: CallSettings?

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -220,8 +220,14 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate {
         statsAdapter?.isTracingEnabled = value
     }
 
-    func set(clientCapabilities value: Set<ClientCapability>) {
-        self.clientCapabilities = value
+    // MARK: - Client Capabilities
+
+    func enableClientCapabilities(_ capabilities: Set<ClientCapability>) {
+        self.clientCapabilities = self.clientCapabilities.union(capabilities)
+    }
+
+    func disableClientCapabilities(_ capabilities: Set<ClientCapability>) {
+        self.clientCapabilities = self.clientCapabilities.subtracting(capabilities)
     }
 
     // MARK: - Session Management

--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -439,7 +439,16 @@ public struct ParticipantInfoView: View {
                 .font(fonts.caption1)
                 .minimumScaleFactor(0.7)
                 .accessibility(identifier: "participantName")
-                        
+
+            if participant.pausedTracks.contains(.video) {
+                Image(systemName: "wifi.slash")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: maxHeight)
+                    .foregroundColor(.white)
+                    .padding(.trailing, 4)
+            }
+
             SoundIndicator(participant: participant)
                 .frame(maxHeight: maxHeight)
         }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -363,11 +363,12 @@
 		408721F12E12741F006A68CB /* DispatchWorkItem+TimerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408721F02E12741F006A68CB /* DispatchWorkItem+TimerControl.swift */; };
 		408721F72E127551006A68CB /* TimerPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408721F62E127551006A68CB /* TimerPublisher.swift */; };
 		408721FA2E127A18006A68CB /* TimerPublisher_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408721F92E127A18006A68CB /* TimerPublisher_Tests.swift */; };
+		408722372E13C91F006A68CB /* AVCaptureDevice.Format+MediaSubType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408722362E13C91F006A68CB /* AVCaptureDevice.Format+MediaSubType.swift */; };
 		408722392E13CD9D006A68CB /* DemoMoreThermalStateButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408722382E13CD9D006A68CB /* DemoMoreThermalStateButtonView.swift */; };
 		4087223A2E13CD9D006A68CB /* DemoMoreThermalStateButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408722382E13CD9D006A68CB /* DemoMoreThermalStateButtonView.swift */; };
-		408722372E13C91F006A68CB /* AVCaptureDevice.Format+MediaSubType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408722362E13C91F006A68CB /* AVCaptureDevice.Format+MediaSubType.swift */; };
 		4089378B2C062B17000EEB69 /* StreamUUIDFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4089378A2C062B17000EEB69 /* StreamUUIDFactory.swift */; };
 		408937912C134305000EEB69 /* View+AlertWithTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408937902C134305000EEB69 /* View+AlertWithTextField.swift */; };
+		40895E602E25538E00D3049D /* ClientCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40895E5F2E25538E00D3049D /* ClientCapability.swift */; };
 		408CE0F72BD95EB60052EC3A /* VideoConfig+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408CE0F62BD95EB60052EC3A /* VideoConfig+Dummy.swift */; };
 		408CE0F82BD95F170052EC3A /* VideoConfig+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408CE0F62BD95EB60052EC3A /* VideoConfig+Dummy.swift */; };
 		408CE0F92BD95F1B0052EC3A /* VideoConfig+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408CE0F62BD95EB60052EC3A /* VideoConfig+Dummy.swift */; };
@@ -1937,10 +1938,11 @@
 		408721F02E12741F006A68CB /* DispatchWorkItem+TimerControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchWorkItem+TimerControl.swift"; sourceTree = "<group>"; };
 		408721F62E127551006A68CB /* TimerPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerPublisher.swift; sourceTree = "<group>"; };
 		408721F92E127A18006A68CB /* TimerPublisher_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerPublisher_Tests.swift; sourceTree = "<group>"; };
-		408722382E13CD9D006A68CB /* DemoMoreThermalStateButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoMoreThermalStateButtonView.swift; sourceTree = "<group>"; };
 		408722362E13C91F006A68CB /* AVCaptureDevice.Format+MediaSubType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice.Format+MediaSubType.swift"; sourceTree = "<group>"; };
+		408722382E13CD9D006A68CB /* DemoMoreThermalStateButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoMoreThermalStateButtonView.swift; sourceTree = "<group>"; };
 		4089378A2C062B17000EEB69 /* StreamUUIDFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamUUIDFactory.swift; sourceTree = "<group>"; };
 		408937902C134305000EEB69 /* View+AlertWithTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertWithTextField.swift"; sourceTree = "<group>"; };
+		40895E5F2E25538E00D3049D /* ClientCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCapability.swift; sourceTree = "<group>"; };
 		408CE0F62BD95EB60052EC3A /* VideoConfig+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoConfig+Dummy.swift"; sourceTree = "<group>"; };
 		408CF9C22CAE886500F56833 /* WebRTCIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCIntegrationTests.swift; sourceTree = "<group>"; };
 		408CF9C52CAEC24A00F56833 /* ScreenPropertiesAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenPropertiesAdapter.swift; sourceTree = "<group>"; };
@@ -5957,6 +5959,7 @@
 				8454A3182AAB374B00A012C6 /* CallStatsReport.swift */,
 				40034C1F2CFDABE600A318B1 /* PublishOptions.swift */,
 				4039F0CB2D0241120078159E /* AudioCodec.swift */,
+				40895E5F2E25538E00D3049D /* ClientCapability.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -7785,6 +7788,7 @@
 				84DC389529ADFCFD00946713 /* QueryMembersRequest.swift in Sources */,
 				84DC38AB29ADFCFD00946713 /* RecordSettingsRequest.swift in Sources */,
 				84EA5D3F28C09AAC004D3531 /* CallController.swift in Sources */,
+				40895E602E25538E00D3049D /* ClientCapability.swift in Sources */,
 				84DC38CA29ADFCFD00946713 /* UpdateCallRequest.swift in Sources */,
 				40E363752D0A2C6B0028C52A /* CGSize+Adapt.swift in Sources */,
 				4031D7FA2B84B077002EC6E4 /* StreamActiveCallProvider.swift in Sources */,

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -537,6 +537,24 @@ final class Call_Tests: StreamVideoTestCase {
         XCTAssert(call?.state.broadcasting == false)
     }
 
+    // MARK: - updateClientCapabilities
+
+    func test_updateClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        let mockCallController = MockCallController()
+        let call = MockCall(.dummy(callController: mockCallController))
+        call.stub(for: \.state, with: .init())
+
+        await call.updateClientCapabilities([.subscriberVideoPause])
+
+        XCTAssertEqual(
+            mockCallController.recordedInputPayload(
+                Set<ClientCapability>.self,
+                for: .updateClientCapabilities
+            )?.first,
+            [.subscriberVideoPause]
+        )
+    }
+
     // MARK: - Private helpers
 
     private func assertUpdateState(

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -537,19 +537,37 @@ final class Call_Tests: StreamVideoTestCase {
         XCTAssert(call?.state.broadcasting == false)
     }
 
-    // MARK: - updateClientCapabilities
+    // MARK: - enableClientCapabilities
 
-    func test_updateClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+    func test_enableClientCapabilities_correctlyUpdatesStateAdapter() async throws {
         let mockCallController = MockCallController()
         let call = MockCall(.dummy(callController: mockCallController))
         call.stub(for: \.state, with: .init())
 
-        await call.updateClientCapabilities([.subscriberVideoPause])
+        await call.enableClientCapabilities([.subscriberVideoPause])
 
         XCTAssertEqual(
             mockCallController.recordedInputPayload(
                 Set<ClientCapability>.self,
-                for: .updateClientCapabilities
+                for: .enableClientCapabilities
+            )?.first,
+            [.subscriberVideoPause]
+        )
+    }
+
+    // MARK: - disableClientCapabilities
+
+    func test_disableClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        let mockCallController = MockCallController()
+        let call = MockCall(.dummy(callController: mockCallController))
+        call.stub(for: \.state, with: .init())
+
+        await call.disableClientCapabilities([.subscriberVideoPause])
+
+        XCTAssertEqual(
+            mockCallController.recordedInputPayload(
+                Set<ClientCapability>.self,
+                for: .disableClientCapabilities
             )?.first,
             [.subscriberVideoPause]
         )

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -659,6 +659,15 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertEqual(call.state.anonymousParticipantCount, 0)
     }
 
+    func test_updateClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        await subject.updateClientCapabilities([.subscriberVideoPause])
+
+        await assertEqualAsync(
+            await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.clientCapabilities,
+            [.subscriberVideoPause]
+        )
+    }
+
     // MARK: - Private helpers
 
     private func assertTransitionToStage(

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -659,12 +659,25 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertEqual(call.state.anonymousParticipantCount, 0)
     }
 
-    func test_updateClientCapabilities_correctlyUpdatesStateAdapter() async throws {
-        await subject.updateClientCapabilities([.subscriberVideoPause])
+    // MARK: - enableClientCapabilities
+
+    func test_enableClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        await subject.enableClientCapabilities([.subscriberVideoPause])
 
         await assertEqualAsync(
             await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.clientCapabilities,
             [.subscriberVideoPause]
+        )
+    }
+
+    // MARK: - disableClientCapabilities
+
+    func test_disableClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        await subject.disableClientCapabilities([.subscriberVideoPause])
+
+        await assertEqualAsync(
+            await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.clientCapabilities,
+            []
         )
     }
 

--- a/StreamVideoTests/Mock/CallParticipant_Mock.swift
+++ b/StreamVideoTests/Mock/CallParticipant_Mock.swift
@@ -29,7 +29,8 @@ extension CallParticipant {
         joinedAt: Date = .init(timeIntervalSince1970: 0),
         audioLevel: Float = 0,
         audioLevels: [Float] = [],
-        pin: PinInfo? = nil
+        pin: PinInfo? = nil,
+        pausedTracks: Set<TrackType> = []
     ) -> CallParticipant {
         .init(
             id: id,
@@ -52,7 +53,8 @@ extension CallParticipant {
             joinedAt: joinedAt,
             audioLevel: audioLevel,
             audioLevels: audioLevels,
-            pin: pin
+            pin: pin,
+            pausedTracks: pausedTracks
         )
     }
 }

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -12,6 +12,7 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         case setDisconnectionTimeout
         case observeWebRTCStateUpdated
         case changeVideoState
+        case updateClientCapabilities
     }
 
     enum MockFunctionInputKey: Payloadable {
@@ -29,6 +30,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
 
         case changeVideoState(Bool)
 
+        case updateClientCapabilities(Set<ClientCapability>)
+
         var payload: Any {
             switch self {
             case let .setDisconnectionTimeout(timeout):
@@ -38,6 +41,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
             case .observeWebRTCStateUpdated:
                 return ()
             case let .changeVideoState(value):
+                return value
+            case let .updateClientCapabilities(value):
                 return value
             }
         }
@@ -114,5 +119,10 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
     override func changeVideoState(isEnabled: Bool) async throws {
         stubbedFunctionInput[.changeVideoState]?
             .append(.changeVideoState(isEnabled))
+    }
+
+    override func updateClientCapabilities(_ capabilities: Set<ClientCapability>) async {
+        stubbedFunctionInput[.updateClientCapabilities]?
+            .append(.updateClientCapabilities(capabilities))
     }
 }

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -12,7 +12,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         case setDisconnectionTimeout
         case observeWebRTCStateUpdated
         case changeVideoState
-        case updateClientCapabilities
+        case enableClientCapabilities
+        case disableClientCapabilities
     }
 
     enum MockFunctionInputKey: Payloadable {
@@ -30,7 +31,9 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
 
         case changeVideoState(Bool)
 
-        case updateClientCapabilities(Set<ClientCapability>)
+        case enableClientCapabilities(Set<ClientCapability>)
+
+        case disableClientCapabilities(Set<ClientCapability>)
 
         var payload: Any {
             switch self {
@@ -42,7 +45,9 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 return ()
             case let .changeVideoState(value):
                 return value
-            case let .updateClientCapabilities(value):
+            case let .enableClientCapabilities(value):
+                return value
+            case let .disableClientCapabilities(value):
                 return value
             }
         }
@@ -121,8 +126,17 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
             .append(.changeVideoState(isEnabled))
     }
 
-    override func updateClientCapabilities(_ capabilities: Set<ClientCapability>) async {
-        stubbedFunctionInput[.updateClientCapabilities]?
-            .append(.updateClientCapabilities(capabilities))
+    override func enableClientCapabilities(
+        _ capabilities: Set<ClientCapability>
+    ) async {
+        stubbedFunctionInput[.enableClientCapabilities]?
+            .append(.enableClientCapabilities(capabilities))
+    }
+
+    override func disableClientCapabilities(
+        _ capabilities: Set<ClientCapability>
+    ) async {
+        stubbedFunctionInput[.disableClientCapabilities]?
+            .append(.disableClientCapabilities(capabilities))
     }
 }

--- a/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinator.swift
+++ b/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinator.swift
@@ -191,7 +191,8 @@ final class MockRTCPeerConnectionCoordinator:
                 peerConnection: peerConnection,
                 sfuAdapter: sfuAdapter
             ),
-            iceConnectionStateAdapter: iceConnectionStateAdapter ?? .init()
+            iceConnectionStateAdapter: iceConnectionStateAdapter ?? .init(),
+            clientCapabilities: []
         )
 
         stub(for: \.isHealthy, with: true)

--- a/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinatorFactory.swift
+++ b/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinatorFactory.swift
@@ -21,7 +21,8 @@ final class MockRTCPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordinato
         publishOptions: PublishOptions,
         sfuAdapter: SFUAdapter,
         videoCaptureSessionProvider: VideoCaptureSessionProvider,
-        screenShareSessionProvider: ScreenShareSessionProvider
+        screenShareSessionProvider: ScreenShareSessionProvider,
+        clientCapabilities: Set<ClientCapability>
     ) -> RTCPeerConnectionCoordinator {
         stubbedBuildCoordinatorResult[peerType] ?? MockRTCPeerConnectionCoordinator(
             sessionId: sessionId,
@@ -35,7 +36,8 @@ final class MockRTCPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordinato
             publishOptions: publishOptions,
             sfuAdapter: sfuAdapter,
             videoCaptureSessionProvider: videoCaptureSessionProvider,
-            screenShareSessionProvider: screenShareSessionProvider
+            screenShareSessionProvider: screenShareSessionProvider,
+            clientCapabilities: clientCapabilities
         )
     }
 }

--- a/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinatorStack.swift
+++ b/StreamVideoTests/Mock/MockRTCPeerConnectionCoordinatorStack.swift
@@ -39,7 +39,8 @@ struct MockRTCPeerConnectionCoordinatorStack: @unchecked Sendable {
         spySubject: PassthroughSubject<TrackEvent, Never> = .init(),
         mockLocalAudioMediaAdapter: MockLocalMediaAdapter = .init(),
         mockLocalVideoMediaAdapter: MockLocalMediaAdapter = .init(),
-        mockLocalScreenSharingMediaAdapter: MockLocalMediaAdapter = .init()
+        mockLocalScreenSharingMediaAdapter: MockLocalMediaAdapter = .init(),
+        clientCapabilities: Set<ClientCapability> = []
     ) {
         self.sessionId = sessionId
         self.peerConnection = peerConnection
@@ -108,7 +109,8 @@ struct MockRTCPeerConnectionCoordinatorStack: @unchecked Sendable {
             sfuAdapter: mockSFUStack.adapter,
             mediaAdapter: mediaAdapter,
             iceAdapter: iceAdapter,
-            iceConnectionStateAdapter: iceConnectionStateAdapter
+            iceConnectionStateAdapter: iceConnectionStateAdapter,
+            clientCapabilities: clientCapabilities
         )
     }
 }

--- a/StreamVideoTests/Models/CallParticipants_Tests.swift
+++ b/StreamVideoTests/Models/CallParticipants_Tests.swift
@@ -27,7 +27,8 @@ final class CallParticipants_Tests: XCTestCase, @unchecked Sendable {
             joinedAt: Date(),
             audioLevel: 0,
             audioLevels: [],
-            pin: nil
+            pin: nil,
+            pausedTracks: []
         )
         
         // When
@@ -98,5 +99,36 @@ final class CallParticipants_Tests: XCTestCase, @unchecked Sendable {
         )
 
         XCTAssertTrue(subject.shouldDisplayTrack)
+    }
+
+    func test_shouldDisplayTrack_hasVideoTrueShowTrackTrueTrackNotNilPausedTracksContainsVideo_returnsFalse() {
+        let subject = CallParticipant.dummy(
+            hasVideo: true,
+            showTrack: true,
+            track: PeerConnectionFactory.mock().mockVideoTrack(forScreenShare: false),
+            pausedTracks: [.video]
+        )
+
+        XCTAssertFalse(subject.shouldDisplayTrack)
+    }
+
+    func test_shouldDisplayTrack_hasVideoTrueShowTrackTrueTrackNotNilPausedTracksDoesNotContainVideo_returnstrue() {
+        let subject = CallParticipant.dummy(
+            hasVideo: true,
+            showTrack: true,
+            track: PeerConnectionFactory.mock().mockVideoTrack(forScreenShare: false),
+            pausedTracks: []
+        )
+
+        XCTAssertTrue(subject.shouldDisplayTrack)
+    }
+
+    // MARK: - Equatable
+
+    func test_isEqual_participantWithDifferentPausedTracksAreNotEqual() {
+        let participantA = CallParticipant.dummy(pausedTracks: [.video])
+        let participantB = participantA.withPausedTrack(.audio)
+
+        XCTAssertNotEqual(participantA, participantB)
     }
 }

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
@@ -63,7 +63,8 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
             peerConnection: mockPeerConnection,
             sfuAdapter: mockSFUStack.adapter
         ),
-        iceConnectionStateAdapter: iceConnectionStateAdapter
+        iceConnectionStateAdapter: iceConnectionStateAdapter,
+        clientCapabilities: []
     )
 
     override func tearDown() {

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -114,10 +114,6 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .stateAdapter
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
-        await mockCoordinatorStack
-            .coordinator
-            .updateClientCapabilities([.subscriberVideoPause])
-
         try await assertTransition(
             from: .connected,
             expectedTarget: .disconnected,

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -114,6 +114,10 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .stateAdapter
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
+        await mockCoordinatorStack
+            .coordinator
+            .updateClientCapabilities([.subscriberVideoPause])
+
         try await assertTransition(
             from: .connected,
             expectedTarget: .disconnected,
@@ -139,6 +143,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             XCTAssertEqual(request.joinRequest.reconnectDetails.strategy, .unspecified)
             XCTAssertTrue(request.joinRequest.reconnectDetails.previousSessionID.isEmpty)
             XCTAssertTrue(request.joinRequest.reconnectDetails.fromSfuID.isEmpty)
+            XCTAssertEqual(request.joinRequest.capabilities, [.subscriberVideoPause])
         }
     }
 

--- a/StreamVideoTests/WebRTC/v2/UpdateSubscriptions/WebRTCUpdateSubscriptionsAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/UpdateSubscriptions/WebRTCUpdateSubscriptionsAdapter_Tests.swift
@@ -17,7 +17,8 @@ final class WebRTCUpdateSubscriptionsAdapter_Tests: XCTestCase, @unchecked Senda
         participantsPublisher: participantsSubject.eraseToAnyPublisher(),
         incomingVideoQualitySettingsPublisher: incomingVideoQualitySettingsSubject.eraseToAnyPublisher(),
         sfuAdapter: mockSFUStack.adapter,
-        sessionID: sessionID
+        sessionID: sessionID,
+        clientCapabilities: []
     )
 
     override func setUp() {

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -548,6 +548,14 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(videoPublishOptions.bitrate, 1000)
     }
 
+    // MARK: - updateClientCapabilities
+
+    func test_updateClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        await subject.updateClientCapabilities([.subscriberVideoPause])
+
+        await assertEqualAsync(await subject.stateAdapter.clientCapabilities, [.subscriberVideoPause])
+    }
+
     // MARK: - Private helpers
 
     private func assertEqualAsync<T: Equatable>(

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -548,12 +548,26 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(videoPublishOptions.bitrate, 1000)
     }
 
-    // MARK: - updateClientCapabilities
+    // MARK: - enableClientCapabilities
 
-    func test_updateClientCapabilities_correctlyUpdatesStateAdapter() async throws {
-        await subject.updateClientCapabilities([.subscriberVideoPause])
+    func test_enableClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        await subject.enableClientCapabilities([.subscriberVideoPause])
 
-        await assertEqualAsync(await subject.stateAdapter.clientCapabilities, [.subscriberVideoPause])
+        await assertEqualAsync(
+            await subject.stateAdapter.clientCapabilities,
+            [.subscriberVideoPause]
+        )
+    }
+
+    // MARK: - disableClientCapabilities
+
+    func test_disableClientCapabilities_correctlyUpdatesStateAdapter() async throws {
+        await subject.disableClientCapabilities([.subscriberVideoPause])
+
+        await assertEqualAsync(
+            await subject.stateAdapter.clientCapabilities,
+            []
+        )
     }
 
     // MARK: - Private helpers

--- a/StreamVideoTests/WebRTC/v2/WebRTCJoinRequestFactory_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCJoinRequestFactory_Tests.swift
@@ -13,7 +13,7 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
     private lazy var mockCoordinatorStack: MockWebRTCCoordinatorStack! = .init(
         videoConfig: Self.videoConfig
     )
-    private var subject: WebRTCJoinRequestFactory! = .init()
+    private var subject: WebRTCJoinRequestFactory! = .init(capabilities: [])
 
     // MARK: - Lifecycle
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -277,6 +277,24 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    // MARK: - clientCapabilities
+
+    func test_clientCapabilities_expectedDefaultValue() async throws {
+        await assertEqualAsync(
+            await subject.clientCapabilities,
+            [.subscriberVideoPause]
+        )
+    }
+
+    // MARK: - setClientCapabilities
+
+    func test_setClientCapabilities_shouldUpdateClientCapabilities() async throws {
+
+        await subject.set(clientCapabilities: [])
+
+        await assertEqualAsync(await subject.clientCapabilities, [])
+    }
+
     // MARK: - refreshSession
 
     func test_refreshSession_shouldUpdateSessionID() async throws {

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -286,11 +286,22 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
-    // MARK: - setClientCapabilities
+    // MARK: - enableClientCapabilities
 
-    func test_setClientCapabilities_shouldUpdateClientCapabilities() async throws {
+    func enableClientCapabilities_shouldUpdateClientCapabilities() async throws {
 
-        await subject.set(clientCapabilities: [])
+        await subject.enableClientCapabilities([.subscriberVideoPause])
+
+        await assertEqualAsync(await subject.clientCapabilities, [.subscriberVideoPause])
+    }
+
+    // MARK: - disableClientCapabilities
+
+    func test_enableClientCapabilities_shouldUpdateClientCapabilities() async throws {
+
+        await subject.enableClientCapabilities([.subscriberVideoPause])
+
+        await subject.disableClientCapabilities([.subscriberVideoPause])
 
         await assertEqualAsync(await subject.clientCapabilities, [])
     }

--- a/TestTools/TestData/ViewFactory.swift
+++ b/TestTools/TestData/ViewFactory.swift
@@ -85,7 +85,8 @@ struct ParticipantFactory {
                 joinedAt: Date(),
                 audioLevel: 0,
                 audioLevels: [],
-                pin: nil
+                pin: nil,
+                pausedTracks: []
             )
             factory.append(participant)
         }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-994/featureinbound-video-pause

### 🎯 Goal

Provide a way for the SFU to instruct the client which tracks are remotely paused.

### 📝 Summary

Docs preview: https://github.com/GetStream/docs-content/pull/452

### 🧪 Manual Testing Notes

- By default the feature is disabled
- Enter a call with another client
- Activate the Link conditioner to Edge
- Remain in the call a few seconds
- You shouldn't observe any changes during the call. Remote track should be lagging but always visible
- Disable the link conditioner
- Logout and enable the feature from the debug menu (Client Capabilities > Subscriber video pause)
- Enter a call with another client
- Activate the Link conditioner to Edge
- Remote track should get disabled at some point (it's ok if it gets reenabled)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)