### PR TITLE
[Enhancement]Gate WebRTC permission prompts to joined foreground calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
 - Prevent hanging up while a call is still joining from briefly showing the in-call UI after the join finishes in the background. [#1101](https://github.com/GetStream/stream-video-swift/pull/1101)
+- Delay microphone and camera permission prompts until the app is in the foreground and the WebRTC join has completed.
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
 - Prevent hanging up while a call is still joining from briefly showing the in-call UI after the join finishes in the background. [#1101](https://github.com/GetStream/stream-video-swift/pull/1101)
-- Delay microphone and camera permission prompts until the app is in the foreground and the WebRTC join has completed.
+- Delay microphone and camera permission prompts until the app is in the foreground and the WebRTC join has completed. [#1103](https://github.com/GetStream/stream-video-swift/pull/1103)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator.swift
@@ -29,9 +29,16 @@ class RTCPeerConnectionCoordinator: @unchecked Sendable {
 
     // MARK: - Properties
 
+    /// The role of the underlying peer connection in the current WebRTC
+    /// session.
+    ///
+    /// The readiness-aware join flow inspects this value to decide whether it
+    /// should wait for the connection to report `.connected` before finishing
+    /// the join transition.
+    let peerType: PeerConnectionType
+
     private let identifier = UUID()
     private let sessionId: String
-    private let peerType: PeerConnectionType
     private let peerConnection: StreamRTCPeerConnectionProtocol
     private let subsystem: LogSubsystem
     private let clientCapabilities: Set<ClientCapability>

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+PeerConnectionPreparing.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+PeerConnectionPreparing.swift
@@ -11,6 +11,10 @@ extension WebRTCCoordinator.StateMachine.Stage {
     /// Creates the stage that waits briefly for the publisher peer connection
     /// to report `.connected` before the join call completes.
     ///
+    /// If the publisher is joining with both audio and video disabled, the
+    /// stage skips the readiness wait because there is no local media to
+    /// negotiate yet.
+    ///
     /// - Parameters:
     ///   - context: The state machine context for the pending join flow.
     ///   - telemetryReporter: Reports telemetry after the stage finishes.
@@ -29,6 +33,9 @@ extension WebRTCCoordinator.StateMachine.Stage {
 
     /// Delays join completion while waiting for the publisher peer connection
     /// to report `.connected`.
+    ///
+    /// Muted joins that do not publish local audio or video skip the
+    /// publisher wait and proceed directly to `.joined`.
     final class PeerConnectionPreparingStage:
         WebRTCCoordinator.StateMachine.Stage,
         @unchecked Sendable {
@@ -154,11 +161,39 @@ extension WebRTCCoordinator.StateMachine.Stage {
             }
         }
 
+        /// Returns whether the provided peer connection has work that can make
+        /// progress during the readiness wait.
+        ///
+        /// Subscriber connections always wait because they receive remote
+        /// media. Publisher connections only wait when the current
+        /// `CallSettings` indicate that local audio or video should be
+        /// published.
+        private func canWaitForPeerConnection(
+            _ peerConnection: RTCPeerConnectionCoordinator
+        ) async -> Bool {
+            switch peerConnection.peerType {
+            case .subscriber:
+                return true
+            case .publisher:
+                guard
+                    let callSettings = await context.coordinator?.stateAdapter.callSettings
+                else {
+                    return true
+                }
+
+                return callSettings.shouldPublish
+            }
+        }
+
         private func waitForPeerConnectionToBePrepared(
             _ peerConnection: RTCPeerConnectionCoordinator,
             subsystem: LogSubsystem,
             timeout: TimeInterval
         ) async {
+            guard await canWaitForPeerConnection(peerConnection) else {
+                return
+            }
+
             do {
                 _ = try await peerConnection
                     .connectionStatePublisher

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -42,7 +42,10 @@ final class WebRTCCoordinator: @unchecked Sendable {
 
     /// The state machine that manages the different stages of the WebRTC
     /// lifecycle.
-    private(set) lazy var stateMachine: StateMachine = .init(.init(coordinator: self))
+    ///
+    /// The coordinator constructs this eagerly so its stage publisher can be
+    /// passed to `WebRTCStateAdapter` during initialization.
+    let stateMachine: StateMachine
 
     private let disposableBag = DisposableBag()
 
@@ -54,10 +57,12 @@ final class WebRTCCoordinator: @unchecked Sendable {
     ///   - apiKey: The API key to authenticate with the WebRTC service.
     ///   - callCid: The call identifier (cid).
     ///   - videoConfig: The video configuration for the call.
+    ///   - callSettings: Initial media settings applied before the join flow
+    ///     starts.
+    ///   - rtcPeerConnectionCoordinatorFactory: Factory for creating peer
+    ///     connection coordinators.
     ///   - webRTCAuthenticator: The authenticator that will be used during all WebRTC flows.
     ///   - callAuthentication: A closure for handling call authentication.
-    ///   - rtcPeerConnectionCoordinatorFactory: Factory for creating the peer
-    ///     connection coordinator.
     init(
         user: User,
         apiKey: String,
@@ -68,17 +73,21 @@ final class WebRTCCoordinator: @unchecked Sendable {
         webRTCAuthenticator: WebRTCAuthenticating = WebRTCAuthenticator(),
         callAuthentication: @escaping AuthenticationHandler
     ) {
+        let stateMachine = StateMachine.init(.init(coordinator: nil))
         stateAdapter = .init(
             user: user,
             apiKey: apiKey,
             callCid: callCid,
             videoConfig: videoConfig,
             callSettings: callSettings,
-            rtcPeerConnectionCoordinatorFactory: rtcPeerConnectionCoordinatorFactory
+            rtcPeerConnectionCoordinatorFactory: rtcPeerConnectionCoordinatorFactory,
+            stagePublisher: stateMachine.publisher.map(\.id).eraseToAnyPublisher()
         )
+        self.stateMachine = stateMachine
         self.callAuthentication = callAuthentication
 
         // Initialize the state machine.
+        stateMachine.transition(.idle(.init(coordinator: self)))
         stateMachine.currentStage.context.authenticator = webRTCAuthenticator
 
         #if OBSERVE_RECONNECTION_NOTIFICATIONS

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCPermissionsAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCPermissionsAdapter.swift
@@ -31,8 +31,12 @@ protocol WebRTCPermissionsAdapterDelegate: AnyObject {
 /// Coordinates permission prompts and aligns call media with user grants.
 ///
 /// Prompts are deferred until the application is in the foreground and the
-/// WebRTC coordinator has reached the `.joined` stage. Work is serialized to
-/// avoid races across app state and permission updates.
+/// WebRTC coordinator has reached the `.joined` stage.
+///
+/// The adapter observes both app-state transitions and stage changes so
+/// permission prompts are always evaluated against the current lifecycle
+/// state. Work is serialized to avoid races across app state and permission
+/// updates.
 final class WebRTCPermissionsAdapter: @unchecked Sendable {
     private enum RequiredPermission: CustomStringConvertible {
         case microphone, camera
@@ -74,10 +78,9 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
                 .eraseToAnyPublisher(),
             applicationStateAdapter
                 .statePublisher
-                .filter { $0 == .foreground }
                 .removeDuplicates()
-        ).sink { [weak self] stageID, _ in
-            self?.process(canPromptForPermissions: stageID == .joined)
+        ).sink { [weak self] stageID, applicationState in
+            self?.process(stageID: stageID, applicationState: applicationState)
         }
         .store(in: disposableBag)
 
@@ -183,8 +186,11 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
     /// Re-evaluates pending permissions after a stage or app-state change.
     ///
     /// Prompts are only issued once both gating conditions are met: the app is
-    /// in the foreground and the coordinator is already joined.
-    private func process(canPromptForPermissions: Bool) {
+    /// currently in the foreground and the coordinator is already joined.
+    private func process(
+        stageID: WebRTCCoordinator.StateMachine.Stage.ID,
+        applicationState: ApplicationState
+    ) {
         processingQueue.addTaskOperation { [weak self] in
             guard
                 let self
@@ -192,9 +198,10 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
                 return
             }
 
-            self.canPromptForPermissions = canPromptForPermissions
+            self.canPromptForPermissions = stageID == .joined
 
             guard
+                applicationState == .foreground,
                 shouldPrompt(for: requiredPermissions)
             else {
                 return

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCPermissionsAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCPermissionsAdapter.swift
@@ -29,7 +29,10 @@ protocol WebRTCPermissionsAdapterDelegate: AnyObject {
 }
 
 /// Coordinates permission prompts and aligns call media with user grants.
-/// Serializes work to avoid races across app state and permission updates.
+///
+/// Prompts are deferred until the application is in the foreground and the
+/// WebRTC coordinator has reached the `.joined` stage. Work is serialized to
+/// avoid races across app state and permission updates.
 final class WebRTCPermissionsAdapter: @unchecked Sendable {
     private enum RequiredPermission: CustomStringConvertible {
         case microphone, camera
@@ -51,18 +54,32 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
 
     private weak var delegate: WebRTCPermissionsAdapterDelegate?
     private var requiredPermissions: Set<RequiredPermission> = []
+    private var canPromptForPermissions: Bool = false
 
     /// Creates an adapter and begins observing app/permission changes.
     ///
-    /// - Parameter delegate: Target for audio/video enable updates.
-    init(_ delegate: WebRTCPermissionsAdapterDelegate) {
+    /// - Parameters:
+    ///   - delegate: Target for audio/video enable updates.
+    ///   - stagePublisher: Publishes WebRTC stage transitions so prompts can
+    ///     wait until the call is fully joined.
+    init(
+        _ delegate: WebRTCPermissionsAdapterDelegate,
+        stagePublisher: AnyPublisher<WebRTCCoordinator.StateMachine.Stage.ID, Never>
+    ) {
         self.delegate = delegate
-        applicationStateAdapter
-            .statePublisher
-            .filter { $0 == .foreground }
-            .removeDuplicates()
-            .sink { [weak self] _ in self?.didMoveToForeground() }
-            .store(in: disposableBag)
+
+        Publishers.CombineLatest(
+            stagePublisher
+                .removeDuplicates()
+                .eraseToAnyPublisher(),
+            applicationStateAdapter
+                .statePublisher
+                .filter { $0 == .foreground }
+                .removeDuplicates()
+        ).sink { [weak self] stageID, _ in
+            self?.process(canPromptForPermissions: stageID == .joined)
+        }
+        .store(in: disposableBag)
 
         permissions
             .$hasMicrophonePermission
@@ -163,11 +180,21 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
 
     // MARK: - Private Helpers
 
-    /// Requests pending permissions when returning to foreground, if needed.
-    private func didMoveToForeground() {
+    /// Re-evaluates pending permissions after a stage or app-state change.
+    ///
+    /// Prompts are only issued once both gating conditions are met: the app is
+    /// in the foreground and the coordinator is already joined.
+    private func process(canPromptForPermissions: Bool) {
         processingQueue.addTaskOperation { [weak self] in
             guard
-                let self,
+                let self
+            else {
+                return
+            }
+
+            self.canPromptForPermissions = canPromptForPermissions
+
+            guard
                 shouldPrompt(for: requiredPermissions)
             else {
                 return
@@ -234,9 +261,9 @@ final class WebRTCPermissionsAdapter: @unchecked Sendable {
 
             switch permission {
             case .microphone:
-                return !permissions.hasMicrophonePermission && permissions.canRequestMicrophonePermission
+                return !permissions.hasMicrophonePermission && permissions.canRequestMicrophonePermission && canPromptForPermissions
             case .camera:
-                return !permissions.hasCameraPermission && permissions.canRequestCameraPermission
+                return !permissions.hasCameraPermission && permissions.canRequestCameraPermission && canPromptForPermissions
             }
         }
     }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -95,8 +95,11 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
 
     private let processingQueue = OperationQueue(maxConcurrentOperationCount: 1)
     private let callSettingsProcessingQueue = OperationQueue(maxConcurrentOperationCount: 1)
+    /// Publishes WebRTC stage changes so permission prompts can wait until the
+    /// coordinator has fully joined.
+    private let stagePublisher: AnyPublisher<WebRTCCoordinator.StateMachine.Stage.ID, Never>
     private var queuedTraces: ConsumableBucket<WebRTCTrace> = .init()
-    private lazy var permissionsAdapter: WebRTCPermissionsAdapter = .init(self)
+    private lazy var permissionsAdapter: WebRTCPermissionsAdapter = .init(self, stagePublisher: stagePublisher)
 
     /// Initializes the WebRTC state adapter with user details and connection
     /// configurations.
@@ -108,6 +111,8 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     ///   - videoConfig: Configuration for video settings.
     ///   - rtcPeerConnectionCoordinatorFactory: Factory for peer connection
     ///     creation.
+    ///   - stagePublisher: Publishes WebRTC stage transitions for permission
+    ///     handling.
     ///   - videoCaptureSessionProvider: Provides sessions for video capturing.
     ///   - screenShareSessionProvider: Provides sessions for screen sharing.
     init(
@@ -117,6 +122,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         videoConfig: VideoConfig,
         callSettings: CallSettings,
         rtcPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordinatorProviding,
+        stagePublisher: AnyPublisher<WebRTCCoordinator.StateMachine.Stage.ID, Never>,
         videoCaptureSessionProvider: VideoCaptureSessionProvider = .init(),
         screenShareSessionProvider: ScreenShareSessionProvider = .init()
     ) {
@@ -130,6 +136,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
                 audioProcessingModule: videoConfig.audioProcessingModule
             ),
             rtcPeerConnectionCoordinatorFactory: rtcPeerConnectionCoordinatorFactory,
+            stagePublisher: stagePublisher,
             videoCaptureSessionProvider: videoCaptureSessionProvider,
             screenShareSessionProvider: screenShareSessionProvider
         )
@@ -147,6 +154,8 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     ///   audioSession..
     ///   - rtcPeerConnectionCoordinatorFactory: Factory for peer connection
     ///     creation.
+    ///   - stagePublisher: Publishes WebRTC stage transitions for permission
+    ///     handling.
     ///   - videoCaptureSessionProvider: Provides sessions for video capturing.
     ///   - screenShareSessionProvider: Provides sessions for screen sharing.
     init(
@@ -157,6 +166,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         callSettings: CallSettings,
         peerConnectionFactory: PeerConnectionFactory,
         rtcPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordinatorProviding,
+        stagePublisher: AnyPublisher<WebRTCCoordinator.StateMachine.Stage.ID, Never>,
         videoCaptureSessionProvider: VideoCaptureSessionProvider = .init(),
         screenShareSessionProvider: ScreenShareSessionProvider = .init()
     ) {
@@ -171,6 +181,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         self.videoCaptureSessionProvider = videoCaptureSessionProvider
         self.screenShareSessionProvider = screenShareSessionProvider
         self.audioSession = .init()
+        self.stagePublisher = stagePublisher
 
         peerConnectionFactory
             .setFrameBufferPolicy(

--- a/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 @testable import StreamVideo
 import StreamWebRTC
 @preconcurrency import XCTest
@@ -17,13 +18,18 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         webSocket: mockWebSocket,
         webSocketFactory: MockWebSocketClientFactory()
     )
+    private lazy var stageSubject: CurrentValueSubject<
+        WebRTCCoordinator.StateMachine.Stage.ID,
+        Never
+    >! = .init(.idle)
     private lazy var stateAdapter: WebRTCStateAdapter! = .init(
         user: .dummy(),
         apiKey: .unique,
         callCid: .unique,
         videoConfig: Self.videoConfig,
         callSettings: .default,
-        rtcPeerConnectionCoordinatorFactory: MockRTCPeerConnectionCoordinatorFactory()
+        rtcPeerConnectionCoordinatorFactory: MockRTCPeerConnectionCoordinatorFactory(),
+        stagePublisher: stageSubject.eraseToAnyPublisher()
     )
     private lazy var subject: SFUEventAdapter! = .init(
         sfuAdapter: sfuAdapter,
@@ -46,6 +52,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
     override func tearDown() {
         subject = nil
         stateAdapter = nil
+        stageSubject = nil
         sfuAdapter = nil
         mockWebSocket = nil
         mockService = nil

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_PeerConnectionPreparingStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_PeerConnectionPreparingStageTests.swift
@@ -132,6 +132,84 @@ final class WebRTCCoordinatorStateMachine_PeerConnectionPreparingStageTests:
         completionCancellable.cancel()
     }
 
+    func test_transition_publisherHasNoTracksToPublish_transitionsToJoinedWithoutWaitingForReadiness(
+    ) async throws {
+        mockCoordinatorStack = .init(
+            videoConfig: Self.videoConfig,
+            callSettings: .init(audioOn: false, videoOn: false)
+        )
+
+        let expectedJoinCallResponse = JoinCallResponse.dummy(
+            call: .dummy(cid: "expected-call-id")
+        )
+        let completionSubject = PassthroughSubject<JoinCallResponse, Error>()
+        let completionExpectation = expectation(
+            description: "JoinResponseHandler should receive response."
+        )
+        var receivedCallID: String?
+        let completionCancellable = completionSubject.sink(
+            receiveCompletion: { _ in },
+            receiveValue: { response in
+                receivedCallID = response.call.cid
+                completionExpectation.fulfill()
+            }
+        )
+        defer { completionCancellable.cancel() }
+
+        let publisherConnectionState = CurrentValueSubject<
+            RTCPeerConnectionState,
+            Never
+        >(.new)
+        let publisherCoordinator = try XCTUnwrap(
+            MockRTCPeerConnectionCoordinator(
+                peerType: .publisher,
+                callSettings: .init(audioOn: false, videoOn: false),
+                sfuAdapter: mockCoordinatorStack.sfuStack.adapter
+            )
+        )
+        publisherCoordinator.stub(
+            for: \.connectionStatePublisher,
+            with: publisherConnectionState.eraseToAnyPublisher()
+        )
+        mockCoordinatorStack
+            .rtcPeerConnectionCoordinatorFactory
+            .stubbedBuildCoordinatorResult[.publisher] = publisherCoordinator
+
+        let context = WebRTCCoordinator.StateMachine.Stage.Context(
+            coordinator: mockCoordinatorStack.coordinator,
+            initialJoinCallResponse: expectedJoinCallResponse,
+            joinResponseHandler: completionSubject
+        )
+        subject = .peerConnectionPreparing(context, telemetryReporter: .init())
+
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
+        try await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .configurePeerConnections()
+
+        let transitionExpectation = expectation(
+            description: "Stage is expected to transition to joined."
+        )
+        subject.transition = { target in
+            guard target.id == .joined else { return }
+            XCTAssertNil(target.context.initialJoinCallResponse)
+            XCTAssertNil(target.context.joinResponseHandler)
+            transitionExpectation.fulfill()
+        }
+
+        _ = subject.transition(from: .joining(subject.context))
+
+        await fulfillment(
+            of: [transitionExpectation, completionExpectation],
+            timeout: 1
+        )
+        XCTAssertEqual(receivedCallID, expectedJoinCallResponse.call.cid)
+    }
+
     func test_transition_whenSubscriberDoesNotBecomeReadyWithinTimeout_transitionsToJoinedWithoutWaitingForSubscriber(
     ) async throws {
         let expectedJoinCallResponse = JoinCallResponse.dummy(

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -75,6 +75,10 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    func test_init_stateMachineStartsInIdleStage() {
+        XCTAssertEqual(subject.stateMachine.currentStage.id, .idle)
+    }
+
     // MARK: - connect
 
     func test_connect_shouldSetInitialCallSettingsAndTransitionStateMachine() async throws {

--- a/StreamVideoTests/WebRTC/v2/WebRTCPermissionsAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCPermissionsAdapter_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 @testable import StreamVideo
 import XCTest
@@ -11,7 +12,14 @@ final class WebRTCPermissionsAdapter_Tests: StreamVideoTestCase, @unchecked Send
     private lazy var mockAppStateAdapter: MockAppStateAdapter! = .init()
     private lazy var mockPermissions: MockPermissionsStore! = .init()
     private lazy var delegate: MockWebRTCPermissionsAdapterDelegate! = .init()
-    private lazy var subject: WebRTCPermissionsAdapter! = .init(delegate)
+    private lazy var stageSubject: CurrentValueSubject<
+        WebRTCCoordinator.StateMachine.Stage.ID,
+        Never
+    >! = .init(.idle)
+    private lazy var subject: WebRTCPermissionsAdapter! = .init(
+        delegate,
+        stagePublisher: stageSubject.eraseToAnyPublisher()
+    )
 
     override func tearDown() {
         mockAppStateAdapter?.dismante()
@@ -19,6 +27,7 @@ final class WebRTCPermissionsAdapter_Tests: StreamVideoTestCase, @unchecked Send
         mockAppStateAdapter = nil
         mockPermissions = nil
         delegate = nil
+        stageSubject = nil
         subject = nil
         super.tearDown()
     }
@@ -103,6 +112,7 @@ final class WebRTCPermissionsAdapter_Tests: StreamVideoTestCase, @unchecked Send
         mockAppStateAdapter.stubbedState = .foreground
         mockPermissions.stubMicrophonePermission(.unknown)
         await fulfillment { self.mockPermissions.mockStore.state.microphonePermission == .unknown }
+        stageSubject.send(.joined)
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -128,6 +138,7 @@ final class WebRTCPermissionsAdapter_Tests: StreamVideoTestCase, @unchecked Send
         mockAppStateAdapter.stubbedState = .foreground
         mockPermissions.stubCameraPermission(.unknown)
         await fulfillment { self.mockPermissions.mockStore.state.cameraPermission == .unknown }
+        stageSubject.send(.joined)
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -149,5 +160,67 @@ final class WebRTCPermissionsAdapter_Tests: StreamVideoTestCase, @unchecked Send
 
         mockAppStateAdapter?.dismante()
         mockPermissions?.dismantle()
+    }
+
+    func test_willSet_audioOnTrue_unknownMic_inForegroundBeforeJoined_doesNotRequestPermission() async {
+        mockAppStateAdapter.makeShared()
+        mockAppStateAdapter.stubbedState = .foreground
+        mockPermissions.stubMicrophonePermission(.unknown)
+        await fulfillment {
+            self.mockPermissions.mockStore.state.microphonePermission == .unknown
+        }
+
+        let input = CallSettings(audioOn: true, videoOn: false)
+        let output = await subject.willSet(callSettings: input)
+
+        XCTAssertFalse(output.audioOn)
+        XCTAssertFalse(output.videoOn)
+        XCTAssertEqual(mockPermissions.timesCalled(.requestMicrophonePermission), 0)
+    }
+
+    func test_stageTransitionsToJoined_withPendingMicPermissionInForeground_requestsPermission() async {
+        mockAppStateAdapter.makeShared()
+        mockAppStateAdapter.stubbedState = .foreground
+        mockPermissions.stubMicrophonePermission(.unknown)
+        await fulfillment {
+            self.mockPermissions.mockStore.state.microphonePermission == .unknown
+        }
+
+        let input = CallSettings(audioOn: true, videoOn: false)
+        _ = await subject.willSet(callSettings: input)
+        XCTAssertEqual(mockPermissions.timesCalled(.requestMicrophonePermission), 0)
+
+        stageSubject.send(.joined)
+
+        await fulfillment {
+            self.mockPermissions.timesCalled(.requestMicrophonePermission) == 1
+        }
+        mockPermissions.stubMicrophonePermission(.granted)
+        await fulfillment { self.delegate.audioOnValues.contains(true) }
+    }
+
+    func test_appMovesToForeground_withPendingCameraPermissionInJoined_requestsPermission() async {
+        mockAppStateAdapter.makeShared()
+        mockAppStateAdapter.stubbedState = .background
+        stageSubject.send(.joined)
+        mockPermissions.stubCameraPermission(.unknown)
+        await fulfillment {
+            self.mockPermissions.mockStore.state.cameraPermission == .unknown
+        }
+
+        let input = CallSettings(audioOn: false, videoOn: true)
+        let output = await subject.willSet(callSettings: input)
+
+        XCTAssertFalse(output.audioOn)
+        XCTAssertFalse(output.videoOn)
+        XCTAssertEqual(mockPermissions.timesCalled(.requestCameraPermission), 0)
+
+        mockAppStateAdapter.stubbedState = .foreground
+
+        await fulfillment {
+            self.mockPermissions.timesCalled(.requestCameraPermission) == 1
+        }
+        mockPermissions.stubCameraPermission(.granted)
+        await fulfillment { self.delegate.videoOnValues.contains(true) }
     }
 }

--- a/StreamVideoTests/WebRTC/v2/WebRTCPermissionsAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCPermissionsAdapter_Tests.swift
@@ -223,4 +223,35 @@ final class WebRTCPermissionsAdapter_Tests: StreamVideoTestCase, @unchecked Send
         mockPermissions.stubCameraPermission(.granted)
         await fulfillment { self.delegate.videoOnValues.contains(true) }
     }
+
+    func test_stageTransitionsToJoinedWhileAppIsBackgrounded_afterForeground_doesNotRequestUntilForeground(
+    ) async {
+        mockAppStateAdapter.makeShared()
+        mockAppStateAdapter.stubbedState = .foreground
+        mockPermissions.stubMicrophonePermission(.unknown)
+        await fulfillment {
+            self.mockPermissions.mockStore.state.microphonePermission == .unknown
+        }
+
+        let input = CallSettings(audioOn: true, videoOn: false)
+        let output = await subject.willSet(callSettings: input)
+
+        XCTAssertFalse(output.audioOn)
+        XCTAssertFalse(output.videoOn)
+        XCTAssertEqual(mockPermissions.timesCalled(.requestMicrophonePermission), 0)
+
+        mockAppStateAdapter.stubbedState = .background
+        stageSubject.send(.joined)
+
+        await wait(for: 0.1)
+        XCTAssertEqual(mockPermissions.timesCalled(.requestMicrophonePermission), 0)
+
+        mockAppStateAdapter.stubbedState = .foreground
+
+        await fulfillment {
+            self.mockPermissions.timesCalled(.requestMicrophonePermission) == 1
+        }
+        mockPermissions.stubMicrophonePermission(.granted)
+        await fulfillment { self.delegate.audioOnValues.contains(true) }
+    }
 }

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 @testable import StreamVideo
 import StreamWebRTC
 @preconcurrency import XCTest
@@ -22,6 +23,10 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         .init(peerConnectionFactory: mockPeerConnectionFactory)
     private lazy var mockPermissions: MockPermissionsStore! = .init()
     private lazy var mockAudioStore: MockRTCAudioStore! = .init()
+    private lazy var stageSubject: CurrentValueSubject<
+        WebRTCCoordinator.StateMachine.Stage.ID,
+        Never
+    >! = .init(.idle)
     private lazy var subject: WebRTCStateAdapter! = .init(
         user: user,
         apiKey: apiKey,
@@ -29,7 +34,8 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         videoConfig: Self.videoConfig,
         callSettings: callSettings,
         peerConnectionFactory: mockPeerConnectionFactory,
-        rtcPeerConnectionCoordinatorFactory: rtcPeerConnectionCoordinatorFactory
+        rtcPeerConnectionCoordinatorFactory: rtcPeerConnectionCoordinatorFactory,
+        stagePublisher: stageSubject.eraseToAnyPublisher()
     )
 
     // MARK: - Lifecycle
@@ -47,6 +53,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         subject = nil
         callSettings = nil
         mockPermissions = nil
+        stageSubject = nil
         callCid = nil
         apiKey = nil
         user = nil
@@ -1177,7 +1184,10 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         try await subject.configurePeerConnections()
         await subject.enqueueCallSettings { _ in CallSettings(audioOn: false) }
 
-        subject.permissionsAdapter(.init(subject), audioOn: true)
+        subject.permissionsAdapter(
+            .init(subject, stagePublisher: stageSubject.eraseToAnyPublisher()),
+            audioOn: true
+        )
 
         let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
         await fulfillment {
@@ -1200,7 +1210,10 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         try await subject.configurePeerConnections()
         await subject.enqueueCallSettings { _ in CallSettings(videoOn: false) }
 
-        subject.permissionsAdapter(.init(subject), videoOn: true)
+        subject.permissionsAdapter(
+            .init(subject, stagePublisher: stageSubject.eraseToAnyPublisher()),
+            videoOn: true
+        )
 
         let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
         await fulfillment {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1569/bugorinvestigationwhen-permission-prompts-were-visible-user-got-stuck

### 🎯 Goal

Avoid spending the peer-connection readiness timeout on joins that start with
both audio and video disabled, since the publisher has no local media to
negotiate yet. 

Prevent camera and microphone permission prompts from appearing before the call
has actually joined or while the app is not active, while preserving the recent
join-flow readiness improvements.

### 📝 Summary

- skip publisher readiness waiting when the join will not publish local audio or video
- only prompt for microphone or camera permissions when the app is in the foreground and the WebRTC stage is `.joined`

### 🛠 Implementation

- Updated `PeerConnectionPreparingStage` to check `CallSettings.shouldPublish`
  before awaiting `.connected` on the publisher connection.
- `WebRTCCoordinator` now constructs its state machine eagerly so the current
  stage stream can be injected into `WebRTCStateAdapter` during initialization.
- `WebRTCStateAdapter` forwards that stage publisher to
  `WebRTCPermissionsAdapter`.
- `WebRTCPermissionsAdapter` now combines the coordinator stage with app
  foreground state before requesting pending permissions, so prompts are
  deferred until both conditions are true.

### 🧪 Manual Testing Notes

- Install the app
- Login with a user
- Kill the app
- Have someone ring you
- Accept the call (scenarioA from callkit, scenarioB from inApp)
- You should immediately move to the inCall screen rather than waiting 5 seconds for your connections to setup. An easy way to understand the change is that the permission prompts should appear when you are already in the call and not while in joining.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Permission prompts for microphone and camera are now delayed until the app is in the foreground and the WebRTC join process has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->