### PR TITLE
[Fix]Hang up while joining to cancel the pending call flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
+- Prevent hanging up while a call is still joining from briefly showing the in-call UI after the join finishes in the background. [#1101](https://github.com/GetStream/stream-video-swift/pull/1101)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+ConcurrentChildrenTask.swift
+++ b/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+ConcurrentChildrenTask.swift
@@ -1,0 +1,77 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Runs two child tasks concurrently and returns their results in the same
+/// order as the provided operations.
+///
+/// This helper differs from `async let` in an important way: child task
+/// cancellation and completion are managed through an explicit task-group
+/// object instead of compiler-generated lexical cleanup.
+///
+/// Why that matters:
+/// - `async let` is ideal for short, local fan-out where the parent task is
+///   guaranteed to await all children before the scope exits.
+/// - When the parent task is stored and can be cancelled from the outside
+///   during teardown, a task group gives us an explicit `cancelAll()` and a
+///   clear place to drain child completion via `group.next()`.
+///
+/// Prefer this helper over `async let` when:
+/// - The parent task can be cancelled externally while object teardown is in
+///   progress.
+/// - You want explicit control over sibling-task cancellation and completion.
+///
+/// Prefer `async let` when:
+/// - The work is simple, local, and lexically scoped.
+/// - The parent naturally awaits every child before leaving the scope.
+/// - The extra task-group ceremony would add more complexity than value.
+func withConcurrentChildrenTask<First: Sendable, Second: Sendable>(
+    _ first: @Sendable @escaping () async throws -> First,
+    _ second: @Sendable @escaping () async throws -> Second
+) async throws -> (First, Second) {
+    try await withThrowingTaskGroup(
+        of: ConcurrentChildrenTaskResult<First, Second>.self,
+        returning: (First, Second).self
+    ) { group in
+        defer { group.cancelAll() }
+
+        group.addTask {
+            try Task.checkCancellation()
+            let value = try await first()
+            try Task.checkCancellation()
+            return .first(value)
+        }
+
+        group.addTask {
+            try Task.checkCancellation()
+            let value = try await second()
+            try Task.checkCancellation()
+            return .second(value)
+        }
+
+        var firstResult: First?
+        var secondResult: Second?
+
+        while let result = try await group.next() {
+            switch result {
+            case let .first(value):
+                firstResult = value
+            case let .second(value):
+                secondResult = value
+            }
+        }
+
+        guard let firstResult, let secondResult else {
+            throw ClientError("Concurrent child tasks did not complete.")
+        }
+
+        return (firstResult, secondResult)
+    }
+}
+
+private enum ConcurrentChildrenTaskResult<First: Sendable, Second: Sendable>: Sendable {
+    case first(First)
+    case second(Second)
+}

--- a/Sources/StreamVideo/WebRTC/Statistics/Statistics+Convenience.swift
+++ b/Sources/StreamVideo/WebRTC/Statistics/Statistics+Convenience.swift
@@ -51,7 +51,7 @@ struct StreamRTCStatistics {
 }
 
 /// A wrapper around RTCStatisticsReport that can be used to easily access its properties.
-struct StreamRTCStatisticsReport {
+struct StreamRTCStatisticsReport: @unchecked Sendable {
     var statistics: [StreamRTCStatistics]
     var timestamp: TimeInterval
     var source: RTCStatisticsReport?

--- a/Sources/StreamVideo/WebRTC/Statistics/Statistics+Convenience.swift
+++ b/Sources/StreamVideo/WebRTC/Statistics/Statistics+Convenience.swift
@@ -52,9 +52,9 @@ struct StreamRTCStatistics {
 
 /// A wrapper around RTCStatisticsReport that can be used to easily access its properties.
 struct StreamRTCStatisticsReport: @unchecked Sendable {
-    var statistics: [StreamRTCStatistics]
-    var timestamp: TimeInterval
-    var source: RTCStatisticsReport?
+    let statistics: [StreamRTCStatistics]
+    let timestamp: TimeInterval
+    let source: RTCStatisticsReport?
 
     init(_ source: RTCStatisticsReport?) {
         self.init(

--- a/Sources/StreamVideo/WebRTC/v2/Stats/Collector/WebRTCStatsCollector.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Stats/Collector/WebRTCStatsCollector.swift
@@ -104,15 +104,19 @@ final class WebRTCStatsCollector: WebRTCStatsCollecting, @unchecked Sendable {
             }
 
             do {
-                async let statsPublisher = publisher?.statsReport() ?? .init(nil)
-                async let statsSubscriber = subscriber?.statsReport() ?? .init(nil)
-
                 try Task.checkCancellation()
-                let result: [StreamRTCStatisticsReport] = try await [statsPublisher, statsSubscriber]
+                let (publisherReport, subscriberReport) = try await withConcurrentChildrenTask(
+                    { [publisher] in
+                        try await publisher?.statsReport() ?? .init(nil)
+                    },
+                    { [subscriber] in
+                        try await subscriber?.statsReport() ?? .init(nil)
+                    }
+                )
 
                 let report = callStatisticsReporter.buildReport(
-                    publisherReport: result.first ?? .init(nil),
-                    subscriberReport: result.last ?? .init(nil),
+                    publisherReport: publisherReport,
+                    subscriberReport: subscriberReport,
                     datacenter: hostname,
                     trackToKindMap: trackStorage.snapshot
                 )

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -212,6 +212,7 @@ open class CallViewModel: ObservableObject {
 
     private var lastLayoutChange = Date()
     private var enteringCallTask: Task<Void, Never>?
+    private var pendingCall: Call?
     private var participantsSortComparators = defaultSortPreset
     private let callEventsHandler = CallEventsHandler()
     private let disposableBag = DisposableBag()
@@ -822,6 +823,7 @@ open class CallViewModel: ObservableObject {
     /// Leaves the current call.
     private func leaveCall(reason: String?) {
         log.debug("Leaving call")
+        let callToLeave = pendingCall ?? call
         enteringCallTask?.cancel()
         enteringCallTask = nil
         participantUpdates?.cancel()
@@ -838,7 +840,8 @@ open class CallViewModel: ObservableObject {
         skipCallStateUpdates = false
         temporaryCallSettings = nil
         lastScreenSharingParticipant = nil
-        call?.leave(reason: reason)
+        callToLeave?.leave(reason: reason)
+        pendingCall = nil
 
         pictureInPictureAdapter.call = nil
         pictureInPictureAdapter.sourceView = nil
@@ -875,15 +878,16 @@ open class CallViewModel: ObservableObject {
         if enteringCallTask != nil || callingState == .inCall {
             return
         }
+        let resolvedCall = call ?? streamVideo.call(
+            callType: callType,
+            callId: callId,
+            callSettings: callSettings
+        )
+        pendingCall = resolvedCall
         enteringCallTask = Task(disposableBag: disposableBag, priority: .userInitiated) { [weak self] in
             guard let self else { return }
             do {
                 log.debug("Starting call")
-                let call = call ?? streamVideo.call(
-                    callType: callType,
-                    callId: callId,
-                    callSettings: callSettings
-                )
                 var settingsRequest: CallSettingsRequest?
                 var limits: LimitsSettingsRequest?
                 if maxDuration != nil || maxParticipants != nil {
@@ -899,30 +903,38 @@ open class CallViewModel: ObservableObject {
                 )
                 let settings = localCallSettingsChange ? callSettings : nil
 
-                call.updateParticipantsSorting(with: participantsSortComparators)
+                resolvedCall.updateParticipantsSorting(with: participantsSortComparators)
 
-                try await call.join(
+                try await resolvedCall.join(
                     create: true,
                     options: options,
                     ring: ring,
                     callSettings: settings,
                     policy: policy
                 )
-                save(call: call)
+                try Task.checkCancellation()
+                save(call: resolvedCall)
                 enteringCallTask = nil
                 hasAcceptedCall = false
             } catch {
                 hasAcceptedCall = false
+                if error is CancellationError {
+                    enteringCallTask = nil
+                    pendingCall = nil
+                    return
+                }
                 log.error("Error starting a call", error: error)
                 self.error = error
                 setCallingState(.idle)
                 audioRecorder.stopRecording()
                 enteringCallTask = nil
+                pendingCall = nil
             }
         }
     }
 
     private func save(call: Call) {
+        pendingCall = nil
         guard enteringCallTask != nil else {
             call.leave()
             self.call = nil

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -675,6 +675,77 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         await assertCallingState(.inCall)
     }
 
+    func test_joinCall_whenHangingUpWhileJoinIsInProgress_thenCallingStateDoesNotBecomeInCall() async throws {
+        let joinStartedExpectation = expectation(
+            description: "Join flow should start before hang up."
+        )
+        joinStartedExpectation.assertForOverFulfill = false
+
+        let inCallExpectation = expectation(
+            description: "CallingState should not become inCall after hang up."
+        )
+        inCallExpectation.isInverted = true
+        inCallExpectation.assertForOverFulfill = false
+
+        let delayedCall = MockCall(
+            .dummy(
+                callType: callType,
+                callId: callId,
+                coordinatorClient: mockCoordinatorClient
+            )
+        )
+        delayedCall.waitForJoinToResume = true
+        delayedCall.onJoinStarted = {
+            joinStartedExpectation.fulfill()
+        }
+        delayedCall.onJoinResumed = { [weak self] call in
+            await MainActor.run {
+                self?.streamVideo.state.activeCall = call
+            }
+        }
+
+        await prepare(call: delayedCall)
+
+        var activeCallCancellable: AnyCancellable?
+        var callingStateCancellable: AnyCancellable?
+
+        activeCallCancellable = streamVideo
+            .state
+            .$activeCall
+            .sink { [weak self] call in
+                Task { @MainActor [weak self] in
+                    self?.subject.setActiveCall(call)
+                }
+            }
+
+        callingStateCancellable = subject
+            .$callingState
+            .dropFirst()
+            .sink { state in
+                if state == .inCall {
+                    inCallExpectation.fulfill()
+                }
+            }
+
+        defer {
+            activeCallCancellable?.cancel()
+            callingStateCancellable?.cancel()
+        }
+
+        subject.joinCall(callType: callType, callId: callId)
+
+        await fulfillment(of: [joinStartedExpectation], timeout: defaultTimeout)
+
+        subject.hangUp()
+        await assertCallingState(.idle)
+
+        delayedCall.resumeJoin()
+
+        await fulfillment(of: [inCallExpectation], timeout: 1)
+        await fulfilmentInMainActor { delayedCall.timesCalled(.leave) == 1 }
+        await assertCallingState(.idle)
+    }
+
     func test_joinAndRingCall_joinsAndRingsMembers() async throws {
         // Given
         await prepare()
@@ -1338,11 +1409,14 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
     // MARK: - Private helpers
 
     private func prepare(
+        call: MockCall? = nil,
         ringTimeOut: Int = (Int(defaultTimeout) + 1) * 1000,
         file: StaticString = #file,
         line: UInt = #line
     ) async {
-        mockCall.stub(
+        let call = call ?? mockCall!
+
+        call.stub(
             for: .join,
             with: JoinCallResponse.dummy(
                 call: .dummy(
@@ -1355,7 +1429,7 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
                 )
             )
         )
-        mockCall.stub(
+        call.stub(
             for: .create,
             with: CallResponse.dummy(
                 cid: cId,
@@ -1366,7 +1440,7 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
                 type: callType
             )
         )
-        mockCall.stub(
+        call.stub(
             for: .get,
             with: GetCallResponse.dummy(
                 call: CallResponse.dummy(
@@ -1379,11 +1453,17 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
                 )
             )
         )
-        mockCall.stub(for: .reject, with: RejectCallResponse(duration: "0"))
-        mockCall.stub(for: .ring, with: RingCallResponse(duration: "0", membersIds: participants.map(\.id)))
+        call.stub(for: .reject, with: RejectCallResponse(duration: "0"))
+        call.stub(
+            for: .ring,
+            with: RingCallResponse(
+                duration: "0",
+                membersIds: participants.map(\.id)
+            )
+        )
 
         streamVideo = .init(stubbedProperty: [:], stubbedFunction: [
-            .call: mockCall!
+            .call: call
         ])
         streamVideo.state.user = firstUser.user
 

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -991,6 +991,49 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: Simple
+
+    func test_join_whenLeavingWhileJoinIsInProgress_thenCallNeverBecomesActive() async throws {
+        let callId = String.unique
+        let flow = try await helpers
+            .callFlow(id: callId, type: .default, userId: .unique)
+        let activeCallFlow = try await flow.perform { flow in
+            flow.client
+                .state
+                .$activeCall
+                .compactMap { $0?.cId }
+                .filter { $0 == flow.call.cId }
+                .eraseToAnyPublisher()
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await flow
+                    .subscribe(for: CallCreatedEvent.self)
+                    .assertEventually { (event: CallCreatedEvent) in event.call.id == callId }
+                    .perform { $0.call.leave() }
+            }
+
+            group.addTask {
+                try await flow
+                    .performWithErrorExpectation { try await $0.call.join(create: true) }
+            }
+
+            group.addTask {
+                try await activeCallFlow
+                    .performWithErrorExpectation {
+                        try await $0.value.nextValue(timeout: defaultTimeout)
+                    }
+                    .assert { $0.value is TimeOutError }
+            }
+
+            try await group.waitForAll()
+        }
+
+        try await flow
+            .assertEventuallyInMainActor { $0.call.streamVideo.state.activeCall == nil }
+    }
+
     // MARK: - Pin
 
     func test_pin_whenUserGetsPinnedForEveryone_thenCallStateOfAllParticipantsUpdatesAsExpected() async throws {

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -76,6 +76,12 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
     var stubbedFunction: [FunctionKey: Any] = [:]
     @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey.allCases
         .reduce(into: [FunctionKey: [FunctionInputKey]]()) { $0[$1] = [] }
+    var waitForJoinToResume = false
+    var onJoinStarted: (@Sendable () -> Void)?
+    var onJoinResumed: (@Sendable (MockCall) async -> Void)?
+
+    private var joinContinuation: CheckedContinuation<Void, Never>?
+    private var joinWasCancelled = false
 
     override var state: CallState {
         get { self[dynamicMember: \.state] }
@@ -185,6 +191,22 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
                 policy: policy
             )
         )
+        onJoinStarted?()
+
+        if waitForJoinToResume {
+            await withCheckedContinuation { continuation in
+                joinContinuation = continuation
+            }
+        }
+
+        if joinWasCancelled {
+            throw CancellationError()
+        }
+
+        if let onJoinResumed {
+            await onJoinResumed(self)
+        }
+
         if let stub = stubbedFunction[.join] as? JoinCallResponse {
             return stub
         } else {
@@ -199,8 +221,14 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
         }
     }
 
+    func resumeJoin() {
+        joinContinuation?.resume()
+        joinContinuation = nil
+    }
+
     override func leave(reason: String? = nil) {
         stubbedFunctionInput[.leave]?.append(.leave(reason: reason))
+        joinWasCancelled = true
         super.leave(reason: reason)
     }
 

--- a/StreamVideoTests/Utils/Extensions/Concurrency/WithConcurrentChildrenTask_Tests.swift
+++ b/StreamVideoTests/Utils/Extensions/Concurrency/WithConcurrentChildrenTask_Tests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+import XCTest
+
+final class WithConcurrentChildrenTask_Tests: XCTestCase, @unchecked Sendable {
+
+    private enum TestError: Error, Equatable {
+        case expected
+    }
+
+    func test_withConcurrentChildrenTask_returnsResultsInOriginalOrder_whenSecondCompletesFirst() async throws {
+        let result = try await withConcurrentChildrenTask(
+            {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return 1
+            },
+            {
+                try await Task.sleep(nanoseconds: 10_000_000)
+                return "second"
+            }
+        )
+
+        XCTAssertEqual(result.0, 1)
+        XCTAssertEqual(result.1, "second")
+    }
+
+    func test_withConcurrentChildrenTask_rethrowsTheThrownError() async {
+        let error = await XCTAssertThrowsErrorAsync {
+            _ = try await withConcurrentChildrenTask(
+                { throw TestError.expected },
+                { "second" }
+            ) as (Int, String)
+        }
+
+        XCTAssertEqual(error as? TestError, .expected)
+    }
+
+    func test_withConcurrentChildrenTask_cancelsSiblingTask_whenOneTaskThrows() async {
+        let cancellationObserved = Atomic(wrappedValue: false)
+
+        _ = await XCTAssertThrowsErrorAsync {
+            _ = try await withConcurrentChildrenTask(
+                { throw TestError.expected },
+                {
+                    do {
+                        try await Task.sleep(nanoseconds: 5_000_000_000)
+                        return "second"
+                    } catch is CancellationError {
+                        cancellationObserved.wrappedValue = true
+                        throw CancellationError()
+                    }
+                }
+            ) as (Int, String)
+        }
+
+        XCTAssertTrue(cancellationObserved.wrappedValue)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1568/bughang-up-a-call-immediately-after-you-join-shows-the-ui-call-for-a

### 🎯 Goal

Fix the race where hanging up while a call is still joining updates the UI back to idle, but the underlying join continues and briefly promotes the app back into the in-call UI before leaving.

### 📝 Summary

- Make `CallViewModel` cancel an in-flight join by leaving the pending call, not only the active call.
- Prevent `CallViewModel` from saving a call after the join task was cancelled.
- Treat user-initiated join cancellation as a non-error path in `CallViewModel`.
- Add a focused `CallViewModel_Tests` case that reproduces the join-then-hang-up race.
- Add LLC coverage for the same scenario.
- Replace the stats collector `async let` fan-out with a reusable `withConcurrentChildrenTask` helper backed by a task group.
- Add unit tests for `withConcurrentChildrenTask` covering ordering, error propagation, and sibling-task cancellation.

### 🛠 Implementation

This PR fixes the production flow at the `CallViewModel` layer.

Before this change, `enterCall` created a local `Call` and only assigned it to the view model after `join()` completed. If the user tapped hang up while the join was still in progress, `leaveCall` often had no active `call` to leave, so the UI went back to idle while the join continued underneath. Once the join completed, the late `activeCall` update briefly drove the UI back to `.inCall` before the cleanup finished.

The fix introduces a pending-call path in `CallViewModel`:
- `enterCall` now keeps track of the call being joined.
- `leaveCall` uses `pendingCall ?? call`, so hanging up while joining leaves the real in-flight call.
- `enterCall` checks cancellation after `join()` returns and exits before `save(call:)` can promote the call into the UI.
- `CancellationError` caused by a user hang-up is treated as expected control flow instead of a user-visible error.

For test coverage, the new `CallViewModel_Tests` case pauses `MockCall.join()`, hangs up while the join is suspended, then resumes the join and verifies the view model does not transition to `.inCall`.

Separately, while covering the same race at LLC/integration level, we hit a runtime crash in the stats collector when teardown cancelled a parent task that was using `async let`. To make that path more robust, the collector now uses `withConcurrentChildrenTask`, a small task-group-based helper that keeps the parallelism but makes sibling cancellation and task completion explicit. The helper lives in the concurrency utilities and includes targeted tests.

### 🧪 Manual Testing Notes

1. Open the demo app.
2. Join a call and tap hang up immediately while the joining UI is still visible.
3. Verify the app returns to idle and does not briefly show the in-call UI afterward.
4. Repeat the scenario a few times to confirm the behavior is stable.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the in-call UI briefly displayed when hanging up a call while join was still in progress in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->