### PR TITLE
[Enhancement]Expose AudioSessionConfiguration initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
-- The initiliser of `AudioSessionConfiguration` is now marked as `public` in order to allow custom `AudioSessionPolicy` implementations. [#1025](https://github.com/GetStream/stream-video-swift/pull/1025)
-- 
+- The initiliazer of `AudioSessionConfiguration` is now marked as `public` in order to allow custom `AudioSessionPolicy` implementations. [#1025](https://github.com/GetStream/stream-video-swift/pull/1025)
+
 ### 🐞 Fixed
 - An issue causing microphone to stop recording when screen was locked and `always-display-on` was enabled. [#1026](https://github.com/GetStream/stream-video-swift/pull/1026)
 

--- a/Sources/StreamVideo/Utils/AudioSession/AudioSessionConfiguration.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/AudioSessionConfiguration.swift
@@ -27,6 +27,14 @@ public struct AudioSessionConfiguration: CustomStringConvertible, Equatable, Sen
         return result
     }
 
+    /// Creates a new audio session configuration.
+    ///
+    /// - Parameters:
+    ///   - isActive: Whether the audio session should be active.
+    ///   - category: The audio session category.
+    ///   - mode: The audio session mode.
+    ///   - options: The audio session category options.
+    ///   - overrideOutputAudioPort: The audio session port override.
     public init(
         isActive: Bool,
         category: AVAudioSession.Category,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1352/enhancementexpose-the-audiosessionconfiguration-initialiser

### 🎯 Goal

Allow integrators to define their own AudioSessionPolicies.

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AudioSessionConfiguration initializer is now public, enabling direct instantiation with configurable audio session parameters for enhanced audio management and integration.
  * Allows providing activation state, category, mode, options and an optional output override for finer control of audio behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->