### PR TITLE
[Testing]Implement Performance UITesting

### DIFF
--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		40245F652BE27B2000FCF075 /* StatelessAudioOutputIconView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40245F642BE27B2000FCF075 /* StatelessAudioOutputIconView_Tests.swift */; };
 		40245F672BE27B8400FCF075 /* StatelessSpeakerIconView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40245F662BE27B8400FCF075 /* StatelessSpeakerIconView_Tests.swift */; };
 		40245F692BE27CCB00FCF075 /* StatelessParticipantsListButton_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40245F682BE27CCB00FCF075 /* StatelessParticipantsListButton_Tests.swift */; };
+		4026BEEA2EA79FD400360AD0 /* CallFlow_PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4026BEE92EA79FD400360AD0 /* CallFlow_PerformanceTests.swift */; };
 		402778832BD13C62002F4399 /* NoiseCancellationFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402778822BD13C62002F4399 /* NoiseCancellationFilter.swift */; };
 		4028FE982DC4F638001F9DC3 /* ConsumableBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4028FE972DC4F638001F9DC3 /* ConsumableBucket.swift */; };
 		4028FE9A2DC4FC8E001F9DC3 /* ConsumableBucketItemTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4028FE992DC4FC8E001F9DC3 /* ConsumableBucketItemTransformer.swift */; };
@@ -674,6 +675,7 @@
 		40B575D42DCCECE800F489B8 /* MockAVPictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B575D22DCCECDA00F489B8 /* MockAVPictureInPictureController.swift */; };
 		40B575D82DCCF00200F489B8 /* StreamPictureInPictureControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B575D52DCCEFB500F489B8 /* StreamPictureInPictureControllerProtocol.swift */; };
 		40B713692A275F1400D1FE67 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8456E6C5287EB55F004E180E /* AppState.swift */; };
+		40BAD0B32EA7CE3200CCD3D7 /* StreamWebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 40BAD0B22EA7CE3200CCD3D7 /* StreamWebRTC */; };
 		40BBC4792C6227DC002AEF92 /* DemoNoiseCancellationButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40BBC4782C6227DC002AEF92 /* DemoNoiseCancellationButtonView.swift */; };
 		40BBC47C2C6227F1002AEF92 /* View+PresentDemoMoreMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40BBC47B2C6227F1002AEF92 /* View+PresentDemoMoreMenu.swift */; };
 		40BBC47E2C62287F002AEF92 /* DemoReconnectionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40BBC47D2C62287F002AEF92 /* DemoReconnectionButtonView.swift */; };
@@ -1906,6 +1908,7 @@
 		40245F642BE27B2000FCF075 /* StatelessAudioOutputIconView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatelessAudioOutputIconView_Tests.swift; sourceTree = "<group>"; };
 		40245F662BE27B8400FCF075 /* StatelessSpeakerIconView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatelessSpeakerIconView_Tests.swift; sourceTree = "<group>"; };
 		40245F682BE27CCB00FCF075 /* StatelessParticipantsListButton_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatelessParticipantsListButton_Tests.swift; sourceTree = "<group>"; };
+		4026BEE92EA79FD400360AD0 /* CallFlow_PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallFlow_PerformanceTests.swift; sourceTree = "<group>"; };
 		402778822BD13C62002F4399 /* NoiseCancellationFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseCancellationFilter.swift; sourceTree = "<group>"; };
 		4028FE972DC4F638001F9DC3 /* ConsumableBucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsumableBucket.swift; sourceTree = "<group>"; };
 		4028FE992DC4FC8E001F9DC3 /* ConsumableBucketItemTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsumableBucketItemTransformer.swift; sourceTree = "<group>"; };
@@ -3206,6 +3209,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				40C4DF522C1C60A80035DBC2 /* StreamVideo.framework in Frameworks */,
+				40BAD0B32EA7CE3200CCD3D7 /* StreamWebRTC in Frameworks */,
 				822FF7212AEAD100000202A7 /* StreamSwiftTestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6338,6 +6342,7 @@
 				824DBA9F29F6D77B005ACD09 /* ReconnectionTests.swift */,
 				82FB89362A702A9200AC16A1 /* Authentication_Tests.swift */,
 				40B499CB2AC1A90F00A53B60 /* DeeplinkTests.swift */,
+				4026BEE92EA79FD400360AD0 /* CallFlow_PerformanceTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -7696,6 +7701,7 @@
 			name = SwiftUIDemoAppUITests;
 			packageProductDependencies = (
 				822FF7202AEAD100000202A7 /* StreamSwiftTestHelpers */,
+				40BAD0B22EA7CE3200CCD3D7 /* StreamWebRTC */,
 			);
 			productName = SwiftUIDemoAppUITests;
 			productReference = 82392D512993C9E100941435 /* SwiftUIDemoAppUITests.xctest */;
