### PR TITLE
[Fix]Prevent screen-share prompt loop after denied capture on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
+- Prevent repeated screen-sharing permission prompts on reconnection after screen capture is denied. [#1102](https://github.com/GetStream/stream-video-swift/pull/1102)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter.swift
@@ -372,7 +372,11 @@ final class LocalScreenShareMediaAdapter: LocalMediaAdapting, @unchecked Sendabl
             do {
                 try await stopScreenShareCapturingSession()
             } catch {
-                log.error("Failed to stop screenShare capturing session after startCapturing failure.", subsystems: .webRTC)
+                screenShareSessionProvider.activeSession = nil
+                log.error(
+                    "Failed to stop screenShare capturing session after startCapturing failure.",
+                    subsystems: .webRTC
+                )
             }
             throw startError
         }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter.swift
@@ -363,7 +363,19 @@ final class LocalScreenShareMediaAdapter: LocalMediaAdapting, @unchecked Sendabl
             includeAudio: includeAudio
         )
 
-        try await startScreenShareCapturingSession()
+        // In case of failure (e.g. the user denied the prompt to capture screen)
+        // we stop screensharing and propagate higher the initial error.
+        do {
+            try await startScreenShareCapturingSession()
+        } catch {
+            let startError = error
+            do {
+                try await stopScreenShareCapturingSession()
+            } catch {
+                log.error("Failed to stop screenShare capturing session after startCapturing failure.", subsystems: .webRTC)
+            }
+            throw startError
+        }
 
         guard screenShareSessionProvider.activeSession != nil else {
             return

--- a/StreamVideoTests/Mock/MockStreamVideoCapturer.swift
+++ b/StreamVideoTests/Mock/MockStreamVideoCapturer.swift
@@ -100,6 +100,10 @@ final class MockStreamVideoCapturer: StreamVideoCapturing, Mockable, @unchecked 
                 frameRate: frameRate
             )
         )
+
+        if let error = stubbedFunction[.startCapture] as? Error {
+            throw error
+        }
     }
 
     func stopCapture() async throws {

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter_Tests.swift
@@ -298,6 +298,25 @@ final class LocalScreenShareMediaAdapter_Tests: XCTestCase, @unchecked Sendable 
         await fulfillment { capturer.timesCalled(.startCapture) == 1 }
     }
 
+    func test_beginScreenSharing_capturerThrowsError_stopsCapturingAndPropagatesError() async throws {
+        let screensharingType = ScreensharingType.inApp
+        let capturer = MockStreamVideoCapturer()
+        let error = ClientError("permissions denied")
+        capturer.stub(for: .startCapture, with: error)
+        mockCapturerFactory.stub(for: .buildScreenCapturer, with: capturer)
+
+        let thrownError = await XCTAssertThrowsErrorAsync {
+            try await subject.beginScreenSharing(
+                of: screensharingType,
+                ownCapabilities: [.screenshare],
+                includeAudio: true
+            )
+        }
+
+        XCTAssertEqual(thrownError as? ClientError, error)
+        XCTAssertEqual(capturer.timesCalled(.startCapture), 1)
+    }
+
     // MARK: - stopScreenSharing
 
     func test_stopScreenSharing_updateMuteStateOnSFU() async throws {

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter_Tests.swift
@@ -315,6 +315,8 @@ final class LocalScreenShareMediaAdapter_Tests: XCTestCase, @unchecked Sendable 
 
         XCTAssertEqual(thrownError as? ClientError, error)
         XCTAssertEqual(capturer.timesCalled(.startCapture), 1)
+        XCTAssertTrue(capturer.timesCalled(.stopCapture) >= 1)
+        XCTAssertNil(screenShareSessionProvider.activeSession)
     }
 
     // MARK: - stopScreenSharing


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1267/endless-screen-sharing-pop-up-on-reconnection

### 🎯 Goal

Prevent the SDK from repeatedly reopening the iOS screen-sharing prompt after the
user denies screen capture and the call later reconnects/rejoins.

### 📝 Summary

- Clean up the active screen-share session when screen-capture startup fails.
- Rethrow the original capture-start error so the failure is still surfaced.
- Add unit-test support for capturer startup failures.
- Cover the denied-permission path in `LocalScreenShareMediaAdapter` tests.

### 🛠 Implementation

`LocalScreenShareMediaAdapter.beginScreenSharing` configures an active
screen-share session before starting capture. When iOS rejects the screen-capture
prompt, `startCapture` throws, but the active session was left in place.

That stale session could survive into reconnect/rejoin flows and cause the SDK to
attempt screen sharing again automatically, which re-triggered the permission
prompt in a loop.

This change wraps `startScreenShareCapturingSession()` in error handling,
explicitly stops the screen-share capture session if startup fails, logs any
cleanup failure, and then rethrows the original error. The test suite was also
updated so the mock capturer can throw on `startCapture`, and a unit test now
covers this failure path.

### 🧪 Manual Testing Notes

1. Join a call.
2. Open the more menu.
3. Tap the screen-sharing button.
4. Tap `Don't Allow` on the iOS prompt.
5. Trigger reconnect and rejoin.
6. Verify the screen-sharing prompt does not appear again automatically.
7. Verify screen sharing still works normally when the prompt is accepted.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated screen-sharing permission prompts when reconnecting after denying capture.
  * Improved cleanup and error handling when screen-sharing initialization fails, ensuring sessions are not left active.

* **Tests**
  * Added a unit test covering the screen-sharing failure path to verify cleanup and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->