### PR TITLE
[Enhancement]Remove rotation transformation on videoFrames

### DIFF
--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/VideoProcessingPipelineFeatureFlag.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/VideoProcessingPipelineFeatureFlag.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension AppEnvironment {
+
+    /// Debug-only toggle for enabling the video processing pipeline path.
+    enum VideProcessingPipelineToggle: Hashable, Debuggable {
+        case enabled, disabled
+
+        var title: String {
+            switch self {
+            case .enabled:
+                return "Enabled"
+            case .disabled:
+                return "Disabled"
+            }
+        }
+    }
+
+    /// Default to enabled in debug builds so the pipeline is exercised during development.
+    nonisolated(unsafe) static var usesVideoProcessingPipeline: VideProcessingPipelineToggle = {
+        AppEnvironment.configuration == .debug ? .enabled : .disabled
+    }()
+}
+
+extension DebugMenu {
+
+    struct VideoProcessingPipelineToggleView: View {
+
+        @State private var value = AppEnvironment.usesVideoProcessingPipeline {
+            didSet { AppEnvironment.usesVideoProcessingPipeline = value }
+        }
+
+        var body: some View {
+            ItemMenuView(
+                items: [.enabled, .disabled],
+                currentValue: value,
+                label: "VideoProcessing Pipeline",
+                availableAfterLogin: false,
+                updater: { value = $0 }
+            )
+        }
+    }
+}

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
@@ -14,6 +14,7 @@ extension AppEnvironment {
     }
 
     nonisolated(unsafe) static var featureFlags: [FeatureFlag] = [
+        .init { .init(DebugMenu.VideoProcessingPipelineToggleView()) }
     ]
 }
 