@@ -8169,6 +8175,7 @@
 			files = (
 				82392D5F2993CCB300941435 /* ParticipantRobot.swift in Sources */,
 				82C837E429A5333700CB6B0E /* CallDetailsPage.swift in Sources */,
+				4026BEEA2EA79FD400360AD0 /* CallFlow_PerformanceTests.swift in Sources */,
 				82C837E229A532C000CB6B0E /* LoginPage.swift in Sources */,
 				82392D542993C9E100941435 /* StreamTestCase.swift in Sources */,
 				82C837E029A531ED00CB6B0E /* CallPage.swift in Sources */,
@@ -11426,6 +11433,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 40AC73B22BE0062B00C57517 /* XCRemoteSwiftPackageReference "stream-video-noise-cancellation-swift" */;
 			productName = StreamVideoNoiseCancellation;
+		};
+		40BAD0B22EA7CE3200CCD3D7 /* StreamWebRTC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 82EB8F552B0277730038B5A2 /* XCRemoteSwiftPackageReference "stream-video-swift-webrtc" */;
+			productName = StreamWebRTC;
 		};
 		40C708D52D8D729500D3501F /* Gleap */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/StreamVideo.xcodeproj/xcshareddata/xcbaselines/82392D502993C9E100941435.xcbaseline/72BCA2C7-BCAB-4F29-B5A2-C1B720A9D6C7.plist
+++ b/StreamVideo.xcodeproj/xcshareddata/xcbaselines/82392D502993C9E100941435.xcbaseline/72BCA2C7-BCAB-4F29-B5A2-C1B720A9D6C7.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>CallFlow_PerformanceTests</key>
+		<dict>
+			<key>test_performance_with2Participants()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Memory-io.getstream.iOS.VideoDemoApp.physical_absolute</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>125000.000000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/StreamVideo.xcodeproj/xcshareddata/xcbaselines/82392D502993C9E100941435.xcbaseline/A871F8A3-784B-4A04-8235-A22FE4A40D80.plist
+++ b/StreamVideo.xcodeproj/xcshareddata/xcbaselines/82392D502993C9E100941435.xcbaseline/A871F8A3-784B-4A04-8235-A22FE4A40D80.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>CallFlow_PerformanceTests</key>
+		<dict>
+			<key>test_performance_with2Participants()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Memory-io.getstream.iOS.VideoDemoApp.physical</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>414000.000000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_Memory-io.getstream.iOS.VideoDemoApp.physical_absolute</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>414000.000000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_Memory-io.getstream.iOS.VideoDemoApp.physical_peak</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>802000.000000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/StreamVideo.xcodeproj/xcshareddata/xcbaselines/82392D502993C9E100941435.xcbaseline/Info.plist
+++ b/StreamVideo.xcodeproj/xcshareddata/xcbaselines/82392D502993C9E100941435.xcbaseline/Info.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>72BCA2C7-BCAB-4F29-B5A2-C1B720A9D6C7</key>
+		<dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone13,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphoneos</string>
+			</dict>
+		</dict>
+		<key>A871F8A3-784B-4A04-8235-A22FE4A40D80</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Pro</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>MacBookPro18,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone18,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/SwiftUIDemoAppUITests/Tests/CallFlow_PerformanceTests.swift
+++ b/SwiftUIDemoAppUITests/Tests/CallFlow_PerformanceTests.swift
@@ -1,0 +1,60 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+final class CallFlow_PerformanceTests: StreamTestCase {
+
+    private let callDuration: TimeInterval = 1 * 60
+    private let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        launchApp = false
+        try super.setUpWithError()
+    }
+
+    @MainActor
+    func test_performance_with4Participants() throws {
+        try XCTSkipIf(TestRunnerEnvironment.isCI, "https://linear.app/stream/issue/IOS-1220/automate-call-performance-testing")
+        // Reduce noise: fewer iterations for deterministic flows
+        let options = XCTMeasureOptions()
+        options.iterationCount = 3
+        options.invocationOptions = [.manuallyStart, .manuallyStop]
+
+        measure(
+            metrics: [
+                XCTMemoryMetric(application: app)
+            ],
+            options: options
+        ) {
+            app.launch()
+            app.activate()
+
+            startMeasuring()
+            WHEN("user starts a new call") {
+                userRobot
+                    .waitForAutoLogin()
+                    .startCall(callId, waitForCompletion: false)
+            }
+
+            // ensure AUT is foreground
+            app.activate()
+            idle(for: callDuration)
+
+            stopMeasuring()
+            app.terminate()
+        }
+    }
+}
+
+extension XCTestCase {
+    /// Non-blocking idle that won't freeze the app under test.
+    func idle(for seconds: TimeInterval, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Idle \(seconds)s")
+        // Intentionally never fulfill. We expect a timeout.
+        let result = XCTWaiter.wait(for: [exp], timeout: seconds)
+        XCTAssertEqual(result, .timedOut, "Idle wait was interrupted", file: file, line: line)
+    }
+}


### PR DESCRIPTION
### 📝 Summary

This revision adds a simple UI tests that is measure memory usage and compares the result with the 1.30.0 version of the SDK.

Currently the test is supposed to run locally and not on CI due to:
- lack of physical device target to run the test
- video-buddy changes required to support this test

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)