### PR TITLE
[Enhancement]Callkit missing recording permission

### DIFF
--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicy.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicy.swift
@@ -1,0 +1,79 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import CallKit
+import Foundation
+
+/// An enumeration that defines different policies for handling CallKit
+/// calls when microphone permissions are missing.
+///
+/// When an incoming CallKit call is received while the app is in the
+/// background and microphone permission has not been granted, this policy
+/// determines how the app should respond. This is particularly important
+/// for privacy and security reasons, as accessing the microphone without
+/// proper permissions can lead to crashes or security violations.
+///
+/// ## Available Policies
+///
+/// - `.none`: No action is taken when permissions are missing. The call
+///   will proceed normally, which may lead to issues if the microphone
+///   is actually needed.
+/// - `.endCall`: The call is automatically ended with an error when
+///   permissions are missing, ensuring proper handling and user awareness.
+///
+/// ## Usage Example
+///
+/// ```swift
+/// let callKitService = CallKitService()
+/// // Set policy to end calls when permissions are missing
+/// callKitService.missingPermissionPolicy = .endCall
+/// ```
+///
+/// - Note: The default policy is `.endCall` for security reasons.
+public enum CallKitMissingPermissionPolicy: CustomStringConvertible {
+
+    /// A policy that takes no action when microphone permissions are
+    /// missing. The call will proceed regardless of permission status.
+    ///
+    /// - Warning: Using this policy may cause issues if the app attempts
+    ///   to access the microphone without proper permissions.
+    case none
+
+    /// A policy that ends the call with an error when microphone
+    /// permissions are missing while the app is in the background.
+    ///
+    /// This is the recommended policy for handling missing permissions,
+    /// as it ensures proper error handling and prevents security issues.
+    case endCall
+
+    /// A human-readable description of the policy.
+    ///
+    /// - Returns: A string representation of the current policy case.
+    public var description: String {
+        switch self {
+        case .none:
+            return ".none"
+        case .endCall:
+            return ".endCall"
+        }
+    }
+
+    /// Returns the appropriate policy implementation based on the current
+    /// case.
+    ///
+    /// This property provides access to the concrete implementation of the
+    /// `CallKitMissingPermissionPolicyProtocol` that corresponds to the
+    /// selected policy case.
+    ///
+    /// - Returns: An instance conforming to
+    ///   `CallKitMissingPermissionPolicyProtocol`.
+    var policy: CallKitMissingPermissionPolicyProtocol {
+        switch self {
+        case .none:
+            return NoOp()
+        case .endCall:
+            return EndCall()
+        }
+    }
+}

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicy.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicy.swift
@@ -5,51 +5,21 @@
 import CallKit
 import Foundation
 
-/// An enumeration that defines different policies for handling CallKit
-/// calls when microphone permissions are missing.
+/// Policy for handling CallKit calls when the app lacks microphone
+/// permission in the background.
 ///
