### PR TITLE
[Enhancement]Local participant videoRender binded on CallSettings

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoParticipantsView.swift
@@ -2,6 +2,7 @@
 // Copyright © 2025 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import StreamVideo
 import StreamWebRTC
 import SwiftUI
@@ -325,7 +326,10 @@ public struct VideoCallParticipantView<Factory: ViewFactory>: View {
     var customData: [String: RawJSON]
     var call: Call?
 
-    @State private var isUsingFrontCameraForLocalUser: Bool = false
+    private var isLocalParticipant: Bool
+
+    private var callSettingsPublisher: AnyPublisher<CallSettings, Never>?
+    @State private var callSettings: CallSettings?
 
     public init(
         viewFactory: Factory = DefaultViewFactory.shared,
@@ -345,60 +349,73 @@ public struct VideoCallParticipantView<Factory: ViewFactory>: View {
         self.edgesIgnoringSafeArea = edgesIgnoringSafeArea
         self.customData = customData
         self.call = call
+        isLocalParticipant = participant.sessionId == call?.state.localParticipant?.sessionId
+        callSettings = call?.state.callSettings
+        callSettingsPublisher = (participant.sessionId == call?.state.localParticipant?.sessionId)
+            ? call?.state.$callSettings.eraseToAnyPublisher()
+            : nil
     }
     
     public var body: some View {
-        withCallSettingsObservation {
-            VideoRendererView(
-                id: id,
-                size: availableFrame.size,
-                contentMode: contentMode,
-                showVideo: showVideo,
-                handleRendering: { [weak call, participant] view in
-                    guard call != nil else { return }
-                    view.handleViewRendering(for: participant) { [weak call] size, participant in
-                        Task { [weak call] in
-                            await call?.updateTrackSize(size, for: participant)
-                        }
+        rendererViewWithCameraPositionAwareness
+            .opacity(showVideo ? 1 : 0)
+            .edgesIgnoringSafeArea(edgesIgnoringSafeArea)
+            .accessibility(identifier: "callParticipantView")
+            .streamAccessibility(value: showVideo ? "1" : "0")
+            .overlay(overlayView)
+    }
+
+    @ViewBuilder
+    private var rendererViewWithCameraPositionAwareness: some View {
+        if isLocalParticipant {
+            Group {
+                if callSettings?.cameraPosition == .front {
+                    rendererView
+                        .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
+                } else {
+                    rendererView
+                }
+            }
+            .onReceive(callSettingsPublisher) { callSettings = $0 }
+        } else {
+            rendererView
+        }
+    }
+
+    @ViewBuilder
+    private var rendererView: some View {
+        VideoRendererView(
+            id: id,
+            size: availableFrame.size,
+            contentMode: contentMode,
+            showVideo: showVideo,
+            handleRendering: { [weak call, participant] view in
+                guard call != nil else { return }
+                view.handleViewRendering(for: participant) { [weak call] size, participant in
+                    Task { [weak call] in
+                        await call?.updateTrackSize(size, for: participant)
                     }
                 }
-            )
-        }
-        .opacity(showVideo ? 1 : 0)
-        .edgesIgnoringSafeArea(edgesIgnoringSafeArea)
-        .accessibility(identifier: "callParticipantView")
-        .streamAccessibility(value: showVideo ? "1" : "0")
-        .overlay(
-            CallParticipantImageView(
-                viewFactory: viewFactory,
-                id: participant.id,
-                name: participant.name,
-                imageURL: participant.profileImageURL
-            )
-            .opacity(showVideo ? 0 : 1)
+            }
         )
     }
 
-    private var showVideo: Bool {
-        participant.shouldDisplayTrack || customData["videoOn"]?.boolValue == true
+    @ViewBuilder
+    private var overlayView: some View {
+        CallParticipantImageView(
+            viewFactory: viewFactory,
+            id: participant.id,
+            name: participant.name,
+            imageURL: participant.profileImageURL
+        )
+        .opacity(showVideo ? 0 : 1)
     }
 
-    @MainActor
-    @ViewBuilder
-    private func withCallSettingsObservation(
-        @ViewBuilder _ content: () -> some View
-    ) -> some View {
-        if participant.id == streamVideo.state.activeCall?.state.localParticipant?.id {
-            Group {
-                if isUsingFrontCameraForLocalUser {
-                    content()
-                        .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
-                } else {
-                    content()
-                }
-            }.onReceive(call?.state.$callSettings) { self.isUsingFrontCameraForLocalUser = $0.cameraPosition == .front }
+    private var showVideo: Bool {
+        if isLocalParticipant {
+            return callSettings?.videoOn ?? false
         } else {
-            content()
+            return participant.shouldDisplayTrack
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRenderer/LocalVideoView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRenderer/LocalVideoView.swift
@@ -39,7 +39,7 @@ public struct LocalVideoView<Factory: ViewFactory>: View {
             id: "\(streamVideo.user.id)-\(idSuffix)",
             availableFrame: availableFrame,
             contentMode: .scaleAspectFill,
-            customData: ["videoOn": .bool(callSettings.videoOn)],
+            customData: [:],
             call: call
         )
         .adjustVideoFrame(to: availableFrame.width, ratio: availableFrame.width / availableFrame.height)


### PR DESCRIPTION
### 📝 Summary

This revision simplifies VideoRenderer configuration by relying on CallSettings rather that customData.

### 🛠 Implementation

Since the beginning of the project we are controlling the VideoRenderer for the LocalParticipant using customData, to decided if we need to show video or not. As the project has evolved, we have a better more consistent way to handle this, CallSettings observation. The CallSettings observation not only aligns the component with the rest of the UI components in the SDK but also fixes the issue where the VideoRenderer for the local participant was "disconnected" from the CallSettings and was solely relying on rerenders to get the correct value to show/hide the video.

### 🧪 Manual Testing Notes

Join a few calls, toggle video on/off ensure that the VideoRenderer for your user is always showing what you are expecting it to.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)