### PR TITLE
[Enhancement]Allow changing the ViewFactory used by Picture-in-Picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - When the user is missing a permission, the SDK will prompt them to accept any missing permission. [#915](https://github.com/GetStream/stream-video-swift/pull/915)
+- You can now set the `ViewFactory` instance to be used from Picture-in-Picture. [#934](https://github.com/GetStream/stream-video-swift/pull/934) 
 
 ### 🔄 Changed
 - Improved the LastParticipantLeavePolicy to be more robust. [#925](https://github.com/GetStream/stream-video-swift/pull/925)

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureViewFactory.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureViewFactory.swift
@@ -14,6 +14,8 @@ import SwiftUI
 /// ensures thread safety with `@unchecked Sendable` conformance.
 final class PictureInPictureViewFactory: @unchecked Sendable {
 
+    let source: any ViewFactory
+
     private let _makeParticipantImageView: (CallParticipant) -> AnyView
 
     /// Creates a new instance of `PictureInPictureViewFactory`.
@@ -22,6 +24,7 @@ final class PictureInPictureViewFactory: @unchecked Sendable {
     ///   protocol, used to create the participant image views.
     @MainActor
     init<Factory: ViewFactory>(_ viewFactory: Factory) {
+        source = viewFactory
         _makeParticipantImageView = {
             AnyView(
                 CallParticipantImageView(

--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureAdapter.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/StreamPictureInPictureAdapter.swift
@@ -82,6 +82,17 @@ public final class StreamPictureInPictureAdapter: @unchecked Sendable {
                 .store(in: disposableBag)
         }
     }
+
+    // MARK: - State updaters
+
+    /// Updates the ViewFactory instance the will be used by Picture-in-Picture to create UI components.
+    @MainActor
+    public func setViewFactory<V: ViewFactory>(_ viewFactory: V) {
+        guard let store else {
+            return
+        }
+        store.dispatch(.setViewFactory(.init(viewFactory)))
+    }
 }
 
 /// Provides the default value for the Picture-in-Picture adapter.

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureAdapterTests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/StreamPictureInPictureAdapterTests.swift
@@ -37,4 +37,18 @@ final class StreamPictureInPictureAdapterTests: XCTestCase, @unchecked Sendable 
 
         await fulfilmentInMainActor { self.subject.store?.state.sourceView === view }
     }
+
+    // MARK: - ViewFactory updated
+
+    @MainActor
+    func test_setViewFactory_storeWasUpdated() async {
+        final class CustomViewFactory: ViewFactory {}
+        _ = subject
+        await fulfillment { self.subject.store != nil }
+        let viewFactory = CustomViewFactory()
+
+        subject.setViewFactory(viewFactory)
+
+        await fulfillment { self.subject.store?.state.viewFactory.source === viewFactory }
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1121/allow-overriding-the-viewfactory-used-by-picture-in-picture

### 📝 Summary

This revision provides a way to override the ViewFactory instance that is being used by Picture-in-Picture. 

In order to update the ViewFactory, prior to joining a call, use 

```swift
@Injected(\.pictureInPictureAdapter) var pictureInPictureAdapter

...

@MainActor
func updateViewFactory<V: ViewFactory>(_ viewFactory: V) {
    pictureInPictureAdapter.setViewFactory(viewFactory)
}
```

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)