-/// When an incoming CallKit call is received while the app is in the
-/// background and microphone permission has not been granted, this policy
-/// determines how the app should respond. This is particularly important
-/// for privacy and security reasons, as accessing the microphone without
-/// proper permissions can lead to crashes or security violations.
-///
-/// ## Available Policies
-///
-/// - `.none`: No action is taken when permissions are missing. The call
-///   will proceed normally, which may lead to issues if the microphone
-///   is actually needed.
-/// - `.endCall`: The call is automatically ended with an error when
-///   permissions are missing, ensuring proper handling and user awareness.
-///
-/// ## Usage Example
-///
-/// ```swift
-/// let callKitService = CallKitService()
-/// // Set policy to end calls when permissions are missing
-/// callKitService.missingPermissionPolicy = .endCall
-/// ```
-///
-/// - Note: The default policy is `.endCall` for security reasons.
+/// - `.none`: Do nothing.
+/// - `.endCall`: Fail reporting the call with an error.
 public enum CallKitMissingPermissionPolicy: CustomStringConvertible {
 
-    /// A policy that takes no action when microphone permissions are
-    /// missing. The call will proceed regardless of permission status.
-    ///
-    /// - Warning: Using this policy may cause issues if the app attempts
-    ///   to access the microphone without proper permissions.
+    /// Take no action if microphone permission is missing.
     case none
 
-    /// A policy that ends the call with an error when microphone
-    /// permissions are missing while the app is in the background.
-    ///
-    /// This is the recommended policy for handling missing permissions,
-    /// as it ensures proper error handling and prevents security issues.
+    /// End the call with an error when permission is missing in the
+    /// background.
     case endCall
 
-    /// A human-readable description of the policy.
-    ///
-    /// - Returns: A string representation of the current policy case.
+    /// Human readable description.
     public var description: String {
         switch self {
         case .none:
@@ -59,15 +29,7 @@ public enum CallKitMissingPermissionPolicy: CustomStringConvertible {
         }
     }
 
-    /// Returns the appropriate policy implementation based on the current
-    /// case.
-    ///
-    /// This property provides access to the concrete implementation of the
-    /// `CallKitMissingPermissionPolicyProtocol` that corresponds to the
-    /// selected policy case.
-    ///
-    /// - Returns: An instance conforming to
-    ///   `CallKitMissingPermissionPolicyProtocol`.
+    /// Concrete implementation backing each case.
     var policy: CallKitMissingPermissionPolicyProtocol {
         switch self {
         case .none:

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicyProtocol.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicyProtocol.swift
@@ -4,59 +4,13 @@
 
 import Foundation
 
-/// A protocol that defines the interface for handling CallKit calls when
-/// microphone permissions are missing.
-///
-/// Types conforming to this protocol implement specific strategies for
-/// dealing with incoming CallKit calls when the application lacks the
-/// necessary microphone permissions. This is particularly relevant when
-/// the app is running in the background and needs to handle calls safely.
-///
-/// ## Conformance Requirements
-///
-/// Types conforming to this protocol must implement the `reportCall()`
-/// method, which determines whether to allow or block the call based on
-/// the current permission status and application state.
-///
-/// ## Default Implementations
-///
-/// The framework provides two default implementations:
-/// - `CallKitMissingPermissionPolicy.NoOp`: A no-operation implementation
-///   that allows calls to proceed regardless of permission status.
-/// - `CallKitMissingPermissionPolicy.EndCall`: An implementation that
-///   throws an error when permissions are missing, effectively ending
-///   the call.
-///
-/// ## Custom Implementations
-///
-/// You can create custom implementations to handle missing permissions
-/// according to your app's specific requirements:
-///
-/// ```swift
-/// struct CustomPermissionPolicy: CallKitMissingPermissionPolicyProtocol {
-///     func reportCall() throws {
-///         // Custom logic for handling missing permissions
-///         if shouldBlockCall() {
-///             throw CustomError("Call blocked due to permissions")
-///         }
-///     }
-/// }
-/// ```
+/// Contract for handling CallKit calls when microphone permission is
+/// missing while the app runs in the background.
 protocol CallKitMissingPermissionPolicyProtocol {
 
-    /// Reports whether the call should proceed based on the current
-    /// permission status.
+    /// Decide whether reporting the call should proceed.
     ///
-    /// This method is called when a CallKit call is being reported. It
-    /// should check the current microphone permission status and
-    /// application state to determine whether the call should be allowed
-    /// to proceed or should be terminated.
-    ///
-    /// - Throws: An error if the call should be terminated due to missing
-    ///   permissions. The specific error thrown depends on the
-    ///   implementation.
-    ///
-    /// - Note: This method is typically called from a background thread
-    ///   when handling incoming VoIP push notifications.
+    /// Throw to block reporting (e.g., when permission is missing in the
+    /// background).
     func reportCall() throws
 }

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicyProtocol.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicyProtocol.swift
@@ -1,0 +1,62 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A protocol that defines the interface for handling CallKit calls when
+/// microphone permissions are missing.
+///
+/// Types conforming to this protocol implement specific strategies for
+/// dealing with incoming CallKit calls when the application lacks the
+/// necessary microphone permissions. This is particularly relevant when
+/// the app is running in the background and needs to handle calls safely.
+///
+/// ## Conformance Requirements
+///
+/// Types conforming to this protocol must implement the `reportCall()`
+/// method, which determines whether to allow or block the call based on
+/// the current permission status and application state.
+///
+/// ## Default Implementations
+///
+/// The framework provides two default implementations:
+/// - `CallKitMissingPermissionPolicy.NoOp`: A no-operation implementation
+///   that allows calls to proceed regardless of permission status.
+/// - `CallKitMissingPermissionPolicy.EndCall`: An implementation that
+///   throws an error when permissions are missing, effectively ending
+///   the call.
+///
+/// ## Custom Implementations
+///
+/// You can create custom implementations to handle missing permissions
+/// according to your app's specific requirements:
+///
+/// ```swift
+/// struct CustomPermissionPolicy: CallKitMissingPermissionPolicyProtocol {
+///     func reportCall() throws {
+///         // Custom logic for handling missing permissions
+///         if shouldBlockCall() {
+///             throw CustomError("Call blocked due to permissions")
+///         }
+///     }
+/// }
+/// ```
+protocol CallKitMissingPermissionPolicyProtocol {
+
+    /// Reports whether the call should proceed based on the current
+    /// permission status.
+    ///
+    /// This method is called when a CallKit call is being reported. It
+    /// should check the current microphone permission status and
+    /// application state to determine whether the call should be allowed
+    /// to proceed or should be terminated.
+    ///
+    /// - Throws: An error if the call should be terminated due to missing
+    ///   permissions. The specific error thrown depends on the
+    ///   implementation.
+    ///
+    /// - Note: This method is typically called from a background thread
+    ///   when handling incoming VoIP push notifications.
+    func reportCall() throws
+}

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+EndCall.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+EndCall.swift
@@ -7,62 +7,17 @@ import Foundation
 
 extension CallKitMissingPermissionPolicy {
 
-    /// A policy implementation that ends CallKit calls when microphone
-    /// permissions are missing while the app is in the background.
-    ///
-    /// This policy provides a secure way to handle incoming CallKit calls
-    /// when the application lacks the necessary microphone permissions. It
-    /// checks both the application state and permission status before
-    /// allowing a call to proceed.
-    ///
-    /// ## Behavior
-    ///
-    /// The policy will throw an error and end the call when:
-    /// - The application is running in the background AND
-    /// - Microphone permission has not been granted
-    ///
-    /// If either condition is not met (app is in foreground OR microphone
-    /// permission is granted), the call will proceed normally.
-    ///
-    /// ## Security Considerations
-    ///
-    /// This policy helps prevent security and privacy issues that could
-    /// arise from attempting to access the microphone without proper
-    /// permissions. It ensures that users are aware of permission
-    /// requirements and prevents potential crashes or security violations.
-    ///
-    /// ## Usage
-    ///
-    /// This policy is automatically used when
-    /// `CallKitMissingPermissionPolicy.endCall` is selected:
-    ///
-    /// ```swift
-    /// callKitService.missingPermissionPolicy = .endCall
-    /// ```
+    /// Ends calls when microphone permission is missing and the app runs in
+    /// the background.
     final class EndCall: CallKitMissingPermissionPolicyProtocol {
 
-        /// Injected dependency for checking system permissions.
+        /// Checks system permissions.
         @Injected(\.permissions) private var permissions
         
-        /// Injected dependency for checking application state.
+        /// Observes app state.
         @Injected(\.applicationStateAdapter) private var applicationStateAdapter
 
-        /// Reports whether the call should proceed based on current
-        /// permissions and application state.
-        ///
-        /// This method checks if the app is in the background and lacks
-        /// microphone permissions. If both conditions are true, it throws
-        /// an error to prevent the call from proceeding.
-        ///
-        /// - Throws: `ClientError` with message "CallKit missing microphone
-        ///   permission." when the app is in the background and lacks
-        ///   microphone permission.
-        ///
-        /// - Note: This method only blocks calls when BOTH conditions are
-        ///   met: background execution AND missing permissions. This allows
-        ///   foreground calls to proceed (where the user can be prompted
-        ///   for permissions) while protecting against background security
-        ///   issues.
+        /// Throw when in background without microphone permission.
         func reportCall() throws {
             let isRunningInForeground = applicationStateAdapter.state == .foreground
             let hasMicrophonePermission = permissions.hasMicrophonePermission

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+EndCall.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+EndCall.swift
@@ -1,0 +1,79 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import CallKit
+import Foundation
+
+extension CallKitMissingPermissionPolicy {
+
+    /// A policy implementation that ends CallKit calls when microphone
+    /// permissions are missing while the app is in the background.
+    ///
+    /// This policy provides a secure way to handle incoming CallKit calls
+    /// when the application lacks the necessary microphone permissions. It
+    /// checks both the application state and permission status before
+    /// allowing a call to proceed.
+    ///
+    /// ## Behavior
+    ///
+    /// The policy will throw an error and end the call when:
+    /// - The application is running in the background AND
+    /// - Microphone permission has not been granted
+    ///
+    /// If either condition is not met (app is in foreground OR microphone
+    /// permission is granted), the call will proceed normally.
+    ///
+    /// ## Security Considerations
+    ///
+    /// This policy helps prevent security and privacy issues that could
+    /// arise from attempting to access the microphone without proper
+    /// permissions. It ensures that users are aware of permission
+    /// requirements and prevents potential crashes or security violations.
+    ///
+    /// ## Usage
+    ///
+    /// This policy is automatically used when
+    /// `CallKitMissingPermissionPolicy.endCall` is selected:
+    ///
+    /// ```swift
+    /// callKitService.missingPermissionPolicy = .endCall
+    /// ```
+    final class EndCall: CallKitMissingPermissionPolicyProtocol {
+
+        /// Injected dependency for checking system permissions.
+        @Injected(\.permissions) private var permissions
+        
+        /// Injected dependency for checking application state.
+        @Injected(\.applicationStateAdapter) private var applicationStateAdapter
+
+        /// Reports whether the call should proceed based on current
+        /// permissions and application state.
+        ///
+        /// This method checks if the app is in the background and lacks
+        /// microphone permissions. If both conditions are true, it throws
+        /// an error to prevent the call from proceeding.
+        ///
+        /// - Throws: `ClientError` with message "CallKit missing microphone
+        ///   permission." when the app is in the background and lacks
+        ///   microphone permission.
+        ///
+        /// - Note: This method only blocks calls when BOTH conditions are
+        ///   met: background execution AND missing permissions. This allows
+        ///   foreground calls to proceed (where the user can be prompted
+        ///   for permissions) while protecting against background security
+        ///   issues.
+        func reportCall() throws {
+            let isRunningInForeground = applicationStateAdapter.state == .foreground
+            let hasMicrophonePermission = permissions.hasMicrophonePermission
+
+            guard
+                !isRunningInForeground, !hasMicrophonePermission
+            else {
+                return
+            }
+
+            throw ClientError("CallKit missing microphone permission.")
+        }
+    }
+}

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+NoOp.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+NoOp.swift
@@ -6,61 +6,11 @@ import Foundation
 
 extension CallKitMissingPermissionPolicy {
     
-    /// A no-operation policy implementation that allows CallKit calls to
-    /// proceed regardless of microphone permission status.
-    ///
-    /// This policy provides a permissive approach to handling CallKit
-    /// calls when microphone permissions may be missing. It performs no
-    /// checks and takes no action, allowing the call to proceed in all
-    /// cases.
-    ///
-    /// ## Behavior
-    ///
-    /// The policy always allows calls to proceed without checking:
-    /// - Application state (foreground/background)
-    /// - Microphone permission status
-    /// - Any other conditions
-    ///
-    /// ## Use Cases
-    ///
-    /// This policy might be appropriate when:
-    /// - The app handles permissions checks elsewhere in the call flow
-    /// - Testing or development scenarios where permission checks should
-    ///   be bypassed
-    /// - The app design ensures permissions are always granted before
-    ///   CallKit is used
-    ///
-    /// ## Warnings
-    ///
-    /// Using this policy may lead to:
-    /// - Runtime crashes if the system attempts to access the microphone
-    ///   without proper permissions
-    /// - Security and privacy violations
-    /// - Poor user experience if calls fail silently due to permission
-    ///   issues
-    ///
-    /// ## Usage
-    ///
-    /// This policy is automatically used when
-    /// `CallKitMissingPermissionPolicy.none` is selected:
-    ///
-    /// ```swift
-    /// callKitService.missingPermissionPolicy = .none
-    /// ```
-    ///
-    /// - Warning: This policy should be used with caution. The `.endCall`
-    ///   policy is recommended for production applications to ensure
-    ///   proper permission handling.
+    /// No-op policy. Always allows reporting, regardless of permissions or
+    /// app state.
     final class NoOp: CallKitMissingPermissionPolicyProtocol {
         
-        /// Reports that the call should always proceed.
-        ///
-        /// This implementation performs no checks and never throws an
-        /// error, effectively allowing all calls to proceed regardless
-        /// of permission status or application state.
-        ///
-        /// - Note: The empty implementation is intentional - this is a
-        ///   no-operation policy that takes no action.
+        /// Always allow.
         func reportCall() throws { /* No-op */ }
     }
 }

--- a/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+NoOp.swift
+++ b/Sources/StreamVideo/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy+NoOp.swift
@@ -1,0 +1,66 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension CallKitMissingPermissionPolicy {
+    
+    /// A no-operation policy implementation that allows CallKit calls to
+    /// proceed regardless of microphone permission status.
+    ///
+    /// This policy provides a permissive approach to handling CallKit
+    /// calls when microphone permissions may be missing. It performs no
+    /// checks and takes no action, allowing the call to proceed in all
+    /// cases.
+    ///
+    /// ## Behavior
+    ///
+    /// The policy always allows calls to proceed without checking:
+    /// - Application state (foreground/background)
+    /// - Microphone permission status
+    /// - Any other conditions
+    ///
+    /// ## Use Cases
+    ///
+    /// This policy might be appropriate when:
+    /// - The app handles permissions checks elsewhere in the call flow
+    /// - Testing or development scenarios where permission checks should
+    ///   be bypassed
+    /// - The app design ensures permissions are always granted before
+    ///   CallKit is used
+    ///
+    /// ## Warnings
+    ///
+    /// Using this policy may lead to:
+    /// - Runtime crashes if the system attempts to access the microphone
+    ///   without proper permissions
+    /// - Security and privacy violations
+    /// - Poor user experience if calls fail silently due to permission
+    ///   issues
+    ///
+    /// ## Usage
+    ///
+    /// This policy is automatically used when
+    /// `CallKitMissingPermissionPolicy.none` is selected:
+    ///
+    /// ```swift
+    /// callKitService.missingPermissionPolicy = .none
+    /// ```
+    ///
+    /// - Warning: This policy should be used with caution. The `.endCall`
+    ///   policy is recommended for production applications to ensure
+    ///   proper permission handling.
+    final class NoOp: CallKitMissingPermissionPolicyProtocol {
+        
+        /// Reports that the call should always proceed.
+        ///
+        /// This implementation performs no checks and never throws an
+        /// error, effectively allowing all calls to proceed regardless
+        /// of permission status or application state.
+        ///
+        /// - Note: The empty implementation is intentional - this is a
+        ///   no-operation policy that takes no action.
+        func reportCall() throws { /* No-op */ }
+    }
+}

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -264,6 +264,10 @@
 		404C27CB2BF2552800DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		404C27CC2BF2552900DF2937 /* XCTestCase+PredicateFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409CA7982BEE21720045F7AA /* XCTestCase+PredicateFulfillment.swift */; };
 		404CAEE72B8F48F6007087BC /* DemoBackgroundEffectSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A0E95F2B88ABC80089E8D3 /* DemoBackgroundEffectSelector.swift */; };
+		405072602E5F49D5003D2109 /* CallKitMissingPermissionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4050725F2E5F49D5003D2109 /* CallKitMissingPermissionPolicy.swift */; };
+		405072622E5F4CCA003D2109 /* CallKitMissingPermissionPolicyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405072612E5F4CCA003D2109 /* CallKitMissingPermissionPolicyProtocol.swift */; };
+		405072652E5F4CDD003D2109 /* CallKitMissingPermissionPolicy+NoOp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405072642E5F4CDD003D2109 /* CallKitMissingPermissionPolicy+NoOp.swift */; };
+		405072672E5F4CF7003D2109 /* CallKitMissingPermissionPolicy+EndCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405072662E5F4CF7003D2109 /* CallKitMissingPermissionPolicy+EndCall.swift */; };
 		4051A26F2D665B03000C3167 /* Sendable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */; };
 		4051A2732D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
 		4051A2742D673430000C3167 /* CustomStringConvertible+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */; };
