### PR TITLE
[Enhancement]Add leave reason parity across Call APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+- Added optional leave reasons to `Call.leave` and `CallViewModel.hangUp`, and propagated them through the WebRTC leave flow so SFU leave requests include explicit end-of-call context. [#1100](https://github.com/GetStream/stream-video-swift/pull/1100)
+
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_
 

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -614,9 +614,13 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     ///
     /// The cleanup sequence clears active/ringing call references from
     /// `StreamVideo` state before emitting `CallNotification.callEnded`.
-    public func leave() {
+    ///
+    /// - Parameter reason: Optional reason forwarded to the SFU leave request.
+    ///   Pass a custom value when you want the backend to distinguish between
+    ///   different leave flows (for example, user action vs timeout).
+    public func leave(reason: String? = nil) {
         disposableBag.removeAll()
-        callController.leave()
+        callController.leave(reason: reason)
         closedCaptionsAdapter.stop()
         stateMachine.transition(.idle(.init(call: self)))
         /// Upon `Call.leave` we remove the call from the cache. Any further actions that are required

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -433,10 +433,10 @@ class CallController: @unchecked Sendable {
         try await webRTCCoordinator.zoom(by: factor)
     }
 
-    func leave() {
+    func leave(reason: String?) {
         guard call != nil else { return }
         call = nil
-        webRTCCoordinator.leave()
+        webRTCCoordinator.leave(reason: reason)
     }
 
     /// Cleans up the call controller.

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
@@ -169,10 +169,10 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         context.flowError = nil
                         try transition?(.error(context, error: error))
                     } else {
-                        try transition?(.leaving(context))
+                        try transition?(.leaving(context, reason: "error"))
                     }
                 case .disconnected:
-                    try transition?(.leaving(context))
+                    try transition?(.leaving(context, reason: "disconnected"))
                 }
             } catch let (blockError) {
                 if context.reconnectionStrategy == .disconnected {

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joined.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joined.swift
@@ -254,9 +254,9 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 .publisher(eventType: Stream_Video_Sfu_Event_CallEnded.self)
                 .log(.debug, subsystems: .sfu) { "Call ended with reason: \($0.reason)." }
                 .receive(on: processingQueue)
-                .sink { [weak self] _ in
+                .sink { [weak self] in
                     guard let self else { return }
-                    transitionOrError(.leaving(context))
+                    transitionOrError(.leaving(context, reason: "\($0.reason)"))
                 }
                 .store(in: disposableBag)
         }
@@ -311,7 +311,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 .receive(on: processingQueue)
                 .sink { [weak self] _ in
                     guard let self else { return }
-                    transitionOrError(.leaving(context))
+                    transitionOrError(.leaving(context, reason: "error"))
                 }
                 .store(in: disposableBag)
         }

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Leaving.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Leaving.swift
@@ -12,10 +12,12 @@ extension WebRTCCoordinator.StateMachine.Stage {
     /// - Returns: A `LeavingStage` instance representing the leaving state of
     ///   the WebRTC coordinator.
     static func leaving(
-        _ context: Context
+        _ context: Context,
+        reason: String?
     ) -> WebRTCCoordinator.StateMachine.Stage {
         LeavingStage(
-            context
+            context,
+            reason: reason
         )
     }
 }
@@ -26,13 +28,16 @@ extension WebRTCCoordinator.StateMachine.Stage {
     final class LeavingStage:
         WebRTCCoordinator.StateMachine.Stage,
         @unchecked Sendable {
+        private let reason: String?
         private let disposableBag = DisposableBag()
 
         /// Initializes a new instance of `LeavingStage`.
         /// - Parameter context: The context for the leaving stage.
         init(
-            _ context: Context
+            _ context: Context,
+            reason: String?
         ) {
+            self.reason = reason
             super.init(id: .leaving, context: context)
         }
 
@@ -70,6 +75,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     if let sfuAdapter = await coordinator.stateAdapter.sfuAdapter {
                         if case .connected = sfuAdapter.connectionState {
                             await sfuAdapter.sendLeaveRequest(
+                                reason: reason ?? "",
                                 for: coordinator.stateAdapter.sessionID
                             )
                         }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -134,9 +134,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
     }
 
     /// Leaves the call and transitions the state machine to the `leaving` stage.
-    func leave() {
+    func leave(reason: String?) {
         stateMachine.transition(
-            .leaving(stateMachine.currentStage.context)
+            .leaving(stateMachine.currentStage.context, reason: reason)
         )
     }
 

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -720,8 +720,11 @@ open class CallViewModel: ObservableObject {
     }
 
     /// Hangs up from the active call.
-    public func hangUp() {
-        handleCallHangUp(ringTimeout: false)
+    ///
+    /// - Parameter reason: Optional reason forwarded to ``Call/leave(reason:)``
+    ///   so the SFU receives context about why the call ended.
+    public func hangUp(reason: String? = nil) {
+        handleCallHangUp(ringTimeout: false, reason: reason)
     }
 
     /// Sets a video filter for the current call.
@@ -817,7 +820,7 @@ open class CallViewModel: ObservableObject {
     }
 
     /// Leaves the current call.
-    private func leaveCall() {
+    private func leaveCall(reason: String?) {
         log.debug("Leaving call")
         enteringCallTask?.cancel()
         enteringCallTask = nil
@@ -835,7 +838,7 @@ open class CallViewModel: ObservableObject {
         skipCallStateUpdates = false
         temporaryCallSettings = nil
         lastScreenSharingParticipant = nil
-        call?.leave()
+        call?.leave(reason: reason)
 
         pictureInPictureAdapter.call = nil
         pictureInPictureAdapter.sourceView = nil
@@ -949,7 +952,10 @@ open class CallViewModel: ObservableObject {
             }
     }
 
-    private func handleCallHangUp(ringTimeout: Bool = false) {
+    private func handleCallHangUp(
+        ringTimeout: Bool = false,
+        reason: String? = nil
+    ) {
         if skipCallStateUpdates {
             skipCallStateUpdates = false
         }
@@ -957,7 +963,7 @@ open class CallViewModel: ObservableObject {
             let call,
             callingState == .outgoing
         else {
-            leaveCall()
+            leaveCall(reason: reason)
             return
         }
 
@@ -980,7 +986,7 @@ open class CallViewModel: ObservableObject {
                 log.error(error)
             }
 
-            leaveCall()
+            leaveCall(reason: reason)
         }
     }
 
@@ -1016,7 +1022,7 @@ open class CallViewModel: ObservableObject {
                         if
                             callEventInfo.user?.id == streamVideo.user.id,
                             callEventInfo.callCid == call?.cId {
-                            leaveCall()
+                            leaveCall(reason: "blocked")
                         }
                     case .userUnblocked:
                         break
@@ -1119,7 +1125,7 @@ open class CallViewModel: ObservableObject {
                     _ = try? await outgoingCall.reject(
                         reason: "Call rejected by all \(outgoingMembersCount) outgoing call members."
                     )
-                    self?.leaveCall()
+                    self?.leaveCall(reason: "unanswered")
                 }
             }
         default:
@@ -1153,7 +1159,7 @@ open class CallViewModel: ObservableObject {
 
         default:
             if call?.cId == event.callCid {
-                leaveCall()
+                leaveCall(reason: "ended")
             }
         }
     }
@@ -1186,7 +1192,7 @@ open class CallViewModel: ObservableObject {
     }
 
     private func participantAutoLeavePolicyTriggered() {
-        leaveCall()
+        leaveCall(reason: "auto-leave")
     }
 
     private func subscribeToApplicationLifecycleEvents() {

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -444,6 +444,29 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         await assertCallingState(.idle)
     }
 
+    func test_outgoingCall_hangUpWithReason_forwardsReasonToCallLeave() async throws {
+        // Given
+        await prepare()
+        subject.startCall(
+            callType: .default,
+            callId: callId,
+            members: participants,
+            ring: true
+        )
+        await assertCallingState(.outgoing)
+        let expectedReason = "user-ended"
+
+        // When
+        subject.hangUp(reason: expectedReason)
+
+        // Then
+        await assertCallingState(.idle)
+        XCTAssertEqual(
+            mockCall.recordedInputPayload(String.self, for: .leave)?.first,
+            expectedReason
+        )
+    }
+
     func test_outgoingCall_ringTimeout() async throws {
         // Given
         let ringTimeoutSeconds = 3

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -666,6 +666,25 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - leave
+
+    func test_leave_withReason_reasonWasPassedToCallController() {
+        let mockCallController = MockCallController()
+        let call = MockCall(.dummy(callController: mockCallController))
+        call.stub(for: \.state, with: .init(.dummy()))
+        let expectedReason = "manual-hangup"
+
+        call.leave(reason: expectedReason)
+
+        XCTAssertEqual(
+            mockCallController.recordedInputPayload(
+                String.self,
+                for: .leave
+            )?.first,
+            expectedReason
+        )
+    }
+
     // MARK: - updateParticipantsSorting
 
     func test_call_customSorting() async throws {

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -473,6 +473,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             XCTFail()
         case .reject:
             XCTFail()
+        case .leave:
+            XCTFail()
         case .ring:
             XCTFail()
         case .setVideoFilter(videoFilter: let videoFilter):
@@ -533,6 +535,8 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         case .callKitActivated:
             XCTFail()
         case .reject:
+            XCTFail()
+        case .leave:
             XCTFail()
         case .ring:
             XCTFail()

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -17,6 +17,7 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
         case accept
         case reject
         case join
+        case leave
         case updateTrackSize
         case callKitActivated
         case ring
@@ -39,6 +40,8 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
         case reject(reason: String?)
 
+        case leave(reason: String?)
+
         case ring(request: RingCallRequest)
 
         case setVideoFilter(videoFilter: VideoFilter?)
@@ -55,6 +58,9 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
                 return audioSession
 
             case let .reject(reason):
+                return reason ?? ""
+
+            case let .leave(reason):
                 return reason ?? ""
 
             case let .ring(request):
@@ -191,6 +197,11 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
                 policy: policy
             )
         }
+    }
+
+    override func leave(reason: String? = nil) {
+        stubbedFunctionInput[.leave]?.append(.leave(reason: reason))
+        super.leave(reason: reason)
     }
 
     override func updateTrackSize(

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -9,6 +9,7 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
 
     enum MockFunctionKey: Hashable, CaseIterable {
         case join
+        case leave
         case setDisconnectionTimeout
         case observeWebRTCStateUpdated
         case changeAudioState
@@ -31,6 +32,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
             source: JoinSource,
             policy: WebRTCJoinPolicy
         )
+
+        case leave(reason: String?)
 
         case observeWebRTCStateUpdated
 
@@ -60,6 +63,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 policy
             ):
                 return (create, callSettings, options, ring, notify, source, policy)
+            case let .leave(reason):
+                return reason ?? ""
             case .observeWebRTCStateUpdated:
                 return ()
             case let .changeAudioState(value):
@@ -150,6 +155,11 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
     override func setDisconnectionTimeout(_ timeout: TimeInterval) {
         stubbedFunctionInput[.setDisconnectionTimeout]?
             .append(.setDisconnectionTimeout(timeout: timeout))
+    }
+
+    override func leave(reason: String?) {
+        stubbedFunctionInput[.leave]?
+            .append(.leave(reason: reason))
     }
 
     override func observeWebRTCStateUpdated() {

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_LeavingStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_LeavingStageTests.swift
@@ -24,7 +24,7 @@ final class WebRTCCoordinatorStateMachine_LeavingStageTests: XCTestCase, @unchec
         .joining,
         .peerConnectionPreparing
     ]
-    private lazy var subject: WebRTCCoordinator.StateMachine.Stage! = .leaving(.init())
+    private lazy var subject: WebRTCCoordinator.StateMachine.Stage! = .leaving(.init(), reason: nil)
     private lazy var mockCoordinatorStack: MockWebRTCCoordinatorStack! = .init(
         videoConfig: Self.videoConfig
     )
@@ -121,9 +121,61 @@ final class WebRTCCoordinatorStateMachine_LeavingStageTests: XCTestCase, @unchec
                 .recordedInputPayload(
                     Stream_Video_Sfu_Event_SfuRequest.self,
                     for: .sendMessage
-                )?.first?.leaveCallRequest.sessionID, sessionId
+                )?.first?.leaveCallRequest.sessionID,
+            sessionId
+        )
+        XCTAssertEqual(
+            webSocket
+                .mockEngine
+                .recordedInputPayload(
+                    Stream_Video_Sfu_Event_SfuRequest.self,
+                    for: .sendMessage
+                )?.first?.leaveCallRequest.reason,
+            ""
         )
         XCTAssertEqual(webSocket.timesCalled(.disconnectAsync), 1)
+    }
+
+    func test_transition_withReason_sendsLeaveRequestWithReason() async throws {
+        let reason = "ended-by-host"
+        let subject: WebRTCCoordinator.StateMachine.Stage = .leaving(.init(), reason: reason)
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        let sessionId = try await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .$sessionID
+            .filter { !$0.isEmpty }
+            .nextValue()
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
+        mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+
+        _ = subject.transition(from: .joined(subject.context))
+        await wait(for: 1)
+
+        let webSocket = mockCoordinatorStack.sfuStack.webSocket
+        XCTAssertEqual(
+            webSocket
+                .mockEngine
+                .recordedInputPayload(
+                    Stream_Video_Sfu_Event_SfuRequest.self,
+                    for: .sendMessage
+                )?.first?.leaveCallRequest.sessionID,
+            sessionId
+        )
+        XCTAssertEqual(
+            webSocket
+                .mockEngine
+                .recordedInputPayload(
+                    Stream_Video_Sfu_Event_SfuRequest.self,
+                    for: .sendMessage
+                )?.first?.leaveCallRequest.reason,
+            reason
+        )
     }
 
     // MARK: - Private helpers

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -186,7 +186,7 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
             }
         ) { _ in
             await self.assertTransitionToStage(.leaving) {
-                self.subject.leave()
+                self.subject.leave(reason: nil)
             } handler: { _ in }
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1575/feature-paritycustom-reason-parameter-missing-for-callleave

### 🎯 Goal

Ensure call leave reasons can be passed consistently from public SDK and SwiftUI APIs down to the SFU leave request, so backend analytics and call-end semantics have the correct context.

### 📝 Summary

- Added an optional `reason` parameter to public leave/hang-up flows and propagated it through `Call`, `CallController`, `WebRTCCoordinator`, and leaving stage transitions.
- Updated joined/disconnected state-machine transitions to provide explicit leave reasons for disconnect/error/call-ended paths.
- Added DocC updates for the new public API parameters in `Call` and `CallViewModel`.
- Added/updated tests and mocks to validate reason forwarding from `CallViewModel.hangUp(reason:)` and `Call.leave(reason:)` through SFU leave requests.

### 🛠 Implementation

This change threads an optional leave reason through the full leave pipeline:
`CallViewModel.hangUp(reason:)` -> `Call.leave(reason:)` -> `CallController.leave(reason:)` -> `WebRTCCoordinator.leave(reason:)` -> `LeavingStage` -> `sendLeaveRequest(reason:for:)`.

State-machine-triggered leave transitions now include explicit reasons where applicable:
- disconnected flow -> `"disconnected"`
- error flow -> `"error"`
- call ended event -> server-provided reason string

Tests were updated to keep strong coverage:
- Added leave-reason assertions in `Call_Tests` and `CallViewModel_Tests`
- Extended leaving-stage tests to verify default (`""`) and explicit reason forwarding
- Updated mocks and exhaustive test switches for new mock input case

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)