### PR TITLE
[Enhancement]WebRTC logs via SDK logger

### DIFF
--- a/DemoApp/Sources/Components/AppEnvironment.swift
+++ b/DemoApp/Sources/Components/AppEnvironment.swift
@@ -639,3 +639,9 @@ extension String: Debuggable {
         self
     }
 }
+
+extension Bool: Debuggable {
+    var title: String {
+        self ? "True" : "False"
+    }
+}

--- a/DemoApp/Sources/Extensions/DemoApp+Sentry.swift
+++ b/DemoApp/Sources/Extensions/DemoApp+Sentry.swift
@@ -27,6 +27,7 @@ func configureSentry() {
         ]
     } else {
         LogConfig.level = .debug
+        LogConfig.webRTCLogsEnabled = true
         LogConfig.destinationTypes = [
             MemoryLogDestination.self,
             OSLogDestination.self

--- a/DemoApp/Sources/Views/Login/DebugMenu.swift
+++ b/DemoApp/Sources/Views/Login/DebugMenu.swift
@@ -298,6 +298,12 @@ struct DebugMenu: View {
                 label: "Log Level"
             ) { LogConfig.level = $0 }
 
+            makeMenu(
+                for: [true, false],
+                currentValue: LogConfig.webRTCLogsEnabled,
+                label: "WebRTC Logs"
+            ) { LogConfig.webRTCLogsEnabled = $0 }
+
             Button {
                 isLogsViewerVisible = true
             } label: {

--- a/Sources/StreamVideo/Utils/Logger/Logger.swift
+++ b/Sources/StreamVideo/Utils/Logger/Logger.swift
@@ -32,7 +32,8 @@ public struct LogSubsystem: OptionSet, CustomStringConvertible, Sendable {
         .audioSession,
         .videoCapturer,
         .pictureInPicture,
-        .callKit
+        .callKit,
+        .webRTCInternal
     ]
 
     /// All subsystems within the SDK.
@@ -52,7 +53,8 @@ public struct LogSubsystem: OptionSet, CustomStringConvertible, Sendable {
         .audioSession,
         .videoCapturer,
         .pictureInPicture,
-        .callKit
+        .callKit,
+        .webRTCInternal
     ]
     
     /// The subsystem responsible for any other part of the SDK.
@@ -88,6 +90,7 @@ public struct LogSubsystem: OptionSet, CustomStringConvertible, Sendable {
     public static let pictureInPicture = Self(rawValue: 1 << 14)
     /// The subsystem responsible for PicutreInPicture.
     public static let callKit = Self(rawValue: 1 << 15)
+    public static let webRTCInternal = Self(rawValue: 1 << 16)
 
     public var description: String {
         switch rawValue {
@@ -123,6 +126,8 @@ public struct LogSubsystem: OptionSet, CustomStringConvertible, Sendable {
             return "picture-in-picture"
         case LogSubsystem.callKit.rawValue:
             return "CallKit"
+        case LogSubsystem.webRTCInternal.rawValue:
+            return "webRTC-Internal"
         default:
             return "unknown(rawValue:\(rawValue)"
         }
@@ -284,7 +289,12 @@ public enum LogConfig {
             _logger = newValue
         }
     }
-    
+
+    public static var webRTCLogsEnabled: Bool {
+        get { WebRTCLogger.default.enabled }
+        set { WebRTCLogger.default.enabled = true }
+    }
+
     /// Invalidates the current logger instance so it can be recreated.
     private static func invalidateLogger() {
         _logger = nil

--- a/Sources/StreamVideo/Utils/Logger/WebRTCLogger.swift
+++ b/Sources/StreamVideo/Utils/Logger/WebRTCLogger.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import OSLog
+import StreamWebRTC
+
+final class WebRTCLogger: @unchecked Sendable {
+
+    static let `default` = WebRTCLogger()
+
+    var enabled: Bool = false {
+        didSet { didUpdate(enabled) }
+    }
+
+    var severity: RTCLoggingSeverity = .error {
+        didSet { webRTCLogger.severity = severity }
+    }
+
+    private let webRTCLogger: RTCCallbackLogger = .init()
+
+    private init() {
+        webRTCLogger.severity = .verbose
+    }
+
+    private func didUpdate(_ enabled: Bool) {
+        guard enabled else {
+            webRTCLogger.stop()
+            return
+        }
+        webRTCLogger.start { message, severity in
+            let trimmedMessage = message.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            switch severity {
+            case .none, .verbose:
+                log.debug(trimmedMessage, subsystems: .webRTCInternal)
+            case .info:
+                log.info(trimmedMessage, subsystems: .webRTCInternal)
+            case .warning:
+                log.warning(trimmedMessage, subsystems: .webRTCInternal)
+            case .error:
+                log.error(trimmedMessage, subsystems: .webRTCInternal)
+            @unknown default:
+                log.debug(trimmedMessage, subsystems: .webRTCInternal)
+            }
+        }
+    }
+}

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -737,6 +737,7 @@
 		40E363772D0A2E320028C52A /* BroadcastBufferReaderKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E363762D0A2E320028C52A /* BroadcastBufferReaderKey.swift */; };
 		40E741FA2D54E6F40044C955 /* RTCAudioSessionDelegatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E741F92D54E6F40044C955 /* RTCAudioSessionDelegatePublisher.swift */; };
 		40E741FF2D553ACD0044C955 /* CurrentDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E741FE2D553ACD0044C955 /* CurrentDevice.swift */; };
+		40E7A45B2E29495500E8AB8B /* WebRTCLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7A4582E29487700E8AB8B /* WebRTCLogger.swift */; };
 		40E9B3B12BCD755F00ACF18F /* MemberResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E9B3B02BCD755F00ACF18F /* MemberResponse+Dummy.swift */; };
 		40E9B3B32BCD93AE00ACF18F /* JoinCallResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E9B3B22BCD93AE00ACF18F /* JoinCallResponse+Dummy.swift */; };
 		40E9B3B52BCD93F500ACF18F /* Credentials+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E9B3B42BCD93F500ACF18F /* Credentials+Dummy.swift */; };
