### PR TITLE
[Enhancement]Seperate ringing duration from actual call duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent repeated screen-sharing permission prompts on reconnection after screen capture is denied. [#1102](https://github.com/GetStream/stream-video-swift/pull/1102)
 - Prevent hanging up while a call is still joining from briefly showing the in-call UI after the join finishes in the background. [#1101](https://github.com/GetStream/stream-video-swift/pull/1101)
 - Delay microphone and camera permission prompts until the app is in the foreground and the WebRTC join has completed. [#1103](https://github.com/GetStream/stream-video-swift/pull/1103)
+- Prevent outgoing ringing time from being counted toward call duration. [#1106](https://github.com/GetStream/stream-video-swift/pull/1106)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -77,12 +77,7 @@ public class CallState: ObservableObject {
 
     @Published public internal(set) var updatedAt: Date = .distantPast
     @Published public internal(set) var startsAt: Date?
-    @Published public internal(set) var startedAt: Date? {
-        didSet {
-            setupDurationTimer()
-        }
-    }
-
+    @Published public internal(set) var startedAt: Date?
     @Published public internal(set) var endedAt: Date?
     @Published public internal(set) var endedBy: User?
     @Published public internal(set) var custom: [String: RawJSON] = [:]
@@ -93,12 +88,7 @@ public class CallState: ObservableObject {
     @Published public internal(set) var transcribing: Bool = false
     @Published public internal(set) var captioning: Bool = false
     @Published public internal(set) var egress: EgressResponse? { didSet { didUpdate(egress) } }
-    @Published public internal(set) var session: CallSessionResponse? {
-        didSet {
-            didUpdate(session)
-        }
-    }
-
+    @Published public internal(set) var session: CallSessionResponse?
     @Published public internal(set) var reconnectionStatus = ReconnectionStatus.connected
     @Published public internal(set) var anonymousParticipantCount: UInt32 = 0
     @Published public internal(set) var participantCount: UInt32 = 0
@@ -372,48 +362,88 @@ public class CallState: ObservableObject {
         }
     }
     
-    internal func update(from response: GetOrCreateCallResponse) {
-        update(from: response.call)
+    internal func update(
+        from response: GetOrCreateCallResponse,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: response.call, file: file, function: function, line: line)
         mergeMembers(response.members)
         ownCapabilities = response.ownCapabilities
     }
     
-    internal func update(from response: JoinCallResponse) {
-        update(from: response.call)
+    internal func update(
+        from response: JoinCallResponse,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: response.call, file: file, function: function, line: line)
         mergeMembers(response.members)
         ownCapabilities = response.ownCapabilities
         statsCollectionInterval = response.statsOptions.reportingIntervalMs / 1000
     }
     
-    internal func update(from response: GetCallResponse) {
-        update(from: response.call)
+    internal func update(
+        from response: GetCallResponse,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: response.call, file: file, function: function, line: line)
         mergeMembers(response.members)
         ownCapabilities = response.ownCapabilities
     }
     
-    internal func update(from response: CallStateResponseFields) {
-        update(from: response.call)
+    internal func update(
+        from response: CallStateResponseFields,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: response.call, file: file, function: function, line: line)
         mergeMembers(response.members)
         ownCapabilities = response.ownCapabilities
     }
     
-    internal func update(from response: UpdateCallResponse) {
-        update(from: response.call)
+    internal func update(
+        from response: UpdateCallResponse,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: response.call, file: file, function: function, line: line)
         mergeMembers(response.members)
         ownCapabilities = response.ownCapabilities
     }
     
-    internal func update(from event: CallCreatedEvent) {
-        update(from: event.call)
+    internal func update(
+        from event: CallCreatedEvent,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: event.call, file: file, function: function, line: line)
         mergeMembers(event.members)
     }
     
-    internal func update(from event: CallRingEvent) {
-        update(from: event.call)
+    internal func update(
+        from event: CallRingEvent,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        update(from: event.call, file: file, function: function, line: line)
         mergeMembers(event.members)
     }
     
-    internal func update(from response: CallResponse) {
+    internal func update(
+        from response: CallResponse,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
         custom = response.custom
         createdAt = response.createdAt
         updatedAt = response.updatedAt
@@ -426,6 +456,7 @@ public class CallState: ObservableObject {
         captioning = response.captioning
         blockedUserIds = Set(response.blockedUserIds.map { $0 })
         team = response.team
+        configureDuration(for: response.session, file: file, function: function, line: line)
         session = response.session
         settings = response.settings
         egress = response.egress
@@ -521,40 +552,66 @@ public class CallState: ObservableObject {
         individualRecordingStatus = egress?.individualRecording?.status == runningStatus
         compositeRecordingStatus = egress?.compositeRecording?.status == runningStatus
     }
-    
-    private func didUpdate(_ session: CallSessionResponse?) {
-        guard let session else { return }
-        if let startedAt = session.startedAt {
-            self.startedAt = startedAt
-        } else if let liveStartedAt = session.liveStartedAt {
-            startedAt = liveStartedAt
-        } else if startedAt == nil {
-            /// If we don't receive a value from the SFU we start the timer on the current date.
-            startedAt = Date()
+
+    private func configureDuration(
+        for session: CallSessionResponse?,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        func reset() {
+            durationCancellable?.cancel()
+            durationCancellable = nil
+
+            duration = 0
+            startedAt = nil
         }
-        
-        if session.liveEndedAt != nil {
-            resetTimer()
+
+        guard let session else {
+            log.debug("[IP]No session.Resetting...", functionName: function, fileName: file, lineNumber: line)
+            return reset()
         }
-    }
-    
-    private func setupDurationTimer() {
-        resetTimer()
-        durationCancellable = DefaultTimer
-            .publish(every: 1.0)
-            .receive(on: DispatchQueue.main)
-            .compactMap { [weak self] _ in
-                if let startedAt = self?.startedAt {
-                    return Date().timeIntervalSince(startedAt)
-                } else {
-                    return 0
-                }
+
+        if session.endedAt != nil {
+            log.debug("[IP]Ended.Resetting...", functionName: function, fileName: file, lineNumber: line)
+            reset()
+        } else if session.liveEndedAt != nil {
+            log.debug("[IP]Live ended.Resetting...", functionName: function, fileName: file, lineNumber: line)
+            reset()
+        } else if let newStartedAt = session.startedAt ?? session.liveStartedAt {
+            guard newStartedAt != startedAt else {
+                log.debug("[IP]startedAt wasn't updated. Skipping...", functionName: function, fileName: file, lineNumber: line)
+                return
             }
-            .assign(to: \.duration, onWeak: self)
-    }
-    
-    private func resetTimer() {
-        durationCancellable?.cancel()
-        durationCancellable = nil
+
+            let now = Date()
+            let newDuration = now.timeIntervalSince(newStartedAt).rounded()
+
+            durationCancellable?.cancel()
+            durationCancellable = nil
+            durationCancellable = DefaultTimer
+                .publish(every: 1.0)
+                .receive(on: DispatchQueue.main)
+                .map { _ in Date().timeIntervalSince(newStartedAt) }
+                .log(.debug) { "[IP]Duration timer updated duration:\(String(format: "%.2f", $0))" }
+                .assign(to: \.duration, onWeak: self)
+
+            self.duration = newDuration
+            self.startedAt = newStartedAt
+            log.debug(
+                "[IP]startedAt:\(newStartedAt) duration:\(newDuration)",
+                functionName: function,
+                fileName: file,
+                lineNumber: line
+            )
+        } else if startedAt == nil {
+            log.debug(
+                "[IP]startedAt:nil session.endedAt:nil session.liveEndedAt:nil.Resetting...",
+                functionName: function,
+                fileName: file,
+                lineNumber: line
+            )
+            reset()
+        }
     }
 }

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -77,6 +77,10 @@ public class CallState: ObservableObject {
 
     @Published public internal(set) var updatedAt: Date = .distantPast
     @Published public internal(set) var startsAt: Date?
+    /// The time when the active call session started.
+    ///
+    /// This value is populated from the backend session payload once the call
+    /// has actually started. It excludes any ringing or pre-join time.
     @Published public internal(set) var startedAt: Date?
     @Published public internal(set) var endedAt: Date?
     @Published public internal(set) var endedBy: User?
@@ -96,6 +100,10 @@ public class CallState: ObservableObject {
     @Published public internal(set) var callSettings: CallSettings = .default
 
     @Published public internal(set) var isCurrentUserScreensharing: Bool = false
+    /// The elapsed duration of the active call session in seconds.
+    ///
+    /// The timer begins only after the backend reports a started session and is
+    /// reset when that session ends. Ringing time is not included.
     @Published public internal(set) var duration: TimeInterval = 0
     @Published public internal(set) var statsReport: CallStatsReport?
 
@@ -568,19 +576,18 @@ public class CallState: ObservableObject {
         }
 
         guard let session else {
-            log.debug("[IP]No session.Resetting...", functionName: function, fileName: file, lineNumber: line)
-            return reset()
+            if startedAt == nil {
+                reset()
+            }
+            return
         }
 
         if session.endedAt != nil {
-            log.debug("[IP]Ended.Resetting...", functionName: function, fileName: file, lineNumber: line)
             reset()
         } else if session.liveEndedAt != nil {
-            log.debug("[IP]Live ended.Resetting...", functionName: function, fileName: file, lineNumber: line)
             reset()
         } else if let newStartedAt = session.startedAt ?? session.liveStartedAt {
             guard newStartedAt != startedAt else {
-                log.debug("[IP]startedAt wasn't updated. Skipping...", functionName: function, fileName: file, lineNumber: line)
                 return
             }
 
@@ -593,24 +600,11 @@ public class CallState: ObservableObject {
                 .publish(every: 1.0)
                 .receive(on: DispatchQueue.main)
                 .map { _ in Date().timeIntervalSince(newStartedAt) }
-                .log(.debug) { "[IP]Duration timer updated duration:\(String(format: "%.2f", $0))" }
                 .assign(to: \.duration, onWeak: self)
 
             self.duration = newDuration
             self.startedAt = newStartedAt
-            log.debug(
-                "[IP]startedAt:\(newStartedAt) duration:\(newDuration)",
-                functionName: function,
-                fileName: file,
-                lineNumber: line
-            )
         } else if startedAt == nil {
-            log.debug(
-                "[IP]startedAt:nil session.endedAt:nil session.liveEndedAt:nil.Resetting...",
-                functionName: function,
-                fileName: file,
-                lineNumber: line
-            )
             reset()
         }
     }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -131,7 +131,10 @@ extension Call.StateMachine.Stage {
 
             try Task.checkCancellation()
 
+            let sessionID = await call.callController.sessionID()
+            await MainActor.run { call.state.sessionId = sessionID }
             await call.state.update(from: response)
+            call.update(recordingState: response.call.recording ? .recording : .noRecording)
 
             try Task.checkCancellation()
 

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -58,7 +58,6 @@ class CallController: @unchecked Sendable {
     private var cachedLocation: String?
     private let initialCallSettings: CallSettings
 
-    private var joinCallResponseFetchObserver: AnyCancellable?
     private var webRTCClientSessionIDObserver: AnyCancellable?
     private var webRTCClientStateObserver: AnyCancellable?
     private var webRTCParticipantsObserver: AnyCancellable?
@@ -105,6 +104,8 @@ class CallController: @unchecked Sendable {
         }
     }
 
+    func sessionID() async -> String { await webRTCCoordinator.stateAdapter.sessionID }
+
     /// Joins a call with the provided information and join source.
     /// The returned `JoinCallResponse` is emitted only after the call flow has
     /// reached the connected state.
@@ -133,20 +134,9 @@ class CallController: @unchecked Sendable {
         source: JoinSource,
         policy: WebRTCJoinPolicy = .default
     ) async throws -> JoinCallResponse {
-        joinCallResponseFetchObserver?.cancel()
-        joinCallResponseFetchObserver = nil
-
         // Each join attempt uses a fresh delivery subject so a failed attempt
         // cannot complete future retries on the same controller.
         let joinCallResponseSubject = PassthroughSubject<JoinCallResponse, Error>()
-        joinCallResponseFetchObserver = joinCallResponseSubject
-            .compactMap { $0 }
-            .sinkTask(storeIn: disposableBag) { [weak self] in await self?.didFetch($0) }
-
-        defer {
-            joinCallResponseFetchObserver?.cancel()
-            joinCallResponseFetchObserver = nil
-        }
 
         try await webRTCCoordinator.connect(
             create: create,
@@ -659,16 +649,6 @@ class CallController: @unchecked Sendable {
             return cachedLocation
         }
         return try await LocationFetcher.getLocation()
-    }
-
-    private func didFetch(_ response: JoinCallResponse) async {
-        let sessionId = await webRTCCoordinator.stateAdapter.sessionID
-        Task(disposableBag: disposableBag) { @MainActor [weak self] in
-            self?.call?.state.sessionId = sessionId
-            self?.call?.update(recordingState: response.call.recording ? .recording : .noRecording)
-            self?.call?.state.ownCapabilities = response.ownCapabilities
-            self?.call?.state.update(from: response)
-        }
     }
 
     private func webRTCClientDidUpdateStage(

--- a/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
@@ -9,10 +9,19 @@ import SwiftUI
 /// A view that presents the call's duration and recording state.
 public struct CallDurationView: View {
 
-    var showRingingDuration: Bool
+    private let showRingingDuration: Bool
 
     @ObservedObject private var viewModel: CallViewModel
 
+    /// Creates a duration view for the provided call view model.
+    ///
+    /// - Parameters:
+    ///   - viewModel: The view model that supplies the current calling state and
+    ///     in-call duration updates.
+    ///   - showRingingDuration: When `true`, the view shows a locally tracked
+    ///     timer while the call is still ringing in the outgoing state. Once the
+    ///     call is connected, the view always switches to the backend-provided
+    ///     call duration.
     public init(_ viewModel: CallViewModel, showRingingDuration: Bool = true) {
         self.viewModel = viewModel
         self.showRingingDuration = showRingingDuration
@@ -49,8 +58,8 @@ private struct InCallDurationView: View {
     @Injected(\.colors) private var colors: Colors
     @Injected(\.images) private var images: Images
 
-    var viewModel: CallViewModel
-    @State var duration: TimeInterval
+    let viewModel: CallViewModel
+    @State private var duration: TimeInterval
 
     init(_ viewModel: CallViewModel) {
         self.viewModel = viewModel
@@ -72,8 +81,8 @@ private struct InCallDurationView: View {
 }
 
 private struct RingingCallDurationView: View {
-    var startedRingingAt: Date
-    @State var duration: TimeInterval
+    private let startedRingingAt: Date
+    @State private var duration: TimeInterval
 
     init(_ startRingingAt: Date) {
         self.startedRingingAt = startRingingAt
@@ -91,8 +100,8 @@ private struct DurationView<IconView: View>: View {
     @Injected(\.colors) private var colors: Colors
     @Injected(\.formatters.mediaDuration) private var formatter: MediaDurationFormatter
 
-    var duration: TimeInterval
-    var iconView: IconView
+    let duration: TimeInterval
+    private let iconView: IconView
 
     init(duration: TimeInterval, @ViewBuilder iconView: () -> IconView) {
         self.duration = duration

--- a/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
@@ -9,66 +9,111 @@ import SwiftUI
 /// A view that presents the call's duration and recording state.
 public struct CallDurationView: View {
 
-    @Injected(\.colors) private var colors: Colors
-    @Injected(\.fonts) private var fonts: Fonts
-    @Injected(\.images) private var images: Images
-    @Injected(\.formatters.mediaDuration) private var formatter: MediaDurationFormatter
+    var showRingingDuration: Bool
 
-    @State private var duration: TimeInterval
     @ObservedObject private var viewModel: CallViewModel
 
-    @MainActor
-    public init(_ viewModel: CallViewModel) {
+    public init(_ viewModel: CallViewModel, showRingingDuration: Bool = true) {
         self.viewModel = viewModel
-        _duration = .init(initialValue: viewModel.call?.state.duration ?? 0)
+        self.showRingingDuration = showRingingDuration
     }
 
     public var body: some View {
-        Group {
-            if duration > 0, let formattedDuration = formatter.format(duration) {
-                HStack(spacing: 4) {
-                    iconView
-                        .foregroundColor(foregroundColor)
-
-                    TimeView(formattedDuration)
-                        .layoutPriority(2)
-                }
-                .padding(.horizontal)
-                .padding(.vertical, 4)
-                .background(Color(colors.participantBackground))
-                .clipShape(Capsule())
-            } else {
-                EmptyView()
-            }
-        }
-        .onReceive(viewModel.call?.state.$duration) { self.duration = $0 }
-        .accessibility(identifier: accessibilityIdentifier)
+        contentView
     }
 
     // MARK: - Private Helpers
-
-    private var foregroundColor: Color {
-        viewModel.recordingState == .recording
-            ? colors.inactiveCallControl
-            : colors.onlineIndicatorColor
-    }
-
-    @ViewBuilder
-    private var iconView: some View {
-        if viewModel.recordingState == .recording {
-            images.recordIcon
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 12)
-        } else {
-            EmptyView()
-        }
-    }
 
     private var accessibilityIdentifier: String {
         viewModel.recordingState == .recording
             ? "recordingView"
             : "callDurationView"
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        switch viewModel.callingState {
+        case .outgoing where showRingingDuration:
+            RingingCallDurationView(Date())
+                .accessibility(identifier: accessibilityIdentifier)
+        case .inCall:
+            InCallDurationView(viewModel)
+                .accessibility(identifier: accessibilityIdentifier)
+        default:
+            EmptyView()
+        }
+    }
+}
+
+private struct InCallDurationView: View {
+    @Injected(\.colors) private var colors: Colors
+    @Injected(\.images) private var images: Images
+
+    var viewModel: CallViewModel
+    @State var duration: TimeInterval
+
+    init(_ viewModel: CallViewModel) {
+        self.viewModel = viewModel
+        self._duration = .init(initialValue: viewModel.call?.state.duration ?? 0)
+    }
+
+    var body: some View {
+        DurationView(duration: duration) {
+            if viewModel.recordingState == .recording {
+                images.recordIcon
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 12)
+                    .foregroundColor(colors.inactiveCallControl)
+            }
+        }
+        .onReceive(viewModel.call?.state.$duration) { self.duration = $0 }
+    }
+}
+
+private struct RingingCallDurationView: View {
+    var startedRingingAt: Date
+    @State var duration: TimeInterval
+
+    init(_ startRingingAt: Date) {
+        self.startedRingingAt = startRingingAt
+        self._duration = .init(initialValue: Date().timeIntervalSince(startRingingAt))
+    }
+
+    var body: some View {
+        DurationView(duration: duration) { EmptyView() }
+            .onReceive(DefaultTimer.publish(every: 1).receive(on: DispatchQueue.main)) { _ in duration += 1 }
+    }
+}
+
+private struct DurationView<IconView: View>: View {
+
+    @Injected(\.colors) private var colors: Colors
+    @Injected(\.formatters.mediaDuration) private var formatter: MediaDurationFormatter
+
+    var duration: TimeInterval
+    var iconView: IconView
+
+    init(duration: TimeInterval, @ViewBuilder iconView: () -> IconView) {
+        self.duration = duration
+        self.iconView = iconView()
+    }
+
+    var body: some View {
+        if duration > 0, let formattedDuration = formatter.format(duration) {
+            HStack(spacing: 4) {
+                iconView
+
+                TimeView(formattedDuration)
+                    .layoutPriority(2)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 4)
+            .background(Color(colors.participantBackground))
+            .clipShape(Capsule())
+        } else {
+            EmptyView()
+        }
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/CallDurationView.swift
@@ -86,7 +86,7 @@ private struct RingingCallDurationView: View {
 
     init(_ startRingingAt: Date) {
         self.startedRingingAt = startRingingAt
-        self._duration = .init(initialValue: Date().timeIntervalSince(startRingingAt))
+        self._duration = .init(initialValue: Date().timeIntervalSince(startRingingAt).rounded())
     }
 
     var body: some View {

--- a/StreamVideoSwiftUITests/CallView/CallDurationView_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/CallDurationView_Tests.swift
@@ -24,6 +24,7 @@ final class CallDurationView_Tests: StreamVideoUITestCase, @unchecked Sendable {
             members: [],
             ring: true
         )
+        viewModel.callingState = .inCall
     }
 
     override func tearDown() async throws {
@@ -31,7 +32,7 @@ final class CallDurationView_Tests: StreamVideoUITestCase, @unchecked Sendable {
         try await super.tearDown()
     }
 
-    // MARK: - Rendering based on viewModel.call.state.duration
+    // MARK: - Rendering based on active call duration
 
     func test_callDurationView_durationIsLessThanZero_viewWasConfiguredCorrectly() throws {
         viewModel.call?.state.duration = -100

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -373,34 +373,37 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
     // MARK: - Duration
 
     func test_call_duration() async throws {
-        // Given
         let call = streamVideo?.call(callType: callType, callId: callId)
-        let startDate = Date()
-        let callResponse = mockResponseBuilder.makeCallResponse(
-            cid: callCid,
-            liveStartedAt: startDate
+        let startedAt = Date(timeIntervalSinceNow: -75)
+
+        call?.state.update(
+            from: CallResponse.dummy(
+                cid: callCid,
+                session: .dummy(
+                    startedAt: startedAt
+                )
+            )
         )
 
-        // When
-        call?.state.update(from: callResponse)
-        try await waitForCallEvent(nanoseconds: 1_500_000_000)
-
-        // Then
-        var duration = call?.state.duration ?? 0
-        XCTAssertTrue(Int(duration) >= 1)
-        XCTAssertEqual(startDate, call?.state.startedAt)
-
-        // When
-        let endCallResponse = mockResponseBuilder.makeCallResponse(
-            cid: callCid,
-            liveStartedAt: startDate,
-            liveEndedAt: Date()
+        XCTAssertEqual(call?.state.startedAt, startedAt)
+        XCTAssertEqual(
+            call?.state.duration ?? 0,
+            Date().timeIntervalSince(startedAt),
+            accuracy: 1
         )
-        call?.state.update(from: endCallResponse)
 
-        // Then
-        duration = call?.state.duration ?? 0
-        XCTAssertTrue(Int(duration) >= 1)
+        call?.state.update(
+            from: CallResponse.dummy(
+                cid: callCid,
+                session: .dummy(
+                    endedAt: Date(),
+                    startedAt: startedAt
+                )
+            )
+        )
+
+        XCTAssertNil(call?.state.startedAt)
+        XCTAssertEqual(call?.state.duration, 0)
     }
 
     // MARK: - setIncomingVideoQualitySettings

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -221,6 +221,85 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(subject.callSettings, initialCallSettings)
     }
 
+    func test_update_fromCallResponse_withoutStartedSession_keepsDurationReset() {
+        let subject = CallState(.dummy())
+
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy()
+            )
+        )
+
+        XCTAssertNil(subject.startedAt)
+        XCTAssertEqual(subject.duration, 0)
+    }
+
+    func test_update_fromCallResponse_withStartedAt_usesActualCallStart() {
+        let subject = CallState(.dummy())
+        let startedAt = Date(timeIntervalSinceNow: -95)
+
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(
+                    liveStartedAt: Date(timeIntervalSinceNow: -120),
+                    startedAt: startedAt
+                )
+            )
+        )
+
+        XCTAssertEqual(subject.startedAt, startedAt)
+        XCTAssertEqual(
+            subject.duration,
+            Date().timeIntervalSince(startedAt),
+            accuracy: 1
+        )
+    }
+
+    func test_update_fromCallResponse_withOnlyLiveStartedAt_usesLiveStartedAt() {
+        let subject = CallState(.dummy())
+        let liveStartedAt = Date(timeIntervalSinceNow: -42)
+
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(
+                    liveStartedAt: liveStartedAt
+                )
+            )
+        )
+
+        XCTAssertEqual(subject.startedAt, liveStartedAt)
+        XCTAssertEqual(
+            subject.duration,
+            Date().timeIntervalSince(liveStartedAt),
+            accuracy: 1
+        )
+    }
+
+    func test_update_fromCallResponse_withEndedSession_resetsDuration() {
+        let subject = CallState(.dummy())
+        let startedAt = Date(timeIntervalSinceNow: -30)
+
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(
+                    startedAt: startedAt
+                )
+            )
+        )
+
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(
+                    endedAt: Date(),
+                    startedAt: startedAt
+                )
+            )
+        )
+
+        XCTAssertNil(subject.startedAt)
+        XCTAssertEqual(subject.duration, 0)
+    }
+
     // MARK: - Private helpers
 
     private func assertParticipantsUpdate(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1597/bugcall-duration-bug-while-joining

### 🎯 Goal

Separate ringing duration from actual in-call duration while keeping `CallDurationView`
behavior consistent for connected calls.

### 📝 Summary

- Update `CallState` so `duration` and `startedAt` reflect only the active call
  session, not the ringing/joining phase.
- Preserve the previous connected-call experience in `CallDurationView`, while
  allowing outgoing ringing UI to show a separate local ringing timer.
- Align join/joined state handling so session state, capabilities, and call
  settings are applied in the correct lifecycle stages.
- Add doc comments and expand test coverage around duration semantics and the
  SwiftUI duration UI.
- Include related reliability fixes around joining, CallKit/state restoration,
  SFU migration, and WebRTC lifecycle handling that support the timing changes.

### 🛠 Implementation

The core change is in `CallState`: the duration timer is now configured from the
session’s actual start timestamps (`startedAt`, with `liveStartedAt` as a
fallback) and is reset when the session ends. This prevents the ringing phase
from being counted as call duration.

On the SwiftUI side, `CallDurationView` now distinguishes between outgoing
ringing and in-call rendering. While the call is still ringing, it can show a
local ringing timer. Once the call transitions to `.inCall`, it continues to
render the backend-driven call duration exactly as before, including the
recording-state presentation.

The branch also moves some join-related side effects into the appropriate state
machine stages so session id, call settings, own capabilities, and related UI
state are updated at the right point in the join lifecycle. Tests were updated
or added in both `StreamVideo` and `StreamVideoSwiftUI` to cover the new
duration semantics and preserve the connected-call UX.

### 🎨 Showcase

Not applicable.

|  Before  |  After  |
| -------- | ------- |
|  Ringing time and call time were conflated in call duration handling.  |  Ringing duration and actual call duration are tracked separately, while connected-call UI remains unchanged.  |

### 🧪 Manual Testing Notes

- Start an outgoing ringing call and verify the timer advances while the call is
  still in the outgoing/ringing state.
- Accept/join the call and verify the visible duration reflects only the actual
  connected call time.
- Verify `CallDurationView` still looks the same during an active call,
  including when recording is enabled.
- Reject/end the call and verify the duration resets as expected.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Separate duration UI for ringing vs in-call, with optional ringing duration display and a shared, styled duration component.

* **Improvements**
  * More accurate and reliable call duration start/stop and timer behavior across call states; outgoing ringing time no longer included in call duration.
  * Call join now more reliably updates session ID and recording status so displayed call/recording info is consistent.

* **Tests**
  * Added/updated tests to validate duration and session-timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->