### PR TITLE
[Enhancement]Add unified session id to join request

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/WebRTCJoinRequestFactory.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCJoinRequestFactory.swift
@@ -18,9 +18,9 @@ struct WebRTCJoinRequestFactory {
         var isFastReconnect: Bool {
             switch self {
             case .fastReconnect:
-                return true
+                true
             default:
-                return false
+                false
             }
         }
     }
@@ -63,6 +63,7 @@ struct WebRTCJoinRequestFactory {
         )
         result.capabilities = capabilities
         result.source = .webrtcUnspecified
+        result.unifiedSessionID = coordinator.stateAdapter.unifiedSessionId
 
         if let reconnectDetails = await buildReconnectDetails(
             for: connectionType,
@@ -112,11 +113,11 @@ struct WebRTCJoinRequestFactory {
                 function: function,
                 line: line
             )
-            result.subscriptions = buildSubscriptionDetails(
+            result.subscriptions = await buildSubscriptionDetails(
                 nil,
-                sessionID: await coordinator.stateAdapter.sessionID,
-                participants: Array(await coordinator.stateAdapter.participants.values),
-                incomingVideoQualitySettings: await coordinator
+                sessionID: coordinator.stateAdapter.sessionID,
+                participants: Array(coordinator.stateAdapter.participants.values),
+                incomingVideoQualitySettings: coordinator
                     .stateAdapter
                     .incomingVideoQualitySettings,
                 file: file,
@@ -135,11 +136,11 @@ struct WebRTCJoinRequestFactory {
                 line: line
             )
             result.fromSfuID = fromHostname
-            result.subscriptions = buildSubscriptionDetails(
+            result.subscriptions = await buildSubscriptionDetails(
                 nil,
-                sessionID: await coordinator.stateAdapter.sessionID,
-                participants: Array(await coordinator.stateAdapter.participants.values),
-                incomingVideoQualitySettings: await coordinator
+                sessionID: coordinator.stateAdapter.sessionID,
+                participants: Array(coordinator.stateAdapter.participants.values),
+                incomingVideoQualitySettings: coordinator
                     .stateAdapter
                     .incomingVideoQualitySettings,
                 file: file,
@@ -157,11 +158,11 @@ struct WebRTCJoinRequestFactory {
                 function: function,
                 line: line
             )
-            result.subscriptions = buildSubscriptionDetails(
+            result.subscriptions = await buildSubscriptionDetails(
                 fromSessionID,
-                sessionID: await coordinator.stateAdapter.sessionID,
-                participants: Array(await coordinator.stateAdapter.participants.values),
-                incomingVideoQualitySettings: await coordinator
+                sessionID: coordinator.stateAdapter.sessionID,
+                participants: Array(coordinator.stateAdapter.participants.values),
+                incomingVideoQualitySettings: coordinator
                     .stateAdapter
                     .incomingVideoQualitySettings,
                 file: file,

--- a/StreamVideoTests/WebRTC/v2/WebRTCJoinRequestFactory_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCJoinRequestFactory_Tests.swift
@@ -18,7 +18,7 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
     // MARK: - Lifecycle
 
     override class func tearDown() {
-        Self.videoConfig = nil
+        videoConfig = nil
         super.tearDown()
     }
 
@@ -42,6 +42,10 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
             .coordinator
             .stateAdapter
             .sessionID
+        let unifiedSessionId = await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .unifiedSessionId
         await mockCoordinatorStack
             .coordinator
             .stateAdapter
@@ -57,6 +61,7 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
         )
 
         XCTAssertEqual(result.sessionID, sessionId)
+        XCTAssertEqual(result.unifiedSessionID, unifiedSessionId)
         XCTAssertEqual(result.subscriberSdp, subscriberSdp)
         XCTAssertFalse(result.fastReconnect)
         XCTAssertEqual(result.token, token)
@@ -81,6 +86,10 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
             .coordinator
             .stateAdapter
             .sessionID
+        let unifiedSessionId = await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .unifiedSessionId
         await mockCoordinatorStack
             .coordinator
             .stateAdapter
@@ -96,6 +105,7 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
         )
 
         XCTAssertEqual(result.sessionID, sessionId)
+        XCTAssertEqual(result.unifiedSessionID, unifiedSessionId)
         XCTAssertEqual(result.subscriberSdp, subscriberSdp)
         XCTAssertTrue(result.fastReconnect)
         XCTAssertEqual(result.token, token)
@@ -120,6 +130,10 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
             .coordinator
             .stateAdapter
             .sessionID
+        let unifiedSessionId = await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .unifiedSessionId
         await mockCoordinatorStack
             .coordinator
             .stateAdapter
@@ -136,6 +150,7 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
         )
 
         XCTAssertEqual(result.sessionID, sessionId)
+        XCTAssertEqual(result.unifiedSessionID, unifiedSessionId)
         XCTAssertEqual(result.subscriberSdp, subscriberSdp)
         XCTAssertFalse(result.fastReconnect)
         XCTAssertEqual(result.token, token)
@@ -160,6 +175,10 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
             .coordinator
             .stateAdapter
             .sessionID
+        let unifiedSessionId = await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .unifiedSessionId
         await mockCoordinatorStack
             .coordinator
             .stateAdapter
@@ -176,6 +195,7 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
         )
 
         XCTAssertEqual(result.sessionID, sessionId)
+        XCTAssertEqual(result.unifiedSessionID, unifiedSessionId)
         XCTAssertEqual(result.subscriberSdp, subscriberSdp)
         XCTAssertFalse(result.fastReconnect)
         XCTAssertEqual(result.token, token)
@@ -400,10 +420,10 @@ final class WebRTCJoinRequestFactory_Tests: XCTestCase, @unchecked Sendable {
                 .participants.count == 4
         }
 
-        let result = subject.buildSubscriptionDetails(
+        let result = await subject.buildSubscriptionDetails(
             .unique,
-            sessionID: await mockCoordinatorStack.coordinator.stateAdapter.sessionID,
-            participants: Array(await mockCoordinatorStack.coordinator.stateAdapter.participants.values),
+            sessionID: mockCoordinatorStack.coordinator.stateAdapter.sessionID,
+            participants: Array(mockCoordinatorStack.coordinator.stateAdapter.participants.values),
             incomingVideoQualitySettings: .none
         ).sorted { $0.sessionID <= $1.sessionID }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1167/send-unified-session-id-on-joinrequest

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)