@@ -1961,6 +1965,10 @@
 		404A81302DA3C5F0001F7FA8 /* MockDefaultAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultAPI.swift; sourceTree = "<group>"; };
 		404A81352DA3CBF0001F7FA8 /* CallConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallConfigurationTests.swift; sourceTree = "<group>"; };
 		404A81372DA3CC0C001F7FA8 /* CallConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallConfiguration.swift; sourceTree = "<group>"; };
+		4050725F2E5F49D5003D2109 /* CallKitMissingPermissionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitMissingPermissionPolicy.swift; sourceTree = "<group>"; };
+		405072612E5F4CCA003D2109 /* CallKitMissingPermissionPolicyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitMissingPermissionPolicyProtocol.swift; sourceTree = "<group>"; };
+		405072642E5F4CDD003D2109 /* CallKitMissingPermissionPolicy+NoOp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallKitMissingPermissionPolicy+NoOp.swift"; sourceTree = "<group>"; };
+		405072662E5F4CF7003D2109 /* CallKitMissingPermissionPolicy+EndCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallKitMissingPermissionPolicy+EndCall.swift"; sourceTree = "<group>"; };
 		4051A26E2D665B03000C3167 /* Sendable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sendable+Extensions.swift"; sourceTree = "<group>"; };
 		4051A2722D673430000C3167 /* CustomStringConvertible+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomStringConvertible+Conformances.swift"; sourceTree = "<group>"; };
 		4052BF542DBA830D0085AFA5 /* MockAppStateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppStateAdapter.swift; sourceTree = "<group>"; };
@@ -3247,9 +3255,9 @@
 		40034C212CFE116200A318B1 /* AvailabilityPolicy */ = {
 			isa = PBXGroup;
 			children = (
+				40034C272CFE156800A318B1 /* CallKitAvailabilityPolicy.swift */,
 				40034C2B2CFE157300A318B1 /* CallKitAlwaysAvailabilityPolicy.swift */,
 				40034C292CFE156F00A318B1 /* CallKitRegionBasedAvailabilityPolicy.swift */,
-				40034C272CFE156800A318B1 /* CallKitAvailabilityPolicy.swift */,
 				40034C252CFE155C00A318B1 /* CallKitAvailabilityPolicyProtocol.swift */,
 			);
 			path = AvailabilityPolicy;
@@ -3997,6 +4005,25 @@
 				4049CE832BBBF8EF003D07D2 /* StreamAsyncImage.swift */,
 			);
 			path = AsyncImage;
