### PR TITLE
[Fix]Stop permission prompts on call cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Permissions prompts won't show up when moving to background for a call that has already ended but the feedback screen is visible. [#951](https://github.com/GetStream/stream-video-swift/pull/951)
 
 # [1.33.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.33.0)
 _September 15, 2025_

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCPermissionsAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCPermissionsAdapter.swift
@@ -155,6 +155,15 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
         }
     }
 
+    func cleanUp() {
+        processingQueue.addOperation { [weak self] in
+            // By emptying the Set we are saying that there are no permissions
+            // required, so when the app moves to foreground no prompts will
+            // appear.
+            self?.requiredPermissions = []
+        }
+    }
+
     // MARK: - Private Helpers
 
     /// Requests pending permissions when returning to foreground, if needed.

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -355,6 +355,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         set(participantPins: [])
         trackStorage.removeAll()
         audioSession.deactivate()
+        permissionsAdapter.cleanUp()
     }
 
     /// Cleans up the session for reconnection, clearing adapters and tracks.


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1137/excess-permissions-prompts-after-the-call-is-ended

### 📝 Summary

This PR addresses the permissions prompts (mic and/or camera) that may show up even when the call has been cleaned up (but the feedback screen is still visible).

### 🧪 Manual Testing Notes

- Uninstall the app
- Install and login with a user
- Let the app running and lock the screen
- Receive a call and accept
- while on Callkit, terminate the call
- After call termination unlock the screen and the app will present with the feedback screen on but now prompts

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)