@@ -2246,6 +2247,7 @@
 		40E363762D0A2E320028C52A /* BroadcastBufferReaderKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastBufferReaderKey.swift; sourceTree = "<group>"; };
 		40E741F92D54E6F40044C955 /* RTCAudioSessionDelegatePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTCAudioSessionDelegatePublisher.swift; sourceTree = "<group>"; };
 		40E741FE2D553ACD0044C955 /* CurrentDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentDevice.swift; sourceTree = "<group>"; };
+		40E7A4582E29487700E8AB8B /* WebRTCLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCLogger.swift; sourceTree = "<group>"; };
 		40E9B3B02BCD755F00ACF18F /* MemberResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberResponse+Dummy.swift"; sourceTree = "<group>"; };
 		40E9B3B22BCD93AE00ACF18F /* JoinCallResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JoinCallResponse+Dummy.swift"; sourceTree = "<group>"; };
 		40E9B3B42BCD93F500ACF18F /* Credentials+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Credentials+Dummy.swift"; sourceTree = "<group>"; };
@@ -5894,6 +5896,7 @@
 		8456E6C7287EC343004E180E /* Logger */ = {
 			isa = PBXGroup;
 			children = (
+				40E7A4582E29487700E8AB8B /* WebRTCLogger.swift */,
 				40BBC4A92C6270F5002AEF92 /* Array+Logger.swift */,
 				40AB34E02C5E73F900B5B6B3 /* Publisher+Logger.swift */,
 				8456E6C8287EC343004E180E /* Logger.swift */,
@@ -8161,6 +8164,7 @@
 				4092517E2E05AFF000DC0FB3 /* MidStereoInformation.swift in Sources */,
 				843DAB9929E695CF00E0EB63 /* CreateGuestResponse.swift in Sources */,
 				84DC389229ADFCFD00946713 /* RequestPermissionRequest.swift in Sources */,
+				40E7A45B2E29495500E8AB8B /* WebRTCLogger.swift in Sources */,
 				84C28C922A84D16A00742E33 /* GoLiveRequest.swift in Sources */,
 				84FC2C1328ACDF3A00181490 /* ProtoModel.swift in Sources */,
 				40BBC4CE2C639054002AEF92 /* WebRTCCoordinator+Error.swift in Sources */,


### PR DESCRIPTION
### 🎯 Goal

Surface WebRTC internal logs via the SDK's logger.

### 📝 Summary

Provide a way for integrators to access those logs (if needed). By default they are disabled for the SDK but enabled for the DemoApp.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)