--- a/DemoApp/Sources/Components/Router.swift
+++ b/DemoApp/Sources/Components/Router.swift
@@ -183,19 +183,24 @@ final class Router: ObservableObject {
         deeplinkInfo: DeeplinkInfo,
         tokenProvider: @escaping UserTokenProvider
     ) {
-        let videoConfig: VideoConfig
-        #if canImport(StreamVideoNoiseCancellation)
-        let processor = NoiseCancellationProcessor()
-        let noiseCancellationFilter = NoiseCancellationFilter(
-            name: "noise-cancellation",
-            initialize: processor.initialize,
-            process: processor.process,
-            release: processor.release
+        let noiseCancellationFilter: NoiseCancellationFilter? = {
+            #if canImport(StreamVideoNoiseCancellation)
+            let processor = NoiseCancellationProcessor()
+            return NoiseCancellationFilter(
+                name: "noise-cancellation",
+                initialize: processor.initialize,
+                process: processor.process,
+                release: processor.release
+            )
+            #else
+            return nil
+            #endif
+        }()
+
+        let videoConfig = VideoConfig(
+            noiseCancellationFilter: noiseCancellationFilter,
+            usesProcessingPipeline: AppEnvironment.usesVideoProcessingPipeline == .enabled
         )
-        videoConfig = .init(noiseCancellationFilter: noiseCancellationFilter)
-        #else
-        videoConfig = .init()
-        #endif
 
         let streamVideo = StreamVideo(
             apiKey: AppState.shared.apiKey,

--- a/Sources/StreamVideo/Utils/Extensions/WebRTC/RTCVideoOrientation+CGImagePropertyOrientation.swift
+++ b/Sources/StreamVideo/Utils/Extensions/WebRTC/RTCVideoOrientation+CGImagePropertyOrientation.swift
@@ -1,0 +1,24 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+import StreamWebRTC
+
+extension RTCVideoRotation {
+    var cgOrientation: CGImagePropertyOrientation {
+        switch self {
+        case ._0:
+            return .up
+        case ._90:
+            return .left
+        case ._180:
+            return .down
+        case ._270:
+            return .right
+        @unknown default:
+            return .up
+        }
+    }
+}

--- a/Sources/StreamVideo/VideoConfig.swift
+++ b/Sources/StreamVideo/VideoConfig.swift
@@ -15,22 +15,30 @@ public final class VideoConfig: Sendable {
 
     /// The audio processing module that handles the audio streams provided by WebRTC.
     public let audioProcessingModule: AudioProcessingModule
-        
+
+    /// Enables the capture-time processing pipeline for video filters.
+    /// Enables the capture-time processing pipeline (e.g., filter nodes).
+    public let usesProcessingPipeline: Bool
+
     /// Initializes a new instance of `VideoConfig` with the specified parameters.
     /// - Parameters:
     ///   - videoFilters: An array of `VideoFilter` objects representing the filters to apply to the video.
     ///   - noiseCancellationFilter: An ``NoiseCancellationFilter`` object representing the
     ///   noiseCancellationFilter, that the SDK will use whenever noiseCancellation handling requires
     ///   automatic actions (e.g. when the NoiseCancellationSettings.mode is set to `autoOn`).
-    ///   - audioProcessingModule: Provide your own audio processing or fallback to the default one..
+    ///   - audioProcessingModule: Provide your own audio processing or fallback to the
+    ///     default one.
+    ///   - usesProcessingPipeline: Enables capture-time processing for camera frames.
     /// - Returns: A new instance of `VideoConfig`.
     public init(
         videoFilters: [VideoFilter] = [],
         noiseCancellationFilter: NoiseCancellationFilter? = nil,
-        audioProcessingModule: AudioProcessingModule? = nil
+        audioProcessingModule: AudioProcessingModule? = nil,
+        usesProcessingPipeline: Bool = false
     ) {
         self.videoFilters = videoFilters
         self.noiseCancellationFilter = noiseCancellationFilter
         self.audioProcessingModule = audioProcessingModule ?? InjectedValues[\.audioFilterProcessingModule]
+        self.usesProcessingPipeline = usesProcessingPipeline
     }
 }

--- a/Sources/StreamVideo/WebRTC/VideoCapturing/SimulatorScreenCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturing/SimulatorScreenCapturer.swift
@@ -2,6 +2,8 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
+import CoreGraphics
 import Foundation
 import StreamWebRTC
 
@@ -10,7 +12,12 @@ final class SimulatorScreenCapturer: RTCVideoCapturer, @unchecked Sendable {
     private var videoURL: URL
     private let queue = DispatchQueue(label: "org.webrtc.RTCFileVideoCapturer")
     private var assetReader: AVAssetReader?
-    private var videoTrackOutput: AVAssetReaderTrackOutput?
+    private var videoTrackOutput: AVAssetReaderOutput?
+    private var videoRotation: RTCVideoRotation = ._0
+    // Cache the rotation after the first frame to avoid repeated detection.
+    private var resolvedRotation: RTCVideoRotation?
+    private var trackNaturalSize: CGSize = .zero
+    private var trackDisplaySize: CGSize = .zero
     private let disposableBag = DisposableBag()
 
     init(delegate: RTCVideoCapturerDelegate, videoURL: URL) {
@@ -52,13 +59,33 @@ final class SimulatorScreenCapturer: RTCVideoCapturer, @unchecked Sendable {
 
         let asset = AVAsset(url: videoURL)
         guard let track = asset.tracks(withMediaType: .video).first else { return }
+        videoRotation = rotation(from: track.preferredTransform)
+        trackNaturalSize = track.naturalSize
+        trackDisplaySize = displaySize(for: track)
+        resolvedRotation = nil
 
-        let trackOutput = AVAssetReaderTrackOutput(
-            track: track,
-            outputSettings: [
-                kCVPixelBufferPixelFormatTypeKey as String: NSNumber(value: kCVPixelFormatType_32BGRA)
-            ]
-        )
+        let outputSettings: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: NSNumber(value: kCVPixelFormatType_32BGRA),
+            kCVPixelBufferMetalCompatibilityKey as String: true,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+        ]
+        let trackOutput: AVAssetReaderOutput
+        if let composition = videoComposition(for: asset, track: track) {
+            let compositionOutput = AVAssetReaderVideoCompositionOutput(
+                videoTracks: [track],
+                videoSettings: outputSettings
+            )
+            compositionOutput.videoComposition = composition
+            trackOutput = compositionOutput
+            // Composition output already bakes rotation into pixels.
+            videoRotation = ._0
+            resolvedRotation = ._0
+        } else {
+            trackOutput = AVAssetReaderTrackOutput(
+                track: track,
+                outputSettings: outputSettings
+            )
+        }
         do {
             assetReader = try AVAssetReader(asset: asset)
             assetReader?.add(trackOutput)
@@ -77,10 +104,14 @@ final class SimulatorScreenCapturer: RTCVideoCapturer, @unchecked Sendable {
         if let sampleBuffer = trackOutput.copyNextSampleBuffer(), CMSampleBufferIsValid(sampleBuffer) {
             let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)!
             let frameTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+            let rotation = resolvedRotation ?? resolvedRotationForFirstFrame(pixelBuffer: pixelBuffer)
+            if resolvedRotation == nil {
+                resolvedRotation = rotation
+            }
             let videoFrame = RTCCVPixelBuffer(pixelBuffer: pixelBuffer)
             let rtcVideoFrame = RTCVideoFrame(
                 buffer: videoFrame,
-                rotation: ._0,
+                rotation: rotation,
                 timeStampNs: Int64(CMTimeGetSeconds(frameTime) * 1e9)
             )
 
@@ -94,6 +125,106 @@ final class SimulatorScreenCapturer: RTCVideoCapturer, @unchecked Sendable {
             // Reached the end of the video file, restart from the beginning
             setupAssetReader()
         }
+    }
+
+    private func resolvedRotationForFirstFrame(
+        pixelBuffer: CVPixelBuffer
+    ) -> RTCVideoRotation {
+        let bufferSize = CGSize(
+            width: CVPixelBufferGetWidth(pixelBuffer),
+            height: CVPixelBufferGetHeight(pixelBuffer)
+        )
+        if isClose(bufferSize, trackDisplaySize) {
+            // Buffer is already in display orientation; avoid double-rotation.
+            return ._0
+        }
+        if isClose(bufferSize, trackNaturalSize) {
+            // Buffer matches the track's natural size; apply preferred rotation.
+            return videoRotation
+        }
+        // Fallback to a best-effort normalization.
+        return normalizedRotationFallback(videoRotation, bufferSize: bufferSize)
+    }
+
+    private func normalizedRotationFallback(
+        _ rotation: RTCVideoRotation,
+        bufferSize: CGSize
+    ) -> RTCVideoRotation {
+        switch rotation {
+        case ._90, ._270:
+            if bufferSize.width < bufferSize.height {
+                return ._0
+            }
+            return rotation
+        default:
+            return rotation
+        }
+    }
+
+    private func displaySize(for track: AVAssetTrack) -> CGSize {
+        let rect = CGRect(origin: .zero, size: track.naturalSize)
+        let transformed = rect.applying(track.preferredTransform)
+        return CGSize(
+            width: abs(transformed.size.width),
+            height: abs(transformed.size.height)
+        )
+    }
+
+    private func isClose(_ lhs: CGSize, _ rhs: CGSize) -> Bool {
+        let epsilon: CGFloat = 1.0
+        return abs(lhs.width - rhs.width) <= epsilon &&
+            abs(lhs.height - rhs.height) <= epsilon
+    }
+
+    private func videoComposition(
+        for asset: AVAsset,
+        track: AVAssetTrack
+    ) -> AVMutableVideoComposition? {
+        let composition = AVMutableVideoComposition()
+        composition.renderSize = displaySize(for: track)
+
+        let frameRate = track.nominalFrameRate
+        let fps = frameRate > 0 ? frameRate : 30
+        composition.frameDuration = CMTime(value: 1, timescale: CMTimeScale(fps))
+
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRange(
+            start: .zero,
+            duration: asset.duration
+        )
+
+        let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: track)
+        layerInstruction.setTransform(track.preferredTransform, at: .zero)
+        instruction.layerInstructions = [layerInstruction]
+        composition.instructions = [instruction]
+
+        return composition
+    }
+
+    private func rotation(from transform: CGAffineTransform) -> RTCVideoRotation {
+        let epsilon: CGFloat = 0.001
+        func isClose(_ lhs: CGFloat, _ rhs: CGFloat) -> Bool {
+            abs(lhs - rhs) <= epsilon
+        }
+
+        let a = transform.a
+        let b = transform.b
+        let c = transform.c
+        let d = transform.d
+
+        if isClose(a, 0), isClose(b, 1), isClose(c, -1), isClose(d, 0) {
+            return ._90
+        }
+        if isClose(a, 0), isClose(b, -1), isClose(c, 1), isClose(d, 0) {
+            return ._270
+        }
+        if isClose(a, -1), isClose(b, 0), isClose(c, 0), isClose(d, -1) {
+            return ._180
+        }
+        if isClose(a, 1), isClose(b, 0), isClose(c, 0), isClose(d, 1) {
+            return ._0
+        }
+        return ._0
     }
 }
 

--- a/Sources/StreamVideo/WebRTC/VideoCapturing/VideoCapturerProviding.swift
+++ b/Sources/StreamVideo/WebRTC/VideoCapturing/VideoCapturerProviding.swift
@@ -17,6 +17,7 @@ protocol VideoCapturerProviding {
     ///   - source: The video source for the capturer, responsible for
     ///     providing captured frames.
     ///   - audioDeviceModule: The audio device module used by the capturer.
+    ///   - usesProcessingPipeline: Whether to enable capture-time processing nodes.
     /// - Returns: An instance of `StreamVideoCapturer` for managing camera-based
     ///   video capturing.
     ///
@@ -24,7 +25,8 @@ protocol VideoCapturerProviding {
     /// which can be further configured to process video frames.
     func buildCameraCapturer(
         source: RTCVideoSource,
-        audioDeviceModule: AudioDeviceModule
+        audioDeviceModule: AudioDeviceModule,
+        usesProcessingPipeline: Bool
     ) -> StreamVideoCapturing
 
     /// Builds a screen capturer based on the specified type and source.
@@ -67,11 +69,13 @@ final class StreamVideoCapturerFactory: VideoCapturerProviding {
     /// where a camera is the video input source.
     func buildCameraCapturer(
         source: RTCVideoSource,
-        audioDeviceModule: AudioDeviceModule
+        audioDeviceModule: AudioDeviceModule,
+        usesProcessingPipeline: Bool
     ) -> StreamVideoCapturing {
         StreamVideoCapturer.cameraCapturer(
             with: source,
-            audioDeviceModule: audioDeviceModule
+            audioDeviceModule: audioDeviceModule,
+            usesProcessingPipeline: usesProcessingPipeline
         )
     }
 

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter.swift
@@ -628,9 +628,11 @@ final class LocalVideoMediaAdapter: LocalMediaAdapting, @unchecked Sendable {
         track: RTCVideoTrack
     ) async throws {
         if videoCaptureSessionProvider.activeSession == nil {
+            // Create the capturer once and honor the configured processing pipeline flag.
             let cameraCapturer = capturerFactory.buildCameraCapturer(
                 source: track.source,
-                audioDeviceModule: audioDeviceModule
+                audioDeviceModule: audioDeviceModule,
+                usesProcessingPipeline: videoConfig.usesProcessingPipeline
             )
             capturer = cameraCapturer
 

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoCapturer.swift
@@ -18,12 +18,19 @@ final class StreamVideoCapturer: StreamVideoCapturing {
     ///   - videoSource: The video source receiving captured frames.
     ///   - videoCaptureSession: The capture session used for camera input.
     ///   - audioDeviceModule: The audio device module for capture coordination.
+    ///   - usesProcessingPipeline: Whether to process frames through pipeline nodes.
     static func cameraCapturer(
         with videoSource: RTCVideoSource,
         videoCaptureSession: AVCaptureSession = .init(),
-        audioDeviceModule: AudioDeviceModule
+        audioDeviceModule: AudioDeviceModule,
+        usesProcessingPipeline: Bool
     ) -> StreamVideoCapturer {
-        let videoCapturerDelegate = StreamVideoCaptureHandler(source: videoSource)
+        // Route frames through the processing pipeline when enabled.
+        let videoCapturerDelegate: RTCVideoCapturerDelegate = usesProcessingPipeline
+            ? StreamVideoProcessPipeline(source: videoSource, nodes: [
+                StreamVideoProcessPipeline.FilterNode()
+            ])
+            : StreamVideoCaptureHandler(source: videoSource)
 
         #if targetEnvironment(simulator)
         let videoCapturer: RTCVideoCapturer = {
@@ -311,12 +318,11 @@ final class StreamVideoCapturer: StreamVideoCapturing {
     }
 
     func setVideoFilter(_ videoFilter: VideoFilter?) {
-        guard
-            let videoCapturerDelegate = videoCapturerDelegate as? StreamVideoCaptureHandler
-        else {
-            return
+        if let videoCapturerDelegate = videoCapturerDelegate as? StreamVideoCaptureHandler {
+            videoCapturerDelegate.selectedFilter = videoFilter
+        } else if let processingPipeline = videoCapturerDelegate as? StreamVideoProcessPipeline {
+            processingPipeline.didUpdate(videoFilter)
         }
-        videoCapturerDelegate.selectedFilter = videoFilter
     }
 
     func updateCaptureQuality(

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoProcessPipeline/Nodes/StreamVideoProcessPipeline+FilterNode.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoProcessPipeline/Nodes/StreamVideoProcessPipeline+FilterNode.swift
@@ -1,0 +1,100 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamWebRTC
+
+extension StreamVideoProcessPipeline {
+
+    /// Applies the active video filter to captured frames.
+    final class FilterNode: StreamVideoProcessNode, @unchecked Sendable {
+
+        private let context: CIContext = .init(
+            options: [CIContextOption.useSoftwareRenderer: false]
+        )
+        private let colorSpace = CGColorSpaceCreateDeviceRGB()
+        // Block the capture callback until the async filter work completes.
+        private let semaphore = DispatchSemaphore(value: 0)
+        @Atomic private var videoFilter: VideoFilter?
+
+        // MARK: - StreamVideoProcessNode
+
+        /// Updates the filter used for subsequent frames.
+        /// - Parameter videoFilter: The filter to apply, or `nil` to bypass filtering.
+        func didUpdate(_ videoFilter: VideoFilter?) {
+            self.videoFilter = videoFilter
+        }
+
+        /// Applies the current filter to the provided frame when available.
+        /// - Parameter frame: The frame to process.
+        /// - Returns: The processed frame.
+        func didCapture(_ frame: RTCVideoFrame) -> RTCVideoFrame {
+            guard
+                let videoFilter,
+                let frameBuffer = frame.buffer as? RTCCVPixelBuffer
+            else {
+                return frame
+            }
+
+            let orientation = frame.rotation.cgOrientation
+
+            Task { [weak self, semaphore] in
+                defer { semaphore.signal() }
+
+                guard let self else {
+                    return
+                }
+
+                await applyFilter(
+                    videoFilter: videoFilter,
+                    frameBuffer: frameBuffer,
+                    orientation: orientation
+                )
+            }
+
+            semaphore.wait()
+
+            return frame
+        }
+
+        // MARK: - Private Helpers
+
+        /// Applies the filter in-place to the frame's pixel buffer.
+        /// - Parameters:
+        ///   - videoFilter: The filter to apply.
+        ///   - frameBuffer: The frame buffer backing the video frame.
+        ///   - orientation: The frame orientation used by the filter.
+        private func applyFilter(
+            videoFilter: VideoFilter,
+            frameBuffer: RTCCVPixelBuffer,
+            orientation: CGImagePropertyOrientation
+        ) async {
+            let imageBuffer = frameBuffer.pixelBuffer
+
+            CVPixelBufferLockBaseAddress(imageBuffer, [])
+
+            let inputImage = CIImage(
+                cvPixelBuffer: imageBuffer,
+                options: [CIImageOption.colorSpace: self.colorSpace]
+            )
+
+            let outputImage = await videoFilter.filter(
+                VideoFilter.Input(
+                    originalImage: inputImage,
+                    originalPixelBuffer: imageBuffer,
+                    originalImageOrientation: orientation
+                )
+            )
+
+            CVPixelBufferUnlockBaseAddress(imageBuffer, [])
+
+            context.render(
+                outputImage,
+                to: imageBuffer,
+                bounds: outputImage.extent,
+                colorSpace: self.colorSpace
+            )
+        }
+    }
+}

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoProcessPipeline/StreamVideoProcessNode.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoProcessPipeline/StreamVideoProcessNode.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamWebRTC
+
+/// Defines a pipeline stage that can mutate or pass through captured frames.
+protocol StreamVideoProcessNode {
+
+    /// Updates the node with the active video filter.
+    /// - Parameter videoFilter: The filter to apply, or `nil` to disable filtering.
+    func didUpdate(_ videoFilter: VideoFilter?)
+
+    /// Processes a captured frame and returns the frame to forward downstream.
+    /// - Parameter frame: The frame to process.
+    /// - Returns: The frame to pass to the next node.
+    func didCapture(_ frame: RTCVideoFrame) -> RTCVideoFrame
+}

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoProcessPipeline/StreamVideoProcessPipeline.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoProcessPipeline/StreamVideoProcessPipeline.swift
@@ -1,0 +1,52 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamWebRTC
+
+/// Chains processing nodes before forwarding frames to the original capturer.
+final class StreamVideoProcessPipeline: NSObject, RTCVideoCapturerDelegate {
+
+    private let source: RTCVideoCapturerDelegate
+    private let nodes: [StreamVideoProcessNode]
+
+    /// Creates a pipeline that forwards processed frames to the provided source.
+    /// - Parameters:
+    ///   - source: The downstream delegate that receives processed frames.
+    ///   - nodes: Ordered processing nodes to apply to each frame.
+    init(
+        source: RTCVideoCapturerDelegate,
+        nodes: [StreamVideoProcessNode]
+    ) {
+        self.source = source
+        self.nodes = nodes
+        super.init()
+    }
+
+    /// Broadcasts a filter update to all pipeline nodes.
+    /// - Parameter videoFilter: The filter to apply, or `nil` to disable filtering.
+    func didUpdate(_ videoFilter: VideoFilter?) {
+        nodes.forEach { $0.didUpdate(videoFilter) }
+    }
+
+    // MARK: - RTCVideoCapturerDelegate
+
+    /// Applies pipeline nodes to a captured frame before forwarding it.
+    /// - Parameters:
+    ///   - capturer: The WebRTC capturer providing the frame.
+    ///   - frame: The captured frame to process.
+    func capturer(
+        _ capturer: RTCVideoCapturer,
+        didCapture frame: RTCVideoFrame
+    ) {
+        if nodes.isEmpty {
+            source.capturer(capturer, didCapture: frame)
+        } else {
+            source.capturer(
+                capturer,
+                didCapture: nodes.reduce(frame) { $1.didCapture($0) }
+            )
+        }
+    }
+}

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -487,12 +487,19 @@
 		4097B3832BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */; };
 		40986C3A2CCB6D2F00510F88 /* RTCRtpEncodingParameters_Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40986C392CCB6D2F00510F88 /* RTCRtpEncodingParameters_Test.swift */; };
 		40986C3C2CCB6E4B00510F88 /* RTCRtpTransceiverInit_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40986C3B2CCB6E4B00510F88 /* RTCRtpTransceiverInit_Tests.swift */; };
-		40999B722F33915B00F0659A /* DebugMenu+BoolValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B6A2F33915B00F0659A /* DebugMenu+BoolValue.swift */; };
-		40999B732F33915B00F0659A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B702F33915B00F0659A /* AppEnvironment.swift */; };
-		40999B742F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B6D2F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift */; };
-		40999B752F33915B00F0659A /* DebugMenu+BoolValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B6A2F33915B00F0659A /* DebugMenu+BoolValue.swift */; };
-		40999B762F33915B00F0659A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B702F33915B00F0659A /* AppEnvironment.swift */; };
-		40999B772F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B6D2F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift */; };
+		40999B392F3369C400F0659A /* StreamVideoProcessNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B382F3369C400F0659A /* StreamVideoProcessNode.swift */; };
+		40999B3B2F3369F000F0659A /* StreamVideoProcessPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B3A2F3369F000F0659A /* StreamVideoProcessPipeline.swift */; };
+		40999B3E2F336B8100F0659A /* StreamVideoProcessPipeline+FilterNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B3D2F336B8100F0659A /* StreamVideoProcessPipeline+FilterNode.swift */; };
+		40999B572F3386E400F0659A /* StreamVideoProcessPipeline_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B562F3386E300F0659A /* StreamVideoProcessPipeline_Tests.swift */; };
+		40999B5A2F33892800F0659A /* RTCVideoOrientation+CGImagePropertyOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B592F33892800F0659A /* RTCVideoOrientation+CGImagePropertyOrientation.swift */; };
+		40999B822F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B7B2F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift */; };
+		40999B832F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B7D2F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift */; };
+		40999B842F3392F500F0659A /* DebugMenu+BoolValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B792F3392F500F0659A /* DebugMenu+BoolValue.swift */; };
+		40999B852F3392F500F0659A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B802F3392F500F0659A /* AppEnvironment.swift */; };
+		40999B862F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B7B2F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift */; };
+		40999B872F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B7D2F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift */; };
+		40999B882F3392F500F0659A /* DebugMenu+BoolValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B792F3392F500F0659A /* DebugMenu+BoolValue.swift */; };
+		40999B892F3392F500F0659A /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40999B802F3392F500F0659A /* AppEnvironment.swift */; };
 		409AF6E62DAFAC4700EE7BF6 /* PictureInPictureReconnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409AF6E52DAFAC4700EE7BF6 /* PictureInPictureReconnectionView.swift */; };
 		409AF6E82DAFC80200EE7BF6 /* PictureInPictureContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409AF6E72DAFC80200EE7BF6 /* PictureInPictureContent.swift */; };
 		409AF6EA2DAFE1B000EE7BF6 /* PictureInPictureContentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409AF6E92DAFE1B000EE7BF6 /* PictureInPictureContentProviderTests.swift */; };
