### PR TITLE
[Fix]Abrupt call endings from audio-session readiness timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Prevent abrupt call endings caused by audio-session readiness timing by
+  hardening WebRTC watchdog behavior and coverage across joining/joined flows.
+  [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
+
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 
 ### 🐞 Fixed
-- Prevent abrupt call endings caused by audio-session readiness timing by
-  hardening WebRTC watchdog behavior and coverage across joining/joined flows.
-  [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
+- Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Components/WebRTCAudioSessionWatchdog.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Components/WebRTCAudioSessionWatchdog.swift
@@ -1,0 +1,57 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// Adapts `RTCAudioStore` state into a single audio-session readiness signal.
+///
+/// Readiness becomes `true` only after:
+/// - the audio session has become active, and
+/// - the current audio route is non-empty.
+final class WebRTCAudioSessionWatchdog {
+    @Injected(\.audioStore) private var audioStore
+
+    /// Current readiness snapshot.
+    var isReady: Bool { subject.value }
+    /// Emits readiness updates and suppresses duplicates.
+    var publisher: AnyPublisher<Bool, Never> { subject.removeDuplicates().eraseToAnyPublisher() }
+
+    private let subject: CurrentValueSubject<Bool, Never> = .init(false)
+    private let disposableBag = DisposableBag()
+
+    init() {
+        let isActivePublisher = audioStore
+            .publisher(\.isActive)
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+
+        let currentRoutePublisher = audioStore
+            .publisher(\.currentRoute)
+            .map { $0 != .empty }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+
+        Publishers
+            .CombineLatest(isActivePublisher, currentRoutePublisher)
+            .map { $0.0 && $0.1 }
+            .sink { [weak self] in self?.subject.send($0) }
+            .store(in: disposableBag)
+    }
+}
+
+extension WebRTCTrace {
+    /// Creates an audio-session readiness trace event.
+    ///
+    /// - Parameters:
+    ///   - source: The readiness adapter providing current readiness state.
+    ///   - timeout: Whether the trace is emitted due to watchdog timeout.
+    init(_ source: WebRTCAudioSessionWatchdog, timeout: Bool = false) {
+        self.init(
+            id: nil,
+            tag: "audio.session.\(source.isReady ? "ready" : timeout ? "timeout" : "preparing")",
+            data: nil
+        )
+    }
+}

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joined.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joined.swift
@@ -139,6 +139,10 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     try Task.checkCancellation()
 
                     observeSFUFullError()
+
+                    try Task.checkCancellation()
+
+                    observeAudioSessionReadiness()
                 } catch {
                     await cleanUpPreviousSessionIfRequired()
                     transitionDisconnectOrError(error)
@@ -557,6 +561,57 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     }
 
                     transitionOrDisconnect(.disconnected(context))
+                }
+                .store(in: disposableBag)
+        }
+
+        /// Starts a joined-stage watchdog for delayed audio-session readiness.
+        ///
+        /// This method runs after the call has already reached `JoinedStage`.
+        /// At this point media and signaling are active, but audio readiness can
+        /// still be pending in edge cases (for example delayed route activation
+        /// after interruptions or CallKit handoff timing).
+        ///
+        /// Behavior:
+        /// - Schedules a one-shot timer using
+        ///   `WebRTCConfiguration.timeout.audioSessionReadinessWatchdog`.
+        /// - If the timer fires first, it:
+        ///   - traces a timeout event (`audio.session.timeout`),
+        ///   - forces reconnection strategy to `.rejoin`,
+        ///   - transitions to `DisconnectedStage` to rebuild media state.
+        /// - In parallel, it listens to `context.audioSessionWatchdog.publisher`
+        ///   and cancels the timer as soon as readiness becomes `true`.
+        ///
+        /// The watchdog signal is effectively one-off/latching for this flow:
+        /// once readiness is observed and timer is cancelled, this stage does not
+        /// re-arm the watchdog again.
+        private func observeAudioSessionReadiness() {
+            let key = "audio-session-readiness"
+            let interval = WebRTCConfiguration.timeout.audioSessionReadinessWatchdog
+
+            DefaultTimer
+                .publish(every: interval)
+                .log(.warning, subsystems: .audioSession) { _ in "AudioSession isn't ready after \(interval) seconds." }
+                .sinkTask(storeIn: disposableBag) { [weak self] _ in
+                    guard let self else { return }
+                    await context.coordinator?.stateAdapter.trace(
+                        .init(
+                            context.audioSessionWatchdog,
+                            timeout: true
+                        )
+                    )
+                    context.reconnectionStrategy = .rejoin
+                    transitionOrDisconnect(.disconnected(context))
+                }
+                .store(in: disposableBag, key: key)
+
+            context
+                .audioSessionWatchdog
+                .publisher
+                .sink { [weak self] isReady in
+                    if isReady {
+                        self?.disposableBag.remove(key)
+                    }
                 }
                 .store(in: disposableBag)
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -390,7 +390,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         /// that the audioSession has been:
                         /// - released from CallKit (if our source was CallKit)
                         /// - activated and configured correctly
-                        try await self?.ensureAudioSessionIsReady()
+                        await self?.ensureAudioSessionIsReady()
 
                         /// Configures all peer connections after the audio session is ready.
                         /// Ensures signaling, media, and routing are correctly established for
@@ -443,35 +443,45 @@ extension WebRTCCoordinator.StateMachine.Stage {
             try Task.checkCancellation()
         }
 
-        /// Waits until the audio session is fully ready for call setup.
+        /// Waits for early audio-session readiness before peer-connection setup.
         ///
-        /// The function waits in parallel for:
-        /// - `audioStore` to report `isActive == true`
-        /// - `audioStore` to report a non-empty `currentRoute`
-        /// within the provided `timeout`.
+        /// This method runs in `JoiningStage` right after audio-session
+        /// configuration and just before `configurePeerConnections()`.
         ///
-        /// - Parameter timeout: Maximum number of seconds to wait for both
-        ///   conditions before failing.
-        /// - Throws: If either readiness condition does not arrive before
-        ///   `timeout`.
-        private func ensureAudioSessionIsReady() async throws {
-            try await withThrowingTaskGroup(of: Void.self) { [audioStore] group in
-                group.addTask {
-                    _ = try await audioStore
-                        .publisher(\.isActive)
-                        .filter { $0 }
-                        .nextValue(timeout: WebRTCConfiguration.timeout.audioSessionConfigurationCompletion)
-                }
-
-                group.addTask {
-                    _ = try await audioStore
-                        .publisher(\.currentRoute)
-                        .filter { $0 != .empty }
-                        .nextValue(timeout: WebRTCConfiguration.timeout.audioSessionConfigurationCompletion)
-                }
-
-                try await group.waitForAll()
+        /// Why this exists:
+        /// - The join flow can race with audio-session activation/route
+        ///   propagation (especially when control is handed back from CallKit).
+        /// - Creating peer connections before audio is active and routed can
+        ///   increase the chance of stale/no-audio media setup.
+        ///
+        /// How it behaves:
+        /// - It waits for `context.audioSessionWatchdog.publisher` to emit
+        ///   `true` (audio session active and route non-empty).
+        /// - The wait is bounded by `timeout`; on timeout it logs a warning and
+        ///   intentionally continues the join flow.
+        /// - It always emits a trace with the watchdog's current readiness
+        ///   snapshot so diagnostics can distinguish "ready" vs "still
+        ///   preparing" join paths.
+        ///
+        /// This method is intentionally best-effort: we prefer joining with a
+        /// degraded readiness signal over blocking join completion indefinitely.
+        ///
+        /// - Parameter timeout: Maximum seconds to wait for the watchdog to
+        ///   report readiness before continuing.
+        private func ensureAudioSessionIsReady(
+            timeout: TimeInterval = WebRTCConfiguration.timeout.audioSessionConfigurationCompletion
+        ) async {
+            do {
+                _ = try await context
+                    .audioSessionWatchdog
+                    .publisher
+                    .filter { $0 }
+                    .nextValue(timeout: timeout)
+            } catch {
+                log.warning("AudioSession isn't ready after \(timeout) seconds. Will continue with the join flow.")
             }
+
+            await context.coordinator?.stateAdapter.trace(.init(context.audioSessionWatchdog))
         }
 
         /// Configures the adapter responsible for updating track subscriptions.

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -32,6 +32,8 @@ extension WebRTCCoordinator.StateMachine {
             /// migration immediately when the current SFU has no capacity.
             var sfuFullObserver: WebRTCSFUFullObserver?
 
+            var audioSessionWatchdog: WebRTCAudioSessionWatchdog = .init()
+
             var isRejoiningFromSessionID: String?
             var migratingFromSFU: String = ""
             /// Tracks all SFUs rejected during migration attempts so retries can

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCConfiguration.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCConfiguration.swift
@@ -7,13 +7,23 @@ import Foundation
 /// Configuration for WebRTC Stack.
 enum WebRTCConfiguration {
 
+    /// Timeout values used by WebRTC join/reconnect flows.
     struct Timeout {
+        /// Maximum time to wait for authentication response.
         var authenticate: TimeInterval
+        /// Maximum time to wait for initial WebSocket connection.
         var connect: TimeInterval
+        /// Maximum time to wait for SFU join response.
         var join: TimeInterval
+        /// Maximum time to wait for migration completion event.
         var migrationCompletion: TimeInterval
+        /// Maximum time to wait for publisher setup before negotiation.
         var publisherSetUpBeforeNegotiation: TimeInterval
+        /// Maximum time the join flow waits for audio-session setup to complete.
         var audioSessionConfigurationCompletion: TimeInterval
+        /// Maximum time to wait in joined state before forcing a rejoin when
+        /// the audio session never becomes fully ready.
+        var audioSessionReadinessWatchdog: TimeInterval
         /// Maximum time to wait for both peer connections to reach
         /// `.connected` after the SFU join flow succeeds.
         var peerConnectionReadiness: TimeInterval
@@ -26,6 +36,7 @@ enum WebRTCConfiguration {
             migrationCompletion: 10,
             publisherSetUpBeforeNegotiation: 2,
             audioSessionConfigurationCompletion: 2,
+            audioSessionReadinessWatchdog: 15,
             peerConnectionReadiness: 5
         )
 
@@ -38,6 +49,7 @@ enum WebRTCConfiguration {
             migrationCompletion: 5,
             publisherSetUpBeforeNegotiation: 5,
             audioSessionConfigurationCompletion: 5,
+            audioSessionReadinessWatchdog: 5,
             peerConnectionReadiness: 5
         )
         #endif

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCConfiguration.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCConfiguration.swift
@@ -36,7 +36,7 @@ enum WebRTCConfiguration {
             migrationCompletion: 10,
             publisherSetUpBeforeNegotiation: 2,
             audioSessionConfigurationCompletion: 2,
-            audioSessionReadinessWatchdog: 15,
+            audioSessionReadinessWatchdog: 10,
             peerConnectionReadiness: 5
         )
 

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Components/WebRTCAudioSessionWatchdog.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Components/WebRTCAudioSessionWatchdog.swift
@@ -1,0 +1,89 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class WebRTCAudioSessionWatchdog_Tests: XCTestCase, @unchecked Sendable {
+
+    private var mockAudioStore: MockRTCAudioStore!
+    private var disposableBag: DisposableBag! = .init()
+    private lazy var subject: WebRTCAudioSessionWatchdog! = .init()
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        super.setUp()
+        mockAudioStore = .init()
+        mockAudioStore.makeShared()
+    }
+
+    override func tearDown() {
+        disposableBag.removeAll()
+        mockAudioStore.dismantle()
+        subject = nil
+        mockAudioStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - tests
+
+    func test_init_isReadyIsFalse() async {
+        await fulfillment { self.subject.isReady == false }
+    }
+
+    func test_publisher_whenAudioSessionBecomesReady_emitsTrue() async {
+        let expectation = expectation(description: "Readiness emits true.")
+        var latestValue = false
+
+        subject
+            .publisher
+            .sink { value in
+                latestValue = value
+                if value {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: disposableBag)
+
+        mockAudioStore.audioStore.dispatch(.setActive(true))
+        mockAudioStore.audioStore.dispatch(
+            .setCurrentRoute(.dummy(inputs: [.dummy()]))
+        )
+
+        await fulfillment(of: [expectation], timeout: defaultTimeout)
+        XCTAssertTrue(latestValue)
+        XCTAssertTrue(subject.isReady)
+    }
+
+    func test_publisher_whenReadyStateRepeated_emitsTrueOnlyOnce() async {
+        let expectation = expectation(description: "Readiness emits first true.")
+        var trueEventsCount = 0
+        let route = RTCAudioStore.StoreState.AudioRoute.dummy(inputs: [.dummy()])
+
+        subject
+            .publisher
+            .sink { value in
+                guard value else { return }
+                trueEventsCount += 1
+                if trueEventsCount == 1 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: disposableBag)
+
+        mockAudioStore.audioStore.dispatch(.setActive(true))
+        mockAudioStore.audioStore.dispatch(.setCurrentRoute(route))
+
+        await fulfillment(of: [expectation], timeout: defaultTimeout)
+
+        mockAudioStore.audioStore.dispatch(.setActive(true))
+        mockAudioStore.audioStore.dispatch(.setCurrentRoute(route))
+        await wait(for: 0.2)
+
+        XCTAssertEqual(trueEventsCount, 1)
+    }
+}

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoinedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoinedStageTests.swift
@@ -672,6 +672,58 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
         }
     }
 
+    // MARK: - observeAudioSessionReadiness
+
+    func test_transition_audioSessionNeverBecomesReadyBeforeWatchdog_transitionsToDisconnected() async {
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        let previousTimeout = WebRTCConfiguration.timeout
+        let mockAudioStore = MockRTCAudioStore()
+        mockAudioStore.makeShared()
+        defer {
+            WebRTCConfiguration.timeout = previousTimeout
+            mockAudioStore.dismantle()
+        }
+        WebRTCConfiguration.timeout.audioSessionReadinessWatchdog = 0.2
+        subject.context.audioSessionWatchdog = .init()
+
+        await assertTransitionAfterTrigger(
+            expectedTarget: .disconnected,
+            trigger: {}
+        ) { stage in
+            XCTAssertEqual(stage.context.reconnectionStrategy, .rejoin)
+        }
+    }
+
+    func test_transition_audioSessionBecomesReadyBeforeWatchdog_remainsOnJoined() async {
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        let previousTimeout = WebRTCConfiguration.timeout
+        let mockAudioStore = MockRTCAudioStore()
+        mockAudioStore.makeShared()
+        defer {
+            WebRTCConfiguration.timeout = previousTimeout
+            mockAudioStore.dismantle()
+        }
+        WebRTCConfiguration.timeout.audioSessionReadinessWatchdog = 1
+        subject.context.audioSessionWatchdog = .init()
+
+        let transitionExpectation = expectation(
+            description: "No transition should be triggered while joined."
+        )
+        transitionExpectation.isInverted = true
+        transitionExpectation.assertForOverFulfill = false
+
+        subject.transition = { _ in transitionExpectation.fulfill() }
+        _ = subject.transition(from: .joining(subject.context))
+
+        mockAudioStore.audioStore.dispatch(.setActive(true))
+        mockAudioStore.audioStore.dispatch(
+            .setCurrentRoute(.dummy(inputs: [.dummy()]))
+        )
+
+        await fulfillment(of: [transitionExpectation], timeout: 1.5)
+        XCTAssertEqual(subject.id, .joined)
+    }
+
     // MARK: observePreferredReconnectionStrategy
 
     func test_transition_sfuErrorWithReconnectionStrategyFastReceived_updatesContext() async {
@@ -943,6 +995,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
             )
             transitionExpectation.isInverted = true
         }
+        transitionExpectation.assertForOverFulfill = false
 
         subject.transition = { target in
             Task {

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -519,6 +519,37 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         eventCancellable.cancel()
     }
 
+    func test_transition_fromConnected_withShortAudioSessionReadinessTimeout_transitionsToJoined() async throws {
+        let previousTimeout = WebRTCConfiguration.timeout
+        let mockAudioStore = MockRTCAudioStore()
+        mockAudioStore.makeShared()
+        defer {
+            WebRTCConfiguration.timeout = previousTimeout
+            mockAudioStore.dismantle()
+        }
+        WebRTCConfiguration.timeout.audioSessionConfigurationCompletion = 0.1
+
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        subject.context.reconnectAttempts = 11
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
+        mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
+        let cancellable = receiveEvent(
+            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            every: 0.3
+        )
+
+        try await assertTransition(
+            from: .connected,
+            expectedTarget: .joined,
+            subject: subject
+        ) { _ in }
+
+        cancellable.cancel()
+    }
+
     // MARK: - transition from connected with isRejoiningFromSessionID != nil
 
     func test_transition_fromConnectedWithRejoinWithoutCoordinator_transitionsToDisconnected() async throws {

--- a/StreamVideoTests/WebRTC/v2/UpdateSubscriptions/WebRTCUpdateSubscriptionsAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/UpdateSubscriptions/WebRTCUpdateSubscriptionsAdapter_Tests.swift
@@ -78,7 +78,7 @@ final class WebRTCUpdateSubscriptionsAdapter_Tests: XCTestCase, @unchecked Senda
         await fulfillment { self.mockSFUStack.service.timesCalled(.updateSubscriptions) == 2 }
     }
 
-    func test_startObservation_whenTracksDontChange_doesNotSendRequest() async throws {
+    func test_startObservation_whenTracksDoNotChange_doesNotSendRequest() async throws {
         participantsSubject.send([
             "1": .dummy(id: "1", hasVideo: true),
             "2": .dummy(id: "2", hasVideo: true),


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1557)

### 🎯 Goal

Fix a bug where calls could end abruptly due to audio-session readiness timing races during the WebRTC join/joined lifecycle, while improving diagnostics and coverage around that behavior.

### 📝 Summary

- Fixed audio-session readiness watchdog behavior to avoid unintended disconnect/rejoin transitions that could abruptly end calls.
- Improved readiness timeout semantics across `JoiningStage` and `JoinedStage`.
- Expanded DocC documentation for:
  - `ensureAudioSessionIsReady(...)`
  - `observeAudioSessionReadiness()`
  with explicit lifecycle and timeout context.
- Added/updated tests for:
  - watchdog readiness signal behavior,
  - joined-stage watchdog timeout/cancel behavior,
  - joining-stage short readiness-timeout behavior.

### 🛠 Implementation

- `JoiningStage` now treats audio-session readiness as a best-effort gate:
  - waits for active + routed audio state,
  - continues safely if readiness signal times out,
  - emits trace snapshots for observability.
- `JoinedStage` watchdog logic is clarified and hardened:
  - arms a bounded readiness timer,
  - cancels on readiness signal,
  - only triggers rejoin/disconnect path on actual watchdog timeout.
- Added focused tests to validate watchdog behavior directly and at stage level so regressions are caught early.

### 🧪 Manual Testing Notes

- Receive a ringing call
- After accepting and while the call is joining trigger multiple audio output changes (i was able to achieve that by placing an airpod on a desk and covering/uncovering it continuously).
- The call should connect as expected without abrupt ending

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented abrupt call endings caused by audio-session readiness timing, improving call stability.

* **New Features**
  * Added an audio-session readiness watchdog with tracing; joining now waits briefly for readiness but proceeds on timeout.
  * Joined sessions will rejoin/disconnect if readiness isn't reached within the configured interval to improve recovery.

* **Tests**
  * Added and updated tests covering the watchdog, readiness timing, and stage transition behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->