### PR TITLE
Generated code for track source type

### DIFF
--- a/Sources/StreamVideo/protobuf/sfu/event/events.pb.swift
+++ b/Sources/StreamVideo/protobuf/sfu/event/events.pb.swift
@@ -815,6 +815,11 @@ struct Stream_Video_Sfu_Event_JoinRequest {
     set {_uniqueStorage()._capabilities = newValue}
   }
 
+  var source: Stream_Video_Sfu_Models_ParticipantSource {
+    get {return _storage._source}
+    set {_uniqueStorage()._source = newValue}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -2368,6 +2373,7 @@ extension Stream_Video_Sfu_Event_JoinRequest: SwiftProtobuf.Message, SwiftProtob
     9: .standard(proto: "preferred_publish_options"),
     10: .standard(proto: "preferred_subscribe_options"),
     11: .same(proto: "capabilities"),
+    12: .same(proto: "source"),
   ]
 
 fileprivate class _StorageClass: @unchecked Sendable {
@@ -2382,6 +2388,7 @@ fileprivate class _StorageClass: @unchecked Sendable {
     var _preferredPublishOptions: [Stream_Video_Sfu_Models_PublishOption] = []
     var _preferredSubscribeOptions: [Stream_Video_Sfu_Models_SubscribeOption] = []
     var _capabilities: [Stream_Video_Sfu_Models_ClientCapability] = []
+    var _source: Stream_Video_Sfu_Models_ParticipantSource = .webrtcUnspecified
 
     static let defaultInstance = _StorageClass()
 
@@ -2399,6 +2406,7 @@ fileprivate class _StorageClass: @unchecked Sendable {
       _preferredPublishOptions = source._preferredPublishOptions
       _preferredSubscribeOptions = source._preferredSubscribeOptions
       _capabilities = source._capabilities
+      _source = source._source
     }
   }
 
@@ -2428,6 +2436,7 @@ fileprivate class _StorageClass: @unchecked Sendable {
         case 9: try { try decoder.decodeRepeatedMessageField(value: &_storage._preferredPublishOptions) }()
         case 10: try { try decoder.decodeRepeatedMessageField(value: &_storage._preferredSubscribeOptions) }()
         case 11: try { try decoder.decodeRepeatedEnumField(value: &_storage._capabilities) }()
+        case 12: try { try decoder.decodeSingularEnumField(value: &_storage._source) }()
         default: break
         }
       }