@@ -2280,9 +2287,15 @@
 		4097B3822BF4E37B0057992D /* OnChangeViewModifier_iOS13.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeViewModifier_iOS13.swift; sourceTree = "<group>"; };
 		40986C392CCB6D2F00510F88 /* RTCRtpEncodingParameters_Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTCRtpEncodingParameters_Test.swift; sourceTree = "<group>"; };
 		40986C3B2CCB6E4B00510F88 /* RTCRtpTransceiverInit_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTCRtpTransceiverInit_Tests.swift; sourceTree = "<group>"; };
-		40999B6A2F33915B00F0659A /* DebugMenu+BoolValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugMenu+BoolValue.swift"; sourceTree = "<group>"; };
-		40999B6D2F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugMenu+FeatureFlagsView.swift"; sourceTree = "<group>"; };
-		40999B702F33915B00F0659A /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		40999B382F3369C400F0659A /* StreamVideoProcessNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamVideoProcessNode.swift; sourceTree = "<group>"; };
+		40999B3A2F3369F000F0659A /* StreamVideoProcessPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamVideoProcessPipeline.swift; sourceTree = "<group>"; };
+		40999B3D2F336B8100F0659A /* StreamVideoProcessPipeline+FilterNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreamVideoProcessPipeline+FilterNode.swift"; sourceTree = "<group>"; };
+		40999B562F3386E300F0659A /* StreamVideoProcessPipeline_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamVideoProcessPipeline_Tests.swift; sourceTree = "<group>"; };
+		40999B592F33892800F0659A /* RTCVideoOrientation+CGImagePropertyOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RTCVideoOrientation+CGImagePropertyOrientation.swift"; sourceTree = "<group>"; };
+		40999B792F3392F500F0659A /* DebugMenu+BoolValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugMenu+BoolValue.swift"; sourceTree = "<group>"; };
+		40999B7B2F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoProcessingPipelineFeatureFlag.swift; sourceTree = "<group>"; };
+		40999B7D2F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugMenu+FeatureFlagsView.swift"; sourceTree = "<group>"; };
+		40999B802F3392F500F0659A /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		409AF6E52DAFAC4700EE7BF6 /* PictureInPictureReconnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictureInPictureReconnectionView.swift; sourceTree = "<group>"; };
 		409AF6E72DAFC80200EE7BF6 /* PictureInPictureContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictureInPictureContent.swift; sourceTree = "<group>"; };
 		409AF6E92DAFE1B000EE7BF6 /* PictureInPictureContentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictureInPictureContentProviderTests.swift; sourceTree = "<group>"; };
@@ -4139,7 +4152,7 @@
 		4030E5962A9DF48C003E8CBA /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				40999B712F33915B00F0659A /* Debug */,
