### PR TITLE
Add a flag for hifi audio enabled

### DIFF
--- a/Sources/StreamVideo/OpenApi/generated/Models/AudioSettings.swift
+++ b/Sources/StreamVideo/OpenApi/generated/Models/AudioSettings.swift
@@ -31,7 +31,16 @@ public final class AudioSettings: @unchecked Sendable, Codable, JSONEncodable, H
     public var redundantCodingEnabled: Bool
     public var speakerDefaultOn: Bool
 
-    public init(accessRequestEnabled: Bool, defaultDevice: DefaultDevice, hifiAudioEnabled: Bool? = nil, micDefaultOn: Bool, noiseCancellation: NoiseCancellationSettingsRequest? = nil, opusDtxEnabled: Bool, redundantCodingEnabled: Bool, speakerDefaultOn: Bool) {
+    public init(
+        accessRequestEnabled: Bool,
+        defaultDevice: DefaultDevice,
+        hifiAudioEnabled: Bool? = nil,
+        micDefaultOn: Bool,
+        noiseCancellation: NoiseCancellationSettingsRequest? = nil,
+        opusDtxEnabled: Bool,
+        redundantCodingEnabled: Bool,
+        speakerDefaultOn: Bool
+    ) {
         self.accessRequestEnabled = accessRequestEnabled
         self.defaultDevice = defaultDevice
         self.hifiAudioEnabled = hifiAudioEnabled

--- a/Sources/StreamVideo/OpenApi/generated/Models/AudioSettingsRequest.swift
+++ b/Sources/StreamVideo/OpenApi/generated/Models/AudioSettingsRequest.swift
@@ -30,7 +30,16 @@ public final class AudioSettingsRequest: @unchecked Sendable, Codable, JSONEncod
     public var redundantCodingEnabled: Bool?
     public var speakerDefaultOn: Bool?
 
-    public init(accessRequestEnabled: Bool? = nil, defaultDevice: DefaultDevice, hifiAudioEnabled: Bool? = nil, micDefaultOn: Bool? = nil, noiseCancellation: NoiseCancellationSettingsRequest? = nil, opusDtxEnabled: Bool? = nil, redundantCodingEnabled: Bool? = nil, speakerDefaultOn: Bool? = nil) {
+    public init(
+        accessRequestEnabled: Bool? = nil,
+        defaultDevice: DefaultDevice,
+        hifiAudioEnabled: Bool? = nil,
+        micDefaultOn: Bool? = nil,
+        noiseCancellation: NoiseCancellationSettingsRequest? = nil,
+        opusDtxEnabled: Bool? = nil,
+        redundantCodingEnabled: Bool? = nil,
+        speakerDefaultOn: Bool? = nil
+    ) {
         self.accessRequestEnabled = accessRequestEnabled
         self.defaultDevice = defaultDevice
         self.hifiAudioEnabled = hifiAudioEnabled


### PR DESCRIPTION
### 🔗 Issue Links

Part of https://linear.app/stream/issue/IOS-1103/hifi-implementation.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