+			sourceTree = "<group>";
+		};
+		4050725E2E5F49B1003D2109 /* MissingPermissionPolicy */ = {
+			isa = PBXGroup;
+			children = (
+				405072632E5F4CD3003D2109 /* Policies */,
+				405072612E5F4CCA003D2109 /* CallKitMissingPermissionPolicyProtocol.swift */,
+				4050725F2E5F49D5003D2109 /* CallKitMissingPermissionPolicy.swift */,
+			);
+			path = MissingPermissionPolicy;
+			sourceTree = "<group>";
+		};
+		405072632E5F4CD3003D2109 /* Policies */ = {
+			isa = PBXGroup;
+			children = (
+				405072662E5F4CF7003D2109 /* CallKitMissingPermissionPolicy+EndCall.swift */,
+				405072642E5F4CDD003D2109 /* CallKitMissingPermissionPolicy+NoOp.swift */,
+			);
+			path = Policies;
 			sourceTree = "<group>";
 		};
 		4051A26D2D665AF5000C3167 /* Swinft6Migration */ = {
@@ -5897,6 +5924,7 @@
 		40FB01FF2BAC8A4000A1C206 /* CallKit */ = {
 			isa = PBXGroup;
 			children = (
+				4050725E2E5F49B1003D2109 /* MissingPermissionPolicy */,
 				40034C212CFE116200A318B1 /* AvailabilityPolicy */,
 				40FB02022BAC93A800A1C206 /* CallKitAdapter.swift */,
 				40FB02042BAC94FB00A1C206 /* CallKitPushNotificationAdapter.swift */,
@@ -8377,6 +8405,7 @@
 				40BBC4BA2C627F83002AEF92 /* TrackEvent.swift in Sources */,
 				406128832CF33000007F5CDC /* SDPParser.swift in Sources */,
 				84B9A56D29112F39004DE31A /* EndpointConfig.swift in Sources */,
+				405072672E5F4CF7003D2109 /* CallKitMissingPermissionPolicy+EndCall.swift in Sources */,
 				4039F0CF2D024DDF0078159E /* MediaTransceiverStorage.swift in Sources */,
 				8469593829BB6B4E00134EA0 /* GetEdgesResponse.swift in Sources */,
 				40AB34AE2C5D02D400B5B6B3 /* SFUAdapter.swift in Sources */,
@@ -8638,8 +8667,10 @@
 				40BBC4E02C63A564002AEF92 /* WebRTCCoordinator+Disconnected.swift in Sources */,
 				40BBC4DA2C63A439002AEF92 /* WebRTCCoordinator+Joined.swift in Sources */,
 				848CCCE92AB8ED8F002E83A2 /* ThumbnailResponse.swift in Sources */,
+				405072602E5F49D5003D2109 /* CallKitMissingPermissionPolicy.swift in Sources */,
 				841BAA322BD15CDE000C73E4 /* CallTranscriptionStoppedEvent.swift in Sources */,
 				84DC38D429ADFCFD00946713 /* CallSettingsResponse.swift in Sources */,
+				405072622E5F4CCA003D2109 /* CallKitMissingPermissionPolicyProtocol.swift in Sources */,
 				84A737CF28F4716E001A6769 /* signal.twirp.swift in Sources */,
 				40BBC4E42C63A5FF002AEF92 /* WebRTCCoordinator+FastReconnected.swift in Sources */,
 				404A81382DA3CC0C001F7FA8 /* CallConfiguration.swift in Sources */,
@@ -8717,6 +8748,7 @@
 				40E363772D0A2E320028C52A /* BroadcastBufferReaderKey.swift in Sources */,
 				40BBC4EA2C63A665002AEF92 /* WebRTCCoordinator+Migrated.swift in Sources */,
 				84E4F7D1294CB5F300DD4CE3 /* ConnectionQuality.swift in Sources */,
+				405072652E5F4CDD003D2109 /* CallKitMissingPermissionPolicy+NoOp.swift in Sources */,
 				848CCCE72AB8ED8F002E83A2 /* ThumbnailsSettingsRequest.swift in Sources */,
 				8206D8532A5FF3260099F5EC /* SystemEnvironment+Version.swift in Sources */,
 				84CD12202C73831000056640 /* CallMissedEvent.swift in Sources */,

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -702,6 +702,8 @@
 		40C4DF522C1C60A80035DBC2 /* StreamVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F737ED287C13AC00A363F4 /* StreamVideo.framework */; };
 		40C4DF532C1C60A80035DBC2 /* StreamVideo.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84F737ED287C13AC00A363F4 /* StreamVideo.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		40C4DF572C1C61BD0035DBC2 /* URL+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401A64B22A9DF86200534ED1 /* URL+Convenience.swift */; };
+		40C4E8322E60BBCC00FC29BC /* CallKitMissingPermissionPolicy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4E8312E60BBCC00FC29BC /* CallKitMissingPermissionPolicy_Tests.swift */; };
+		40C4E8352E60BC6300FC29BC /* CallKitMissingPermissionPolicy_EndCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C4E8342E60BC6300FC29BC /* CallKitMissingPermissionPolicy_EndCallTests.swift */; };
 		40C689182C64DDC70054528A /* Publisher+TaskSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C689172C64DDC70054528A /* Publisher+TaskSink.swift */; };
 		40C708D62D8D729500D3501F /* Gleap in Frameworks */ = {isa = PBXBuildFile; productRef = 40C708D52D8D729500D3501F /* Gleap */; };
 		40C71B5A2E53565300733BF6 /* Store+Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C71B592E53565300733BF6 /* Store+Mocks.swift */; };