@@ -2473,6 +2482,9 @@ fileprivate class _StorageClass: @unchecked Sendable {
       if !_storage._capabilities.isEmpty {
         try visitor.visitPackedEnumField(value: _storage._capabilities, fieldNumber: 11)
       }
+      if _storage._source != .webrtcUnspecified {
+        try visitor.visitSingularEnumField(value: _storage._source, fieldNumber: 12)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2493,6 +2505,7 @@ fileprivate class _StorageClass: @unchecked Sendable {
         if _storage._preferredPublishOptions != rhs_storage._preferredPublishOptions {return false}
         if _storage._preferredSubscribeOptions != rhs_storage._preferredSubscribeOptions {return false}
         if _storage._capabilities != rhs_storage._capabilities {return false}
+        if _storage._source != rhs_storage._source {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/StreamVideo/protobuf/sfu/models/models.pb.swift
+++ b/Sources/StreamVideo/protobuf/sfu/models/models.pb.swift
@@ -210,6 +210,63 @@ extension Stream_Video_Sfu_Models_TrackType: CaseIterable {
 
 #endif  // swift(>=4.2)
 
+/// must be aligned with kit
+enum Stream_Video_Sfu_Models_ParticipantSource: SwiftProtobuf.Enum {
+  typealias RawValue = Int
+  case webrtcUnspecified // = 0
+  case rtmp // = 1
+  case whip // = 2
+  case sip // = 3
+  case rtsp // = 4
+  case srt // = 5
+  case UNRECOGNIZED(Int)
+
+  init() {
+    self = .webrtcUnspecified
+  }
+
+  init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .webrtcUnspecified
+    case 1: self = .rtmp
+    case 2: self = .whip
+    case 3: self = .sip
+    case 4: self = .rtsp
+    case 5: self = .srt
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  var rawValue: Int {
+    switch self {
+    case .webrtcUnspecified: return 0
+    case .rtmp: return 1
+    case .whip: return 2
+    case .sip: return 3
+    case .rtsp: return 4
+    case .srt: return 5
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Stream_Video_Sfu_Models_ParticipantSource: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static let allCases: [Stream_Video_Sfu_Models_ParticipantSource] = [
+    .webrtcUnspecified,
+    .rtmp,
+    .whip,
+    .sip,
+    .rtsp,
+    .srt,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
 enum Stream_Video_Sfu_Models_ErrorCode: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case unspecified // = 0
@@ -915,6 +972,8 @@ struct Stream_Video_Sfu_Models_Participant {
 
   var roles: [String] = []
 
+  var source: Stream_Video_Sfu_Models_ParticipantSource = .webrtcUnspecified
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -1480,6 +1539,7 @@ extension Stream_Video_Sfu_Models_PeerType: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_ConnectionQuality: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_VideoQuality: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_TrackType: @unchecked Sendable {}
+extension Stream_Video_Sfu_Models_ParticipantSource: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_ErrorCode: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_SdkType: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_TrackUnpublishReason: @unchecked Sendable {}
@@ -1552,6 +1612,17 @@ extension Stream_Video_Sfu_Models_TrackType: SwiftProtobuf._ProtoNameProviding {
     2: .same(proto: "TRACK_TYPE_VIDEO"),
     3: .same(proto: "TRACK_TYPE_SCREEN_SHARE"),
     4: .same(proto: "TRACK_TYPE_SCREEN_SHARE_AUDIO"),
+  ]
+}
+
+extension Stream_Video_Sfu_Models_ParticipantSource: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "PARTICIPANT_SOURCE_WEBRTC_UNSPECIFIED"),
+    1: .same(proto: "PARTICIPANT_SOURCE_RTMP"),
+    2: .same(proto: "PARTICIPANT_SOURCE_WHIP"),
+    3: .same(proto: "PARTICIPANT_SOURCE_SIP"),
+    4: .same(proto: "PARTICIPANT_SOURCE_RTSP"),
+    5: .same(proto: "PARTICIPANT_SOURCE_SRT"),
   ]
 }
 
@@ -1810,6 +1881,7 @@ extension Stream_Video_Sfu_Models_Participant: SwiftProtobuf.Message, SwiftProto
     11: .same(proto: "image"),
     12: .same(proto: "custom"),
     13: .same(proto: "roles"),
+    14: .same(proto: "source"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1831,6 +1903,7 @@ extension Stream_Video_Sfu_Models_Participant: SwiftProtobuf.Message, SwiftProto
       case 11: try { try decoder.decodeSingularStringField(value: &self.image) }()
       case 12: try { try decoder.decodeSingularMessageField(value: &self._custom) }()
       case 13: try { try decoder.decodeRepeatedStringField(value: &self.roles) }()
+      case 14: try { try decoder.decodeSingularEnumField(value: &self.source) }()
       default: break
       }
     }
@@ -1880,6 +1953,9 @@ extension Stream_Video_Sfu_Models_Participant: SwiftProtobuf.Message, SwiftProto
     if !self.roles.isEmpty {
       try visitor.visitRepeatedStringField(value: self.roles, fieldNumber: 13)
     }
+    if self.source != .webrtcUnspecified {
+      try visitor.visitSingularEnumField(value: self.source, fieldNumber: 14)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1897,6 +1973,7 @@ extension Stream_Video_Sfu_Models_Participant: SwiftProtobuf.Message, SwiftProto
     if lhs.image != rhs.image {return false}
     if lhs._custom != rhs._custom {return false}
     if lhs.roles != rhs.roles {return false}
+    if lhs.source != rhs.source {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
### 🔗 Issue Links

Part of https://linear.app/stream/issue/IOS-1089/add-track-source-type-in-the-participant-model.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
