### PR TITLE
[Fix]JoinAndRing flow speaker state

### DIFF
--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -166,7 +166,7 @@ public class CallState: ObservableObject {
     /// help customize logic, analytics, and UI based on how the call was started.
     var joinSource: JoinSource?
 
-    private var localCallSettingsUpdate = false
+//    private var localCallSettingsUpdate = false
     private var durationCancellable: AnyCancellable?
     private nonisolated let disposableBag = DisposableBag()
 
@@ -445,20 +445,31 @@ public class CallState: ObservableObject {
             streamKey: streamVideo.token.rawValue
         )
         ingress = Ingress(rtmp: rtmp)
-        
-        if !localCallSettingsUpdate {
-            // All CallSettings updates go through the update method to ensure
-            // proper propagation.
-            update(callSettings: .init(response.settings))
-        }
+//
+//        if !localCallSettingsUpdate {
+//            // All CallSettings updates go through the update method to ensure
+//            // proper propagation.
+//            update(callSettings: .init(response.settings))
+//        }
     }
     
-    internal func update(callSettings: CallSettings) {
+    internal func update(
+        callSettings: CallSettings,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        log.debug(
+            "CallSettings update request \(self.callSettings) → \(callSettings)",
+            functionName: function,
+            fileName: file,
+            lineNumber: line
+        )
         guard callSettings != self.callSettings else {
             return
         }
         self.callSettings = callSettings
-        localCallSettingsUpdate = true
+//        localCallSettingsUpdate = true
     }
     
     internal func update(statsReport: CallStatsReport?) {

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -761,7 +761,7 @@ class CallController: @unchecked Sendable {
             .stateAdapter
             .$callSettings
             .removeDuplicates()
-            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in self?.call?.state.callSettings = $0 }
+            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in self?.call?.state.update(callSettings: $0) }
             .store(in: disposableBag)
     }
 }

--- a/Sources/StreamVideo/Models/CallSettings.swift
+++ b/Sources/StreamVideo/Models/CallSettings.swift
@@ -94,7 +94,14 @@ public final class CallSettings: ObservableObject, Sendable, Equatable, CustomSt
     }
 
     public var description: String {
-        "<CallSettings audioOn:\(audioOn) videoOn:\(videoOn) speakerOn:\(speakerOn) audioOutputOn:\(audioOutputOn) cameraPosition:\(cameraPosition)/>"
+        var result = "{"
+        result += "audioOn:\(audioOn)"
+        result += ", videoOn:\(videoOn)"
+        result += ", speakerOn:\(speakerOn)"
+        result += ", audioOutputOn:\(audioOutputOn)"
+        result += ", cameraPosition:\(cameraPosition)"
+        result += " }"
+        return result
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -502,7 +502,16 @@ open class CallViewModel: ObservableObject {
                     startsAt: startsAt,
                     team: team
                 )
-                let settings = localCallSettingsChange ? callSettings : nil
+
+                // 1. Fetch the current callSettings (local or the Call's default)
+                // 2. Store the current callSettings so we can apply the correct
+                // speaker state after joining the call.
+                // 3. Disable the speaker. As we override the initial CallSettings
+                // whatever the server sends us will be ignored/overriden.
+                var settings = localCallSettingsChange ? callSettings : call.state.callSettings
+                temporaryCallSettings = call.state.callSettings
+                try? await call.speaker.disableSpeakerPhone()
+                settings = settings.withUpdatedSpeakerState(false)
 
                 call.updateParticipantsSorting(with: participantsSortComparators)
 
@@ -512,9 +521,6 @@ open class CallViewModel: ObservableObject {
                     ring: false,
                     callSettings: settings
                 )
-                
-                temporaryCallSettings = call.state.callSettings
-                try? await call.speaker.disableSpeakerPhone()
 
                 try await call.ring(
                     request: .init(membersIds: members.map(\.id).filter { $0 != self.streamVideo.user.id }, video: video)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1393/video-speaker-value-is-rewritten-when-using-join-and-ring

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