+				40999B812F3392F500F0659A /* Debug */,
 				84921D992F3251E300A4AA30 /* Recording */,
 				40B2F3DF2EFAA3D40067BACE /* AudioTrackPlayer */,
 				4000629E2EDF0CB90086E14B /* VideoFilters */,
@@ -4926,6 +4939,7 @@
 		40916E772DA94A150061D860 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				40999B582F33891C00F0659A /* WebRTC */,
 				4028FEA92DC536CF001F9DC3 /* Foundation */,
 				4035AD712DE640E500F56FAB /* Concurrency */,
 				40916E762DA94A150061D860 /* Combine */,
@@ -5058,44 +5072,71 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		40999B6B2F33915B00F0659A /* Components */ = {
+		40999B372F33699300F0659A /* StreamVideoProcessPipeline */ = {
 			isa = PBXGroup;
 			children = (
-				40999B6A2F33915B00F0659A /* DebugMenu+BoolValue.swift */,
+				40999B3C2F336B5900F0659A /* Nodes */,
+				40999B382F3369C400F0659A /* StreamVideoProcessNode.swift */,
+				40999B3A2F3369F000F0659A /* StreamVideoProcessPipeline.swift */,
+			);
+			path = StreamVideoProcessPipeline;
+			sourceTree = "<group>";
+		};
+		40999B3C2F336B5900F0659A /* Nodes */ = {
+			isa = PBXGroup;
+			children = (
+				40999B3D2F336B8100F0659A /* StreamVideoProcessPipeline+FilterNode.swift */,
+			);
+			path = Nodes;
+			sourceTree = "<group>";
+		};
+		40999B582F33891C00F0659A /* WebRTC */ = {
+			isa = PBXGroup;
+			children = (
+				40999B592F33892800F0659A /* RTCVideoOrientation+CGImagePropertyOrientation.swift */,
+			);
+			path = WebRTC;
+			sourceTree = "<group>";
+		};
+		40999B7A2F3392F500F0659A /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				40999B792F3392F500F0659A /* DebugMenu+BoolValue.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
 		};
-		40999B6C2F33915B00F0659A /* Components */ = {
+		40999B7C2F3392F500F0659A /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				40999B7B2F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
 		};
-		40999B6E2F33915B00F0659A /* FeatureFlags */ = {
+		40999B7E2F3392F500F0659A /* FeatureFlags */ = {
 			isa = PBXGroup;
 			children = (
-				40999B6C2F33915B00F0659A /* Components */,
-				40999B6D2F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift */,
+				40999B7C2F3392F500F0659A /* Components */,
+				40999B7D2F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift */,
 			);
 			path = FeatureFlags;
 			sourceTree = "<group>";
 		};
-		40999B6F2F33915B00F0659A /* Items */ = {
+		40999B7F2F3392F500F0659A /* Items */ = {
 			isa = PBXGroup;
 			children = (
-				40999B6E2F33915B00F0659A /* FeatureFlags */,
+				40999B7E2F3392F500F0659A /* FeatureFlags */,
 			);
 			path = Items;
 			sourceTree = "<group>";
 		};
-		40999B712F33915B00F0659A /* Debug */ = {
+		40999B812F3392F500F0659A /* Debug */ = {
 			isa = PBXGroup;
 			children = (
-				40999B6B2F33915B00F0659A /* Components */,
-				40999B6F2F33915B00F0659A /* Items */,
-				40999B702F33915B00F0659A /* AppEnvironment.swift */,
+				40999B7A2F3392F500F0659A /* Components */,
+				40999B7F2F3392F500F0659A /* Items */,
+				40999B802F3392F500F0659A /* AppEnvironment.swift */,
 			);
 			path = Debug;
 			sourceTree = "<group>";
@@ -6259,6 +6300,7 @@
 		40E363472D09F69D0028C52A /* VideoCapturing */ = {
 			isa = PBXGroup;
 			children = (
+				40999B372F33699300F0659A /* StreamVideoProcessPipeline */,
 				40E3634A2D09F9EB0028C52A /* ActionHandlers */,
 				40B48C462D14E803002C4EAB /* StreamVideoCapturing.swift */,
 				40E363482D09F6B20028C52A /* StreamVideoCapturer.swift */,
@@ -6786,6 +6828,7 @@
 			isa = PBXGroup;
 			children = (
 				40FE5EBA2C9C7D40006B0881 /* StreamVideoCaptureHandler_Tests.swift */,
+				40999B562F3386E300F0659A /* StreamVideoProcessPipeline_Tests.swift */,
 			);
 			path = VideoCapturing;
 			sourceTree = "<group>";
@@ -8791,6 +8834,10 @@
 				845C09912C0E0B7600F725B3 /* SessionTimer.swift in Sources */,
 				401C1EE72D48F20F00304609 /* DemoClosedCaptionsView.swift in Sources */,
 				403EFCA12BDC003A0057C248 /* DemoFeedbackView.swift in Sources */,
+				40999B822F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift in Sources */,
+				40999B832F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */,
+				40999B842F3392F500F0659A /* DebugMenu+BoolValue.swift in Sources */,
+				40999B852F3392F500F0659A /* AppEnvironment.swift in Sources */,
 				40BBC4792C6227DC002AEF92 /* DemoNoiseCancellationButtonView.swift in Sources */,
 				409795412DC11381000C6E39 /* DemoVideoViewOverlay.swift in Sources */,
 				847B47AF2A233AE2000714CE /* DemoAppViewFactory.swift in Sources */,
@@ -8804,9 +8851,6 @@
 				40BBC47E2C62287F002AEF92 /* DemoReconnectionButtonView.swift in Sources */,
 				8456E6C6287EB55F004E180E /* AppState.swift in Sources */,
 				40D946412AA5ECEF00C8861B /* CodeScanner.swift in Sources */,
-				40999B752F33915B00F0659A /* DebugMenu+BoolValue.swift in Sources */,
-				40999B762F33915B00F0659A /* AppEnvironment.swift in Sources */,
-				40999B772F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */,
 				409145FC2B68FEF0007F3C17 /* DemoMoreControlsViewModifier.swift in Sources */,
 				40F445AE2A9DFC34004BE3DA /* UserState.swift in Sources */,
 				40F445F52A9E2AA1004BE3DA /* ReactionOverlayView.swift in Sources */,
@@ -8917,9 +8961,6 @@
 				40AB354E2B738C5A00E465CC /* DemoLocalViewModifier.swift in Sources */,
 				40AB35562B738C7100E465CC /* CallsView.swift in Sources */,
 				402F04AF2B7245F800CA1986 /* DemoCallView.swift in Sources */,
-				40999B722F33915B00F0659A /* DebugMenu+BoolValue.swift in Sources */,
-				40999B732F33915B00F0659A /* AppEnvironment.swift in Sources */,
-				40999B742F33915B00F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */,
 				40AB356E2B73B7A400E465CC /* DemoCallingViewModifier.swift in Sources */,
 				4029A6242AB069100065DAFB /* DemoChatViewModel.swift in Sources */,
 				845C09952C10A7D700F725B3 /* SessionTimer.swift in Sources */,
@@ -8940,6 +8981,10 @@
 				40AB35512B738C6400E465CC /* DemoStatsView.swift in Sources */,
 				406A8EB42AA1D8F5001F598A /* LoginView.swift in Sources */,
 				40AB35502B738C6000E465CC /* LongPressToFocusViewModifier.swift in Sources */,
+				40999B862F3392F500F0659A /* VideoProcessingPipelineFeatureFlag.swift in Sources */,
+				40999B872F3392F500F0659A /* DebugMenu+FeatureFlagsView.swift in Sources */,
+				40999B882F3392F500F0659A /* DebugMenu+BoolValue.swift in Sources */,
+				40999B892F3392F500F0659A /* AppEnvironment.swift in Sources */,
 				40AB354C2B738C5700E465CC /* DemoMoreControlsViewModifier.swift in Sources */,
 				406A8E9E2AA1D7E9001F598A /* URL+Convenience.swift in Sources */,
 				40AB353F2B738C1500E465CC /* CodeScanner.swift in Sources */,
@@ -9054,6 +9099,7 @@
 				84C4004229E3F446007B69C2 /* ConnectedEvent.swift in Sources */,
 				402D0E882D0C94CD00E9B83F /* RTCAudioTrack+Clone.swift in Sources */,
 				84DC389C29ADFCFD00946713 /* GetOrCreateCallResponse.swift in Sources */,
+				40999B3E2F336B8100F0659A /* StreamVideoProcessPipeline+FilterNode.swift in Sources */,
 				402D0E8A2D0C94E600E9B83F /* RTCVideoTrack+Clone.swift in Sources */,
 				406B3BD92C8F337000FC93A1 /* MediaAdapting.swift in Sources */,
 				40E363622D0A1C2E0028C52A /* SimulatorCaptureHandler.swift in Sources */,
@@ -9077,6 +9123,7 @@
 				40BBC4B12C6276A7002AEF92 /* LocalAudioMediaAdapter.swift in Sources */,
 				406B3C3C2C9197FF00FC93A1 /* WebRTCConfiguration.swift in Sources */,
 				84D935212F3105BD007A1878 /* CallRecordingType.swift in Sources */,
+				40999B3B2F3369F000F0659A /* StreamVideoProcessPipeline.swift in Sources */,
 				40064BEF2E5CA3C5007CDB33 /* PushNotificationsPermissionProvider.swift in Sources */,
 				84D2E37829DC856D001D2118 /* CallMemberUpdatedPermissionEvent.swift in Sources */,
 				84F3B0E0289150B10088751D /* CallParticipant.swift in Sources */,
@@ -9124,6 +9171,7 @@
 				841BAA462BD15CDE000C73E4 /* CallStatsReportSummaryResponse.swift in Sources */,
 				84DC38D829ADFCFD00946713 /* JoinCallRequest.swift in Sources */,
 				40ADB8612D65DFD700B06AAF /* String.StringInterpolation+Nil.swift in Sources */,
+				40999B5A2F33892800F0659A /* RTCVideoOrientation+CGImagePropertyOrientation.swift in Sources */,
 				84AF64D2287C78E70012A503 /* User.swift in Sources */,
 				84274F482884251600CF8794 /* InternetConnection.swift in Sources */,
 				84DC389129ADFCFD00946713 /* VideoSettings.swift in Sources */,
@@ -9635,6 +9683,7 @@
 				841BAA422BD15CDE000C73E4 /* Stats.swift in Sources */,
 				40D36ADE2DDE018400972D75 /* WebRTCStatsReporting.swift in Sources */,
 				842B8E1D2A2DFED900863A87 /* EgressHLSResponse.swift in Sources */,
+				40999B392F3369C400F0659A /* StreamVideoProcessNode.swift in Sources */,
 				40FF825D2D63527D0029AA80 /* Comparator.swift in Sources */,
 				848CCCE82AB8ED8F002E83A2 /* StartHLSBroadcastingResponse.swift in Sources */,
 				40EE9D512E97C7C60000EA92 /* RTCAudioStore+RouteChangeEffect.swift in Sources */,
@@ -9840,6 +9889,7 @@
 				40B48C302D14D308002C4EAB /* MockRTCRtpEncodingParameters.swift in Sources */,
 				40F017572BBEF07B00E89FD1 /* GeofenceSettings+Dummy.swift in Sources */,
 				40C9E4532C9888C100802B28 /* WebRTCMigrationStatusObserver_Tests.swift in Sources */,
+				40999B572F3386E400F0659A /* StreamVideoProcessPipeline_Tests.swift in Sources */,
 				400C9FC42D9D0BDA00DB26DC /* OperationQueue_TaskOperationTests.swift in Sources */,
 				40944D2C2E534BDF00088AF0 /* MockMiddleware.swift in Sources */,
 				40D75C562E4385FE000E0438 /* MockAVAudioSessionPortDescription.swift in Sources */,

--- a/StreamVideoTests/Mock/MockVideoCapturerFactory.swift
+++ b/StreamVideoTests/Mock/MockVideoCapturerFactory.swift
@@ -28,7 +28,8 @@ final class MockVideoCapturerFactory: VideoCapturerProviding, Mockable, @uncheck
     enum MockFunctionInputKey: Payloadable {
         case buildCameraCapturer(
             source: RTCVideoSource,
-            audioDeviceModule: AudioDeviceModule
+            audioDeviceModule: AudioDeviceModule,
+            usesProcessingPipeline: Bool
         )
         case buildScreenCapturer(
             type: ScreensharingType,
@@ -39,8 +40,8 @@ final class MockVideoCapturerFactory: VideoCapturerProviding, Mockable, @uncheck
 
         var payload: Any {
             switch self {
-            case let .buildCameraCapturer(source, audioDeviceModule):
-                return (source, audioDeviceModule)
+            case let .buildCameraCapturer(source, audioDeviceModule, usesProcessingPipeline):
+                return (source, audioDeviceModule, usesProcessingPipeline)
             case let .buildScreenCapturer(type, source, audioDeviceModule, includeAudio):
                 return (type, source, audioDeviceModule, includeAudio)
             }
@@ -56,13 +57,15 @@ final class MockVideoCapturerFactory: VideoCapturerProviding, Mockable, @uncheck
 
     func buildCameraCapturer(
         source: RTCVideoSource,
-        audioDeviceModule: AudioDeviceModule
+        audioDeviceModule: AudioDeviceModule,
+        usesProcessingPipeline: Bool
     ) -> StreamVideoCapturing {
         stubbedFunctionInput[.buildCameraCapturer]?
             .append(
                 .buildCameraCapturer(
                     source: source,
-                    audioDeviceModule: audioDeviceModule
+                    audioDeviceModule: audioDeviceModule,
+                    usesProcessingPipeline: usesProcessingPipeline
                 )
             )
         return stubbedFunction[.buildCameraCapturer] as! StreamVideoCapturing

--- a/StreamVideoTests/WebRTC/VideoCapturing/StreamVideoProcessPipeline_Tests.swift
+++ b/StreamVideoTests/WebRTC/VideoCapturing/StreamVideoProcessPipeline_Tests.swift
@@ -1,0 +1,134 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import CoreVideo
+@testable import StreamVideo
+import StreamWebRTC
+@preconcurrency import XCTest
+
+final class StreamVideoProcessPipeline_Tests: XCTestCase, @unchecked Sendable {
+
+    private var source: MockRTCVideoCapturerDelegate!
+    private var subject: StreamVideoProcessPipeline!
+
+    // MARK: - Lifecycle
+
+    override func tearDown() {
+        subject = nil
+        source = nil
+        super.tearDown()
+    }
+
+    // MARK: - didUpdate(_:)
+
+    func test_didUpdate_forwardsFilterToNodes() {
+        var nodeOneFilter: VideoFilter?
+        var nodeTwoFilter: VideoFilter?
+        let nodes = [
+            TestNode(onUpdate: { nodeOneFilter = $0 }),
+            TestNode(onUpdate: { nodeTwoFilter = $0 })
+        ]
+        source = .init()
+        subject = StreamVideoProcessPipeline(
+            source: source,
+            nodes: nodes
+        )
+        let filter = VideoFilter(
+            id: "filter",
+            name: "Filter",
+            filter: { $0.originalImage }
+        )
+
+        subject.didUpdate(filter)
+
+        XCTAssertTrue(nodeOneFilter === filter)
+        XCTAssertTrue(nodeTwoFilter === filter)
+    }
+
+    // MARK: - capturer(_:didCapture:)
+
+    func test_capturer_nodesEmpty_forwardsOriginalFrame() throws {
+        source = .init()
+        subject = StreamVideoProcessPipeline(
+            source: source,
+            nodes: []
+        )
+        let capturer = RTCVideoCapturer()
+        let frame = try makeFrame(rotation: ._0, timeStampNs: 10)
+
+        subject.capturer(capturer, didCapture: frame)
+
+        XCTAssertTrue(source.didCaptureWasCalledWith?.capturer === capturer)
+        XCTAssertTrue(source.didCaptureWasCalledWith?.frame === frame)
+    }
+
+    func test_capturer_nodesApplySequentialTransforms_forwardsLastFrame() throws {
+        let nodes = [
+            TestNode(
+                onCapture: { frame in
+                    RTCVideoFrame(
+                        buffer: frame.buffer,
+                        rotation: ._90,
+                        timeStampNs: frame.timeStampNs
+                    )
+                }
+            ),
+            TestNode(
+                onCapture: { frame in
+                    RTCVideoFrame(
+                        buffer: frame.buffer,
+                        rotation: ._180,
+                        timeStampNs: frame.timeStampNs
+                    )
+                }
+            )
+        ]
+        source = .init()
+        subject = StreamVideoProcessPipeline(
+            source: source,
+            nodes: nodes
+        )
+        let capturer = RTCVideoCapturer()
+        let frame = try makeFrame(rotation: ._0, timeStampNs: 20)
+
+        subject.capturer(capturer, didCapture: frame)
+
+        XCTAssertTrue(source.didCaptureWasCalledWith?.capturer === capturer)
+        XCTAssertEqual(source.didCaptureWasCalledWith?.frame.rotation, ._180)
+    }
+
+    // MARK: - Private Helpers
+
+    private func makeFrame(
+        rotation: RTCVideoRotation,
+        timeStampNs: Int64
+    ) throws -> RTCVideoFrame {
+        RTCVideoFrame(
+            buffer: RTCCVPixelBuffer(pixelBuffer: try .make()),
+            rotation: rotation,
+            timeStampNs: timeStampNs
+        )
+    }
+}
+
+private final class TestNode: StreamVideoProcessNode {
+    private let onUpdate: (VideoFilter?) -> Void
+    private let onCapture: (RTCVideoFrame) -> RTCVideoFrame
+
+    init(
+        onUpdate: @escaping (VideoFilter?) -> Void = { _ in },
+        onCapture: @escaping (RTCVideoFrame) -> RTCVideoFrame = { $0 }
+    ) {
+        self.onUpdate = onUpdate
+        self.onCapture = onCapture
+    }
+
+    func didUpdate(_ videoFilter: VideoFilter?) {
+        onUpdate(videoFilter)
+    }
+
+    func didCapture(_ frame: RTCVideoFrame) -> RTCVideoFrame {
+        onCapture(frame)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all JIRA tickets and/or GitHub issues related to this PR, if applicable._

### 🎯 Goal

Introduce a capture-time processing pipeline and fix rotation handling so
filtered frames don't get double-rotated and the pipeline can be toggled in
the demo app.

### 📝 Summary

- Add `StreamVideoProcessPipeline` with a filter node and wire it into camera
  capture behind `VideoConfig.usesProcessingPipeline`.
- Add a DemoApp debug toggle and propagate the pipeline flag through router
  and capturer factory wiring.
- Improve simulator screen-capture rotation handling (preferred transform and
  optional composition) and map `RTCVideoRotation` to
  `CGImagePropertyOrientation` for filter input.
- Add unit tests for the processing pipeline and update the mock capturer
  factory inputs.

### 🛠 Implementation

Added a lightweight processing pipeline (`StreamVideoProcessPipeline`) that
chains `StreamVideoProcessNode`s and forwards the final frame to the original
capturer delegate. The default `FilterNode` applies the active `VideoFilter`
in-place using `CIContext`, keyed off
`RTCVideoRotation -> CGImagePropertyOrientation` so filters respect
orientation without extra transforms. `StreamVideoCapturer` now chooses
between the pipeline delegate and the existing capture handler based on
`VideoConfig.usesProcessingPipeline`, and `setVideoFilter` forwards to the
active delegate. `SimulatorScreenCapturer` detects rotation from the track
transform, optionally uses a composition output to bake rotation into pixels,
and caches the resolved rotation based on buffer size to avoid
double-rotation.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

- DemoApp (simulator): Debug Menu -> Feature Flags -> VideoProcessing
  Pipeline on/off, join a call, apply a filter, confirm orientation is
  correct and no double-rotation.
- Simulator screen capture: verify rotation matches the source asset
  orientation.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
