### PR TITLE
[Fix]CallViewModel ending outgoing group call when one of the participants rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- An issue that caused the CallViewModel to end outgoing group calls prematurely when a participant rejected the call. [#901](https://github.com/GetStream/stream-video-swift/pull/901)
 
 # [1.29.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.29.0)
 _July 21, 2025_

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -67,7 +67,7 @@ open class CallViewModel: ObservableObject {
 
             // We only update the outgoingCallMembers if they are empty (which
             // means that the call was created externally)
-            callMembersUpdates = call?
+            outgoingCallMembersUpdates = call?
                 .state
                 .$members
                 .filter { [weak self] _ in
@@ -174,7 +174,7 @@ open class CallViewModel: ObservableObject {
     private var recordingUpdates: AnyCancellable?
     private var screenSharingUpdates: AnyCancellable?
     private var callSettingsUpdates: AnyCancellable?
-    private var callMembersUpdates: AnyCancellable?
+    private var outgoingCallMembersUpdates: AnyCancellable?
     private var applicationLifecycleUpdates: AnyCancellable?
 
     private var ringingCancellable: AnyCancellable?

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		4072A5922DAEB41500108E8F /* PictureInPictureDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4072A5912DAEB41500108E8F /* PictureInPictureDelegateProxy.swift */; };
 		4072A5942DAF992400108E8F /* PictureInPictureParticipantModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4072A5932DAF992400108E8F /* PictureInPictureParticipantModifier.swift */; };
 		4072A5962DAF99E000108E8F /* PictureInPictureContentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4072A5952DAF99E000108E8F /* PictureInPictureContentProvider.swift */; };
+		4073BC992E326DAF001E8965 /* MockDefaultAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404A81302DA3C5F0001F7FA8 /* MockDefaultAPI.swift */; };
 		407508312DE861E100155CC8 /* DispatchQueueExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407508302DE861E100155CC8 /* DispatchQueueExecutor.swift */; };
 		4075F0782DCE3FFC0062A4CC /* WebRTCTrackStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4075F0772DCE3FFC0062A4CC /* WebRTCTrackStorage.swift */; };
 		407AF7142B615D3300E9E3E7 /* CallDurationView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407AF7132B615D3300E9E3E7 /* CallDurationView_Tests.swift */; };
@@ -8641,6 +8642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4073BC992E326DAF001E8965 /* MockDefaultAPI.swift in Sources */,
 				40B575D02DCCEBA900F489B8 /* PictureInPictureEnforcedStopAdapterTests.swift in Sources */,
 				82FF40BE2A17C73500B4D95E /* CallConnectingView_Tests.swift in Sources */,
 				407AF7182B61619900E9E3E7 /* ParticipantListButton_Tests.swift in Sources */,

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -240,7 +240,7 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
                 created: true,
                 duration: "",
                 members: memberResponses,
-                ownCapabilities: [],
+                ownCapabilities: []
             )
         )
         await prepare()

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -100,7 +100,26 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
         video: Bool? = nil,
         transcription: TranscriptionSettingsRequest? = nil
     ) async throws -> CallResponse {
-        stubbedFunction[.create] as! CallResponse
+        if let response = stubbedFunction[.create] as? CallResponse {
+            return response
+        } else if let error = stubbedFunction[.create] as? Error {
+            throw error
+        } else {
+            return try await super.create(
+                members: members,
+                memberIds: memberIds,
+                custom: custom,
+                startsAt: startsAt,
+                team: team,
+                ring: ring,
+                notify: notify,
+                maxDuration: maxDuration,
+                maxParticipants: maxParticipants,
+                backstage: backstage,
+                video: video,
+                transcription: transcription
+            )
+        }
     }
 
     override func get(

--- a/StreamVideoTests/Mock/MockDefaultAPI.swift
+++ b/StreamVideoTests/Mock/MockDefaultAPI.swift
@@ -11,11 +11,13 @@ final class MockDefaultAPI: DefaultAPI, Mockable, @unchecked Sendable {
     enum MockFunctionKey: Hashable, CaseIterable {
         case acceptCall
         case rejectCall
+        case getOrCreateCall
     }
 
     enum MockFunctionInputKey: Payloadable {
         case acceptCall(type: String, id: String)
         case rejectCall(type: String, id: String, request: RejectCallRequest)
+        case getOrCreateCall(type: String, id: String, getOrCreateCallRequest: GetOrCreateCallRequest)
 
         var payload: Any {
             switch self {
@@ -23,6 +25,9 @@ final class MockDefaultAPI: DefaultAPI, Mockable, @unchecked Sendable {
                 return (type, id)
 
             case let .rejectCall(type, id, request):
+                return (type, id, request)
+
+            case let .getOrCreateCall(type, id, request):
                 return (type, id, request)
             }
         }
@@ -51,6 +56,31 @@ final class MockDefaultAPI: DefaultAPI, Mockable, @unchecked Sendable {
     }
 
     // MARK: - Mocks
+
+    override func getOrCreateCall(
+        type: String,
+        id: String,
+        getOrCreateCallRequest: GetOrCreateCallRequest
+    ) async throws -> GetOrCreateCallResponse {
+        stubbedFunctionInput[.getOrCreateCall]?.append(
+            .getOrCreateCall(
+                type: type,
+                id: id,
+                getOrCreateCallRequest: getOrCreateCallRequest
+            )
+        )
+        if let response = stubbedFunction[.getOrCreateCall] as? GetOrCreateCallResponse {
+            return response
+        } else if let error = stubbedFunction[.getOrCreateCall] as? Error {
+            throw error
+        } else {
+            return try await super.getOrCreateCall(
+                type: type,
+                id: id,
+                getOrCreateCallRequest: getOrCreateCallRequest
+            )
+        }
+    }
 
     override func acceptCall(
         type: String,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1031/blinkios-ending-outgoing-group-call-when-one-of-the-participants

### 📝 Summary

In cases where the call is being created on the backend and the iOS device relies on it to set the call data correctly, by calling `CallViewModel.startCall` with an empty `members` and `ring = true` array then if the call is rejected by one of the participants then iOS mistakenly will end the call for everyone.

### 🛠 Implementation

The CallViewModel now observes the `CallState.members` when its `callingState = .outgoing` and `outgoingCallMembers.isEmpty`.

### 🧪 Manual Testing Notes

- Create a ringing group call (minimum 3 participants) from the cli where the iOS user will be the creator
- Start the call then on iOS
- Reject the call from one of the other participants
- Call should continue ringing for everyone else

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)