@@ -2314,6 +2316,8 @@
 		40C4DF4A2C1C2C330035DBC2 /* ParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C4DF4C2C1C2CD80035DBC2 /* DefaultParticipantAutoLeavePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultParticipantAutoLeavePolicy.swift; sourceTree = "<group>"; };
 		40C4DF4F2C1C415F0035DBC2 /* LastParticipantAutoLeavePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastParticipantAutoLeavePolicyTests.swift; sourceTree = "<group>"; };
+		40C4E8312E60BBCC00FC29BC /* CallKitMissingPermissionPolicy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitMissingPermissionPolicy_Tests.swift; sourceTree = "<group>"; };
+		40C4E8342E60BC6300FC29BC /* CallKitMissingPermissionPolicy_EndCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKitMissingPermissionPolicy_EndCallTests.swift; sourceTree = "<group>"; };
 		40C689172C64DDC70054528A /* Publisher+TaskSink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+TaskSink.swift"; sourceTree = "<group>"; };
 		40C689192C64F74F0054528A /* SFUSignalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFUSignalService.swift; sourceTree = "<group>"; };
 		40C6891D2C6661990054528A /* SFUEventAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFUEventAdapter.swift; sourceTree = "<group>"; };
@@ -5241,6 +5245,23 @@
 			path = ParticipantAutoLeavePolicy;
 			sourceTree = "<group>";
 		};
+		40C4E8302E60BB8A00FC29BC /* MissingPermissionPolicy */ = {
+			isa = PBXGroup;
+			children = (
+				40C4E8332E60BC5900FC29BC /* Policies */,
+				40C4E8312E60BBCC00FC29BC /* CallKitMissingPermissionPolicy_Tests.swift */,
+			);
+			path = MissingPermissionPolicy;
+			sourceTree = "<group>";
+		};
+		40C4E8332E60BC5900FC29BC /* Policies */ = {
+			isa = PBXGroup;
+			children = (
+				40C4E8342E60BC6300FC29BC /* CallKitMissingPermissionPolicy_EndCallTests.swift */,
+			);
+			path = Policies;
+			sourceTree = "<group>";
+		};
 		40C71B572E5355F800733BF6 /* Store */ = {
 			isa = PBXGroup;
 			children = (
@@ -5481,6 +5502,7 @@
 		40DE867A2BBEAA6900E88D8A /* CallKit */ = {
 			isa = PBXGroup;
 			children = (
+				40C4E8302E60BB8A00FC29BC /* MissingPermissionPolicy */,
 				40034C242CFE154F00A318B1 /* AvailabilityPolicy */,
 				40DE867C2BBEAA8600E88D8A /* CallKitPushNotificationAdapterTests.swift */,
 				40F017412BBEC81C00E89FD1 /* CallKitServiceTests.swift */,
@@ -8838,6 +8860,7 @@
 				406B3C4A2C91EE9700FC93A1 /* MockWebRTCCoordinatorStack.swift in Sources */,
 				40C71B692E535D7400733BF6 /* StreamCallAudioRecorder_DefaultReducerTests.swift in Sources */,
 				40AB34C92C5D3F2E00B5B6B3 /* ParticipantsStats+Dummy.swift in Sources */,
+				40C4E8322E60BBCC00FC29BC /* CallKitMissingPermissionPolicy_Tests.swift in Sources */,
 				84F58B7629EE92BF00010C4C /* UniqueValues.swift in Sources */,
 				40B48C512D14F7AE002C4EAB /* SDPParser_Tests.swift in Sources */,
 				84F58B9529EEBA3900010C4C /* EquatableEvent.swift in Sources */,
@@ -8976,6 +8999,7 @@
 				40AF6A372C93423400BA2935 /* WebRTCCoordinatorStateMachine_FastReconnectingStageTests.swift in Sources */,
 				40F0176D2BBEF20D00E89FD1 /* EgressResponse+Dummy.swift in Sources */,
 				40C71B7F2E54790400733BF6 /* Store_RaceConditionTests.swift in Sources */,
+				40C4E8352E60BC6300FC29BC /* CallKitMissingPermissionPolicy_EndCallTests.swift in Sources */,
 				40C71B802E54790400733BF6 /* Store_ConcurrencyTests.swift in Sources */,
 				40C71B812E54790400733BF6 /* Store_PerformanceTests.swift in Sources */,
 				84F58B9129EEB36E00010C4C /* EventNotificationCenter_Mock.swift in Sources */,

--- a/StreamVideoTests/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicy_Tests.swift
+++ b/StreamVideoTests/CallKit/MissingPermissionPolicy/CallKitMissingPermissionPolicy_Tests.swift
@@ -1,0 +1,15 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class CallKitMissingPermissionPolicy_Tests: XCTestCase, @unchecked Sendable {
+
+    func test_returnsExpectedPolicies() {
+        XCTAssertNotNil(CallKitMissingPermissionPolicy.none.policy as? CallKitMissingPermissionPolicy.NoOp)
+        XCTAssertNotNil(CallKitMissingPermissionPolicy.endCall.policy as? CallKitMissingPermissionPolicy.EndCall)
+    }
+}

--- a/StreamVideoTests/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy_EndCallTests.swift
+++ b/StreamVideoTests/CallKit/MissingPermissionPolicy/Policies/CallKitMissingPermissionPolicy_EndCallTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class CallKitMissingPermissionPolicy_EndCallTests: XCTestCase, @unchecked Sendable {
+
+    private lazy var mockApplicationStateAdapter: MockAppStateAdapter! = .init()
+    private lazy var mockPermissions: MockPermissionsStore! = .init()
+    private lazy var subject: CallKitMissingPermissionPolicy.EndCall! = .init()
+
+    override func setUp() {
+        super.setUp()
+        mockApplicationStateAdapter.makeShared()
+    }
+
+    override func tearDown() {
+        subject = nil
+        mockApplicationStateAdapter = nil
+        mockPermissions = nil
+        super.tearDown()
+    }
+
+    // MARK: - reportCall
+
+    func test_report_appIsInForeground_doesNotThrowError() {
+        mockApplicationStateAdapter.stubbedState = .foreground
+
+        XCTAssertNoThrow(try subject.reportCall(), "")
+    }
+
+    func test_report_appIsInBackground_hasMicrophonePermission_doesNotThrowError() {
+        mockApplicationStateAdapter.stubbedState = .background
+        mockPermissions.stubMicrophonePermission(.granted)
+
+        XCTAssertNoThrow(try subject.reportCall(), "")
+    }
+
+    func test_report_appIsInBackground_noMicrophonePermission_throwsError() async {
+        mockApplicationStateAdapter.stubbedState = .background
+        mockPermissions.stubMicrophonePermission(.denied)
+        await fulfillment { self.mockPermissions.mockStore.state.microphonePermission == .denied }
+
+        XCTAssertThrowsError(try subject.reportCall())
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Enhances the user experience when using CallKit and the user hasn't granted the microphone permission.

### 📝 Summary

This revision adds 2 mechanisms to support the scenario where a user receives a VoIP, while the app isn't running or the screen is locked, and the answered call remains in CallKit:
- The CallKitService now is aware of the CallSettings in the active call. When the audioOn setting changes the service updates the CallKit mute button accordingly. Additionally, if the microphone permission isn't granted the services fails any user action to unmute.
- We now expose MissingPermissionPolicy for CallKit, which can be configured with one of the following 2 options:
- - `.none`: There is no special handling happening when the microphone permission is missing.
- - `.endCall`: The call will end, shortly after it has been reported, automatically, if the microphone permission is missing and the app isn't in the foreground.

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)