### PR TITLE
[Fix]CallSettings rapid updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - An issue that was causing the local participant's audio waveform visualization to stop working. [#912](https://github.com/GetStream/stream-video-swift/pull/912)
+- Proximity policies weren't updating CallSettings correctly. That would cause issues where Speaker may not be reenabled or video not being stopped/restarted when proximity changes. [#913](https://github.com/GetStream/stream-video-swift/pull/913)
 
 # [1.30.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.30.0)
 _August 08, 2025_

--- a/Sources/StreamVideo/Models/CallSettings.swift
+++ b/Sources/StreamVideo/Models/CallSettings.swift
@@ -6,7 +6,7 @@ import Combine
 import Foundation
 
 /// Represents the settings for a call.
-public final class CallSettings: ObservableObject, Sendable, Equatable, ReflectiveStringConvertible {
+public final class CallSettings: ObservableObject, Sendable, Equatable, CustomStringConvertible {
     /// Whether the audio is on for the current user.
     public let audioOn: Bool
     /// Whether the video is on for the current user.
@@ -89,6 +89,10 @@ public final class CallSettings: ObservableObject, Sendable, Equatable, Reflecti
     
     public var shouldPublish: Bool {
         audioOn || videoOn
+    }
+
+    public var description: String {
+        "<CallSettings audioOn:\(audioOn) videoOn:\(videoOn) speakerOn:\(speakerOn) audioOutputOn:\(audioOutputOn) cameraPosition:\(cameraPosition)/>"
     }
 }
 

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Effects/RTCAudioStore+RouteChangeEffect.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Effects/RTCAudioStore+RouteChangeEffect.swift
@@ -90,9 +90,8 @@ extension RTCAudioStore {
                         """,
                         subsystems: .audioSession
                     )
-                    delegate?.audioSessionAdapterDidUpdateCallSettings(
-                        callSettings: activeCallSettings
-                            .withUpdatedSpeakerState(session.currentRoute.isSpeaker)
+                    delegate?.audioSessionAdapterDidUpdateSpeakerOn(
+                        session.currentRoute.isSpeaker
                     )
                 }
                 return
@@ -100,13 +99,13 @@ extension RTCAudioStore {
 
             switch (activeCallSettings.speakerOn, session.currentRoute.isSpeaker) {
             case (true, false):
-                delegate?.audioSessionAdapterDidUpdateCallSettings(
-                    callSettings: activeCallSettings.withUpdatedSpeakerState(false)
+                delegate?.audioSessionAdapterDidUpdateSpeakerOn(
+                    false
                 )
 
             case (false, true) where session.category == AVAudioSession.Category.playAndRecord.rawValue:
-                delegate?.audioSessionAdapterDidUpdateCallSettings(
-                    callSettings: activeCallSettings.withUpdatedSpeakerState(true)
+                delegate?.audioSessionAdapterDidUpdateSpeakerOn(
+                    true
                 )
 
             default:

--- a/Sources/StreamVideo/Utils/AudioSession/StreamAudioSessionAdapterDelegate.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/StreamAudioSessionAdapterDelegate.swift
@@ -11,7 +11,7 @@ protocol StreamAudioSessionAdapterDelegate: AnyObject {
     /// - Parameters:
     ///   - audioSession: The `AudioSession` instance that made the update.
     ///   - callSettings: The updated `CallSettings`.
-    func audioSessionAdapterDidUpdateCallSettings(
-        callSettings: CallSettings
+    func audioSessionAdapterDidUpdateSpeakerOn(
+        _ speakerOn: Bool
     )
 }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter.swift
@@ -267,13 +267,13 @@ final class LocalVideoMediaAdapter: LocalMediaAdapting, @unchecked Sendable {
             transceiverStorage
                 .forEach { $0.value.track.isEnabled = false }
 
-            Task(disposableBag: disposableBag) { @MainActor [weak self] in
+            _ = await Task(disposableBag: disposableBag) { @MainActor [weak self] in
                 do {
                     try await self?.stopVideoCapturingSession()
                 } catch {
                     log.error(error, subsystems: .webRTC)
                 }
-            }
+            }.result
 
             log.debug(
                 """

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -131,11 +131,8 @@ final class WebRTCCoordinator: @unchecked Sendable {
     func changeCameraMode(
         position: CameraPosition
     ) async throws {
-        await stateAdapter.set(
-            callSettings: stateAdapter
-                .callSettings
-                .withUpdatedCameraPosition(position)
-        )
+        await stateAdapter
+            .enqueueCallSettings { $0.withUpdatedCameraPosition(position) }
         try await stateAdapter.publisher?.didUpdateCameraPosition(
             position == .front ? .front : .back
         )
@@ -145,44 +142,32 @@ final class WebRTCCoordinator: @unchecked Sendable {
     ///
     /// - Parameter isEnabled: Whether the audio should be enabled.
     func changeAudioState(isEnabled: Bool) async {
-        await stateAdapter.set(
-            callSettings: stateAdapter
-                .callSettings
-                .withUpdatedAudioState(isEnabled)
-        )
+        await stateAdapter
+            .enqueueCallSettings { $0.withUpdatedAudioState(isEnabled) }
     }
 
     /// Changes the video state (enabled/disabled) for the call.
     ///
     /// - Parameter isEnabled: Whether the video should be enabled.
     func changeVideoState(isEnabled: Bool) async {
-        await stateAdapter.set(
-            callSettings: stateAdapter
-                .callSettings
-                .withUpdatedVideoState(isEnabled)
-        )
+        await stateAdapter
+            .enqueueCallSettings { $0.withUpdatedVideoState(isEnabled) }
     }
 
     /// Changes the audio output state (e.g., speaker or headphones).
     ///
     /// - Parameter isEnabled: Whether the output should be enabled.
     func changeSoundState(isEnabled: Bool) async {
-        await stateAdapter.set(
-            callSettings: stateAdapter
-                .callSettings
-                .withUpdatedAudioOutputState(isEnabled)
-        )
+        await stateAdapter
+            .enqueueCallSettings { $0.withUpdatedAudioOutputState(isEnabled) }
     }
 
     /// Changes the speaker state (enabled/disabled) for the call.
     ///
     /// - Parameter isEnabled: Whether the speaker should be enabled.
     func changeSpeakerState(isEnabled: Bool) async {
-        await stateAdapter.set(
-            callSettings: stateAdapter
-                .callSettings
-                .withUpdatedSpeakerState(isEnabled)
-        )
+        await stateAdapter
+            .enqueueCallSettings { $0.withUpdatedSpeakerState(isEnabled) }
     }
 
     /// Updates the visibility of a participant's track.

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -749,18 +749,16 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
     }
 
     private func assertWebRTCCoordinatorSettingsUpdated(
-        expected: @autoclosure () -> CallSettings,
+        expected: @Sendable @escaping @autoclosure () -> CallSettings,
         _ operation: () async throws -> Void,
         file: StaticString = #file,
         line: UInt = #line
     ) async throws {
         try await operation()
-        await assertEqualAsync(
-            await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.callSettings,
-            expected(),
-            file: file,
-            line: line
-        )
+        await fulfillment(file: file, line: line) {
+            let callSettings = await self.mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.callSettings
+            return callSettings == expected()
+        }
     }
 
     private func assertNilAsync<T>(
@@ -788,7 +786,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
             await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.set(videoFilter: videoFilter)
         }
         await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.set(ownCapabilities: ownCapabilities)
-        await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.set(callSettings: callSettings)
+        await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.enqueueCallSettings { _ in callSettings }
         await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.set(sessionID: .unique)
         await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.set(token: .unique)
         await mockWebRTCCoordinatorFactory.mockCoordinatorStack.coordinator.stateAdapter.set(participantsCount: 12)

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Effects/RouteChangeEffect_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Effects/RouteChangeEffect_Tests.swift
@@ -12,10 +12,10 @@ final class RouteChangeEffect_Tests: XCTestCase, @unchecked Sendable {
     // MARK: - Mocks
 
     final class MockDelegate: StreamAudioSessionAdapterDelegate {
-        private(set) var updatedCallSettings: CallSettings?
+        private(set) var updatedSpeakerOn: Bool?
 
-        func audioSessionAdapterDidUpdateCallSettings(callSettings: CallSettings) {
-            updatedCallSettings = callSettings
+        func audioSessionAdapterDidUpdateSpeakerOn(_ speakerOn: Bool) {
+            updatedSpeakerOn = speakerOn
         }
     }
 
@@ -121,6 +121,6 @@ final class RouteChangeEffect_Tests: XCTestCase, @unchecked Sendable {
         )
 
         // Then
-        XCTAssertEqual(delegate.updatedCallSettings, expectedCallSettings)
+        XCTAssertEqual(delegate.updatedSpeakerOn, expectedCallSettings?.speakerOn)
     }
 }

--- a/StreamVideoTests/Utils/Store/Store_PerformanceTests.swift
+++ b/StreamVideoTests/Utils/Store/Store_PerformanceTests.swift
@@ -72,7 +72,6 @@ final class Store_PerformanceTests: XCTestCase, @unchecked Sendable {
                 }
                 
                 let elapsed = CFAbsoluteTimeGetCurrent() - start
-                print("Average sync dispatch latency: \(elapsed / 100 * 1000)ms")
                 
                 expectation.fulfill()
             }
@@ -141,8 +140,6 @@ final class Store_PerformanceTests: XCTestCase, @unchecked Sendable {
             }
             
             wait(for: [expectation], timeout: 10)
-            
-            print("Publisher notifications: \(receivedCount)")
             
             // Reset
             store.dispatch(.reset)

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoinedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoinedStageTests.swift
@@ -625,59 +625,6 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
         }
     }
 
-    // MARK: observeCallSettingsUpdates
-
-    func test_transition_callSettingsUpdatedAndPublisherThrowsError_transitionsToDisconnected() async throws {
-        await mockCoordinatorStack.coordinator.stateAdapter.set(
-            sfuAdapter: mockCoordinatorStack.sfuStack.adapter
-        )
-        try await mockCoordinatorStack
-            .coordinator
-            .stateAdapter
-            .configurePeerConnections()
-        let publisher = await mockCoordinatorStack?.coordinator.stateAdapter.publisher
-        let mockPublisher = try XCTUnwrap(publisher as? MockRTCPeerConnectionCoordinator)
-        mockPublisher.stub(
-            for: .didUpdateCallSettings,
-            with: Result<Void, Error>.failure(ClientError())
-        )
-
-        await assertTransitionAfterTrigger(
-            expectedTarget: .disconnected,
-            trigger: { [mockCoordinatorStack] in
-                await mockCoordinatorStack?
-                    .coordinator
-                    .stateAdapter
-                    .set(callSettings: CallSettings(audioOn: true, videoOn: true))
-            }
-        ) { _ in }
-    }
-
-    func test_transition_callSettingsUpdated_publisherUpdated() async throws {
-        await mockCoordinatorStack.coordinator.stateAdapter.set(
-            sfuAdapter: mockCoordinatorStack.sfuStack.adapter
-        )
-        try await mockCoordinatorStack
-            .coordinator
-            .stateAdapter
-            .configurePeerConnections()
-        let publisher = await mockCoordinatorStack?.coordinator.stateAdapter.publisher
-        let mockPublisher = try XCTUnwrap(publisher as? MockRTCPeerConnectionCoordinator)
-        let updateCallSettings = CallSettings(audioOn: true, videoOn: true)
-
-        await assertResultAfterTrigger(
-            trigger: { [mockCoordinatorStack] in
-                await mockCoordinatorStack?
-                    .coordinator
-                    .stateAdapter
-                    .set(callSettings: updateCallSettings)
-            }
-        ) { [mockPublisher] expectation in
-            XCTAssertEqual(mockPublisher.timesCalled(.didUpdateCallSettings), 1)
-            expectation.fulfill()
-        }
-    }
-
     // MARK: observePeerConnectionState
 
     func test_transition_publisherDisconnects_restartICEWasTriggeredOnPublisher() async throws {

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -189,10 +189,10 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
     func test_changeAudioState_shouldUpdateAudioState() async throws {
         await subject.changeAudioState(isEnabled: false)
 
-        await assertEqualAsync(
-            await subject.stateAdapter.callSettings.audioOn,
-            false
-        )
+        await fulfillment {
+            let currentValue = await self.subject.stateAdapter.callSettings.audioOn
+            return currentValue == false
+        }
     }
 
     // MARK: - changeSoundState
@@ -200,10 +200,10 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
     func test_changeSoundState_shouldUpdateAudioOutputState() async throws {
         await subject.changeSoundState(isEnabled: false)
 
-        await assertEqualAsync(
-            await subject.stateAdapter.callSettings.audioOutputOn,
-            false
-        )
+        await fulfillment {
+            let currentValue = await self.subject.stateAdapter.callSettings.audioOutputOn
+            return currentValue == false
+        }
     }
 
     // MARK: - changeSpeakerState
@@ -211,10 +211,10 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
     func test_changeSpeakerState_shouldUpdateSpeakerState() async throws {
         await subject.changeSpeakerState(isEnabled: false)
 
-        await assertEqualAsync(
-            await subject.stateAdapter.callSettings.speakerOn,
-            false
-        )
+        await fulfillment {
+            let currentValue = await self.subject.stateAdapter.callSettings.speakerOn
+            return currentValue == false
+        }
     }
 
     // MARK: - changeTrackVisibility
@@ -660,7 +660,7 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
             await subject.stateAdapter.set(videoFilter: videoFilter)
         }
         await subject.stateAdapter.set(ownCapabilities: ownCapabilities)
-        await subject.stateAdapter.set(callSettings: callSettings)
+        await subject.stateAdapter.enqueueCallSettings { _ in callSettings }
         await subject.stateAdapter.set(sessionID: .unique)
         await subject.stateAdapter.set(token: .unique)
         await subject.stateAdapter.set(participantsCount: 12)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-916/videoproximity-doesnt-stop-local-video-and-its-visible-on-remote

### 🎯 Goal

This revisions provides improvements in situations that causing CallSettings to update rapidly. With the updates, we can now ensure serial updates for those rapid changes.

### 🛠 Implementation

`WebRTCStateAdapter` now handles `CallSettings` updates as enqueued operations. In that way every update request will be passed the current CallSettings at the moment and is expected to return the update it needs. In this way we provide step by step updates in CallSettings rather than complete replacements.

### 🧪 Manual Testing Notes

- With proximity policies enabled
- Join call
- Move your hand close to the front camera
- Notice that video and speaker should be disabled
- Move your hand away from the front camera
- Video and Speaker should be reenabled
- Do that multiple times with varying speed
- When you move away from the front camera, video and speaker should always be restored

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)