### PR TITLE
[Enhancement]Add call join interception hook before final call entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Added optional leave reasons to `Call.leave` and `CallViewModel.hangUp`, and propagated them through the WebRTC leave flow so SFU leave requests include explicit end-of-call context. [#1100](https://github.com/GetStream/stream-video-swift/pull/1100)
-- Added an optional join interception hook so apps can delay or abort call entry after the join response is applied locally. [#1107](https://github.com/GetStream/stream-video-swift/pull/1107)
+- Added an optional join interception hook so apps can delay or abort call entry after the join response is applied locally. [#1108](https://github.com/GetStream/stream-video-swift/pull/1108)
 
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Added optional leave reasons to `Call.leave` and `CallViewModel.hangUp`, and propagated them through the WebRTC leave flow so SFU leave requests include explicit end-of-call context. [#1100](https://github.com/GetStream/stream-video-swift/pull/1100)
+- Added an optional join interception hook so apps can delay or abort call entry after the join response is applied locally. [#1107](https://github.com/GetStream/stream-video-swift/pull/1107)
 
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/CallJoinInterceptor.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/CallJoinInterceptor.swift
@@ -1,0 +1,57 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamVideo
+import SwiftUI
+
+extension AppEnvironment {
+
+    /// Debug-only toggle for enabling the new capturing pipeline path.
+    enum CallJoinInterceptor: Hashable, Debuggable {
+        case none, synchronised
+
+        var title: String {
+            switch self {
+            case .none:
+                return "None"
+            case .synchronised:
+                return "Synchronised"
+            }
+        }
+
+        @MainActor
+        var value: CallJoinIntercepting? {
+            switch self {
+            case .none:
+                return nil
+            case .synchronised:
+                return DemoCallJoinInterceptor()
+            }
+        }
+    }
+
+    /// Default to enabled in debug builds so the pipeline is exercised during development.
+    nonisolated(unsafe) static var callJoinInterceptor: CallJoinInterceptor = .none
+}
+
+extension DebugMenu {
+
+    struct CallJoinInterceptorSelector: View {
+
+        @State private var value = AppEnvironment.callJoinInterceptor {
+            didSet { AppEnvironment.callJoinInterceptor = value }
+        }
+
+        var body: some View {
+            ItemMenuView(
+                items: [.none, .synchronised],
+                currentValue: value,
+                label: "Call Join Interceptor",
+                availableAfterLogin: true,
+                updater: { value = $0 }
+            )
+        }
+    }
+}

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
@@ -16,7 +16,8 @@ extension AppEnvironment {
     nonisolated(unsafe) static var featureFlags: [FeatureFlag] = [
         .init { .init(DebugMenu.VideoProcessingPipelineToggleView()) },
         .init { .init(DebugMenu.CapturingPipelineToggleView()) },
-        .init { .init(DebugMenu.VideoRenderingMenuView()) }
+        .init { .init(DebugMenu.VideoRenderingMenuView()) },
+        .init { .init(DebugMenu.CallJoinInterceptorSelector()) }
     ]
 }
 

--- a/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
+++ b/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
@@ -9,9 +9,11 @@ import StreamVideoSwiftUI
 
 /// Demo interceptor that waits until another participant announces readiness
 /// through a custom event before the local join flow finishes.
-final class DemoCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
+@MainActor
+final class DemoCallJoinInterceptor: CallJoinIntercepting {
     @Injected(\.streamVideo) private var streamVideo
 
+    private let disposableBag = DisposableBag()
     private var ringingCallCancellable: AnyCancellable?
     private var customEventCancellable: AnyCancellable?
     private let customEventKey: String
@@ -32,7 +34,9 @@ final class DemoCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
                 .$ringingCall
                 .receive(on: DispatchQueue.main)
                 .removeDuplicates { $0?.cId == $1?.cId }
-                .sink { [weak self] in self?.didUpdate(ringingCall: $0) }
+                .sinkTask(storeIn: disposableBag) { @MainActor [weak self] ringingCall in
+                    self?.didUpdate(ringingCall: ringingCall)
+                }
         }
     }
 
@@ -77,8 +81,12 @@ final class DemoCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
             .filter { [currentUserID] in $0 != currentUserID }
             .log(.debug) { "Call presence event was received for userID:\($0)" }
             .map { _ in true }
-            .sink { [weak self] in self?.hasOtherReadyParticipants.send($0) }
-        
+            .sinkTask(
+                storeIn: disposableBag
+            ) { @MainActor [weak self] didReceiveReadyParticipant in
+                self?.hasOtherReadyParticipants.send(didReceiveReadyParticipant)
+            }
+
         log.debug("Call presence events observation has started.")
     }
 

--- a/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
+++ b/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
@@ -44,6 +44,12 @@ final class DemoCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
     /// The demo intentionally ignores send and wait failures so the example
     /// never blocks the UI forever when the readiness handshake is unavailable.
     func callReadyToJoin(_ call: Call) async throws {
+        // If the cancellable is nil it means that this call isn't a ringing
+        // call and thus we take no action.
+        guard customEventCancellable != nil else {
+            return
+        }
+
         do {
             try await call.sendCustomEvent([customEventKey: .string(currentUserID)])
             log.debug("Call presence event was sent for userId:\(currentUserID). Waiting for others.")

--- a/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
+++ b/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
@@ -1,0 +1,88 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+import StreamVideo
+import StreamVideoSwiftUI
+
+/// Demo interceptor that waits until another participant announces readiness
+/// through a custom event before the local join flow finishes.
+final class DemoCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
+    @Injected(\.streamVideo) private var streamVideo
+
+    private var ringingCallCancellable: AnyCancellable?
+    private var customEventCancellable: AnyCancellable?
+    private let customEventKey: String
+    private var currentUserID: String = ""
+
+    private let hasOtherReadyParticipants: CurrentValueSubject<Bool, Never> = .init(false)
+
+    init(
+        customEventKey: String = "participant.ready"
+    ) {
+        self.customEventKey = customEventKey
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.currentUserID = streamVideo.state.user.id
+            self.ringingCallCancellable = streamVideo
+                .state
+                .$ringingCall
+                .receive(on: DispatchQueue.main)
+                .removeDuplicates { $0?.cId == $1?.cId }
+                .sink { [weak self] in self?.didUpdate(ringingCall: $0) }
+        }
+    }
+
+    // MARK: - CallJoinIntercepting
+
+    /// Sends the local readiness marker and waits until another participant
+    /// sends the same signal.
+    ///
+    /// The demo intentionally ignores send and wait failures so the example
+    /// never blocks the UI forever when the readiness handshake is unavailable.
+    func callReadyToJoin(_ call: Call) async throws {
+        do {
+            try await call.sendCustomEvent([customEventKey: .string(currentUserID)])
+            log.debug("Call presence event was sent for userId:\(currentUserID). Waiting for others.")
+        } catch {
+            log.error("Call presence event for userId:\(currentUserID) failed.", error: error)
+        }
+
+        _ = try? await hasOtherReadyParticipants
+            .filter { $0 }
+            .nextValue()
+    }
+
+    // MARK: - Private Helpers
+
+    private func didUpdate(ringingCall: Call?) {
+        cancelCustomEventObservation()
+
+        guard let ringingCall else {
+            return
+        }
+
+        customEventCancellable = ringingCall
+            .eventPublisher(for: CustomVideoEvent.self)
+            .compactMap { [customEventKey] in $0.custom[customEventKey]?.stringValue }
+            .filter { [currentUserID] in $0 != currentUserID }
+            .log(.debug) { "Call presence event was received for userID:\($0)" }
+            .map { _ in true }
+            .sink { [weak self] in self?.hasOtherReadyParticipants.send($0) }
+        
+        log.debug("Call presence events observation has started.")
+    }
+
+    private func cancelCustomEventObservation() {
+        guard customEventCancellable != nil else {
+            return
+        }
+        customEventCancellable?.cancel()
+        customEventCancellable = nil
+        hasOtherReadyParticipants.send(false)
+        log.debug("Call presence events observation was cancelled.")
+    }
+}

--- a/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
@@ -21,6 +21,7 @@ internal struct DemoCallContainerView: View {
         let callViewModel = CallViewModel()
         callViewModel.participantAutoLeavePolicy = AppEnvironment.autoLeavePolicy.policy
         callViewModel.isPictureInPictureEnabled = AppEnvironment.pictureInPictureIntegration == .enabled
+        callViewModel.callJoinInterceptor = DemoCallJoinInterceptor()
         _viewModel = StateObject(wrappedValue: callViewModel)
         _chatViewModel = StateObject(wrappedValue: .init(callViewModel))
         self.callId = callId

--- a/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
@@ -21,7 +21,7 @@ internal struct DemoCallContainerView: View {
         let callViewModel = CallViewModel()
         callViewModel.participantAutoLeavePolicy = AppEnvironment.autoLeavePolicy.policy
         callViewModel.isPictureInPictureEnabled = AppEnvironment.pictureInPictureIntegration == .enabled
-        callViewModel.callJoinInterceptor = DemoCallJoinInterceptor()
+        callViewModel.callJoinInterceptor = AppEnvironment.callJoinInterceptor.value
         _viewModel = StateObject(wrappedValue: callViewModel)
         _chatViewModel = StateObject(wrappedValue: .init(callViewModel))
         self.callId = callId

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -138,6 +138,12 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     }
 
     /// Joins the current call.
+    ///
+    /// The SDK resolves the join source, performs the backend join request,
+    /// updates local call state, and then completes the joined transition. When
+    /// `joinInterceptor` is provided, the SDK waits for it after the join
+    /// response has been applied locally but before the call is marked as the
+    /// active call.
     /// - Parameters:
     ///  - create: whether the call should be created if it doesn't exist.
     ///  - options: configuration options for the call.
@@ -145,7 +151,11 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     ///  - notify: whether the participants should be notified about the call.
     ///  - callSettings: optional call settings.
     ///  - policy: controls when the join request is considered complete.
-    /// - Throws: An error if the call could not be joined.
+    ///  - joinInterceptor: An optional interceptor that can delay or abort the
+    ///    final joined transition after the join response has been received and
+    ///    applied to local state.
+    /// - Throws: An error if the call could not be joined or if
+    ///   `joinInterceptor` throws.
     @discardableResult
     public func join(
         create: Bool = false,
@@ -153,7 +163,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         ring: Bool = false,
         notify: Bool = false,
         callSettings: CallSettings? = nil,
-        policy: WebRTCJoinPolicy = .default
+        policy: WebRTCJoinPolicy = .default,
+        joinInterceptor: CallJoinIntercepting? = nil
     ) async throws -> JoinCallResponse {
         /// Determines the source from which the join action was initiated.
         ///
@@ -222,7 +233,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
                                 notify: notify,
                                 source: joinSource,
                                 deliverySubject: deliverySubject,
-                                policy: policy
+                                policy: policy,
+                                joinInterceptor: joinInterceptor
                             )
                         )
                     )

--- a/Sources/StreamVideo/CallConfiguration.swift
+++ b/Sources/StreamVideo/CallConfiguration.swift
@@ -21,13 +21,18 @@ enum CallConfiguration {
         /// Timeout duration for rejecting a call in seconds.
         var reject: TimeInterval
 
+        /// Timeout duration for a join interceptor to delay the final joined
+        /// transition before the SDK proceeds without it.
+        var joinInterception: TimeInterval
+
         /// Timeout values for authentication in production environment.
         ///
         /// These values are used when the app is running in production mode.
         static let production = Timeout(
             join: 30,
             accept: 10,
-            reject: 10
+            reject: 10,
+            joinInterception: 5
         )
 
         #if STREAM_TESTS
@@ -38,7 +43,8 @@ enum CallConfiguration {
         static let testing = Timeout(
             join: 10,
             accept: 10,
-            reject: 10
+            reject: 10,
+            joinInterception: 10
         )
         #endif
     }

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -237,7 +237,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 }
 
                 if streamVideo.state.ringingCall?.cId != callEntry.call.cId {
-                    Task(disposableBag: disposableBag) { [weak self] in
+                    Task(disposableBag: disposableBag) { @MainActor [weak self] in
                         self?.streamVideo?.state.ringingCall = callEntry.call
                     }
                 }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -85,6 +85,15 @@ extension Call.StateMachine.Stage {
                 do {
                     let response = try await executeJoin(call: call, input: input)
                     transitionOrError(.joined(context, response: response))
+                } catch let error as CallJoinInterceptionError {
+                    // Interception failures are terminal for this join attempt,
+                    // so they are surfaced to the original caller without
+                    // entering the retry branch below.
+                    // Record the failure in the tracing pipeline before the
+                    // stage transitions into the error state.
+                    await call.callController.trace(.init(error))
+                    input.deliverySubject.send(completion: .failure(error))
+                    transitionErrorOrLog(error)
                 } catch {
                     var input = input
                     input.currentNumberOfRetries += 1
@@ -108,6 +117,10 @@ extension Call.StateMachine.Stage {
         /// Executes the join call operation with retry logic.
         /// The call result is returned both as a stage-local response and through the
         /// shared `join` completion channel.
+        ///
+        /// Before the stage publishes the join result, it gives the optional
+        /// join interceptor a bounded window to perform app-specific readiness
+        /// work.
         ///
         /// - Parameters:
         ///   - call: The call to join.
@@ -141,6 +154,16 @@ extension Call.StateMachine.Stage {
 
             try Task.checkCancellation()
 
+            // Use the shared call configuration so production and test builds
+            // can tune interception timing independently.
+            try await interceptJoinIfNeeded(
+                input.joinInterceptor,
+                call: call,
+                timeout: CallConfiguration.timeout.joinInterception
+            )
+
+            try Task.checkCancellation()
+
             await Task(disposableBag: disposableBag) { @MainActor [weak streamVideo] in
                 streamVideo?.state.activeCall = call
             }.value
@@ -152,6 +175,48 @@ extension Call.StateMachine.Stage {
             call.callController.observeWebRTCStateUpdated()
 
             return response
+        }
+
+        /// Runs the optional join interceptor without letting it block the join
+        /// flow indefinitely.
+        ///
+        /// If the interceptor completes first, the join flow continues
+        /// immediately. If the timeout completes first, the interceptor is
+        /// cancelled and the join continues. If the interceptor throws before
+        /// timing out, the error is wrapped and surfaced to the caller.
+        ///
+        /// - Parameters:
+        ///   - interceptor: The interceptor provided by the integrator.
+        ///   - call: The call that is about to become active.
+        ///   - timeout: The maximum number of seconds the interceptor may delay
+        ///     the join flow.
+        /// - Throws: A `CallJoinInterceptionError` when the interceptor throws.
+        private func interceptJoinIfNeeded(
+            _ interceptor: CallJoinIntercepting?,
+            call: Call,
+            timeout: TimeInterval
+        ) async throws {
+            guard let interceptor else {
+                return
+            }
+
+            do {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask {
+                        try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    }
+
+                    group.addTask {
+                        try await interceptor.callReadyToJoin(call)
+                    }
+
+                    try await group.next()
+
+                    group.cancelAll()
+                }
+            } catch {
+                throw CallJoinInterceptionError(with: error)
+            }
         }
     }
 }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -93,6 +93,7 @@ extension Call.StateMachine.Stage {
                     // stage transitions into the error state.
                     await call.callController.trace(.init(error))
                     input.deliverySubject.send(completion: .failure(error))
+                    call.leave(reason: "join.interception.failed")
                     transitionErrorOrLog(error)
                 } catch {
                     var input = input
@@ -200,22 +201,30 @@ extension Call.StateMachine.Stage {
                 return
             }
 
-            do {
-                try await withThrowingTaskGroup(of: Void.self) { group in
-                    group.addTask {
-                        try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            let timeoutInNanoseconds = timeout > 0
+                ? UInt64(timeout * 1_000_000_000)
+                : 0
+
+            let result = await withFirstTaskCompleted(
+                {
+                    try await interceptor.callReadyToJoin(call)
+                },
+                {
+                    if timeoutInNanoseconds > 0 {
+                        try await Task.sleep(nanoseconds: timeoutInNanoseconds)
                     }
-
-                    group.addTask {
-                        try await interceptor.callReadyToJoin(call)
-                    }
-
-                    try await group.next()
-
-                    group.cancelAll()
                 }
-            } catch {
+            )
+
+            switch result {
+            case .first(.success):
+                return
+            case let .first(.failure(error)):
                 throw CallJoinInterceptionError(with: error)
+            case .second:
+                return
+            case .cancelled:
+                throw CancellationError()
             }
         }
     }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+Stage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+Stage.swift
@@ -33,6 +33,9 @@ extension Call.StateMachine {
                 var source: JoinSource
                 var deliverySubject: CurrentValueSubject<JoinCallResponse?, Error>
                 var policy: WebRTCJoinPolicy = .default
+                /// Optional hook that runs after local join state has been
+                /// updated and before the joined transition is finalized.
+                var joinInterceptor: CallJoinIntercepting?
 
                 var currentNumberOfRetries = 0
                 var retryPolicy: RetryPolicy = .fastAndSimple

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -564,6 +564,17 @@ class CallController: @unchecked Sendable {
         await webRTCCoordinator.didPerform(action)
     }
 
+    // MARK: - Call tracing
+
+    /// Records a call-level trace that should be forwarded into the WebRTC
+    /// tracing pipeline.
+    ///
+    /// This is used for call flow events that are not emitted by a lower-level
+    /// WebRTC component directly, such as join interception failures.
+    func trace(_ trace: WebRTCTrace) async {
+        await webRTCCoordinator.trace(trace)
+    }
+
     // MARK: - private
 
     private func handleParticipantsUpdated() {

--- a/Sources/StreamVideo/Utils/CallJoinIntercepting.swift
+++ b/Sources/StreamVideo/Utils/CallJoinIntercepting.swift
@@ -39,10 +39,13 @@ extension WebRTCTrace {
     init(
         _ error: CallJoinInterceptionError
     ) {
+        let redactedError = error.underlyingError ?? error
         self.init(
             id: nil,
             tag: "call.join.interception.failed",
-            data: .init(["error": "\(error)"])
+            data: .init([
+                "errorType": String(describing: type(of: redactedError))
+            ])
         )
     }
 }

--- a/Sources/StreamVideo/Utils/CallJoinIntercepting.swift
+++ b/Sources/StreamVideo/Utils/CallJoinIntercepting.swift
@@ -44,7 +44,7 @@ extension WebRTCTrace {
             id: nil,
             tag: "call.join.interception.failed",
             data: .init([
-                "errorType": String(describing: type(of: redactedError))
+                "error": String(describing: redactedError)
             ])
         )
     }

--- a/Sources/StreamVideo/Utils/CallJoinIntercepting.swift
+++ b/Sources/StreamVideo/Utils/CallJoinIntercepting.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An error emitted when a join interceptor prevents a call from finishing
+/// its transition into the joined state.
+///
+/// The original reason is preserved in `underlyingError`, allowing integrators
+/// to distinguish between their own domain error and an SDK-generated wrapper.
+public final class CallJoinInterceptionError: ClientError, @unchecked Sendable {}
+
+/// Allows integrators to inspect, delay, or veto the final step of joining a
+/// call.
+///
+/// `Call.join(create:options:ring:notify:callSettings:policy:joinInterceptor:)`
+/// invokes this interceptor after the backend join request has succeeded and
+/// the local call state has been updated, but before the SDK marks the call as
+/// active and completes the join flow.
+public protocol CallJoinIntercepting: Sendable {
+
+    /// Performs application-specific work before the SDK completes a call join.
+    ///
+    /// Return normally to let the call continue into the joined state. Throw an
+    /// error to abort the join flow and surface that failure back to the
+    /// original join caller.
+    ///
+    /// - Parameter call: The call whose join response has already been applied
+    ///   to local state and is about to become active.
+    func callReadyToJoin(_ call: Call) async throws
+}
+
+extension WebRTCTrace {
+    /// Creates a trace entry for a join interception failure.
+    ///
+    /// - Parameter error: The wrapped interception error that terminated the
+    ///   join flow.
+    init(
+        _ error: CallJoinInterceptionError
+    ) {
+        self.init(
+            id: nil,
+            tag: "call.join.interception.failed",
+            data: .init(["error": "\(error)"])
+        )
+    }
+}

--- a/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+FirstTaskCompleted.swift
+++ b/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+FirstTaskCompleted.swift
@@ -127,8 +127,12 @@ private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Senda
 
     func setFirstTask(_ task: Task<Void, Never>) {
         let shouldCancel = queue.sync { () -> Bool in
+            guard resolvedResult == nil else {
+                return true
+            }
+
             firstTask = task
-            return resolvedResult != nil
+            return false
         }
 
         if shouldCancel {
@@ -138,8 +142,12 @@ private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Senda
 
     func setSecondTask(_ task: Task<Void, Never>) {
         let shouldCancel = queue.sync { () -> Bool in
+            guard resolvedResult == nil else {
+                return true
+            }
+
             secondTask = task
-            return resolvedResult != nil
+            return false
         }
 
         if shouldCancel {
@@ -148,13 +156,21 @@ private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Senda
     }
 
     func cancelFirstTask() {
-        let task = queue.sync { firstTask }
+        let task = queue.sync {
+            let task = firstTask
+            firstTask = nil
+            return task
+        }
 
         task?.cancel()
     }
 
     func cancelSecondTask() {
-        let task = queue.sync { secondTask }
+        let task = queue.sync {
+            let task = secondTask
+            secondTask = nil
+            return task
+        }
 
         task?.cancel()
     }

--- a/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+FirstTaskCompleted.swift
+++ b/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+FirstTaskCompleted.swift
@@ -1,0 +1,166 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Indicates which of two concurrently started tasks completed first.
+///
+/// Completion means the task either returned a value or threw an error.
+///
+/// - Important: The losing task is cancelled but not awaited. If it does not
+/// cooperate with cancellation, it may continue running in the background after
+/// this helper returns.
+enum FirstTaskCompletedResult<First: Sendable, Second: Sendable>: @unchecked Sendable {
+    case first(Result<First, Error>)
+    case second(Result<Second, Error>)
+    case cancelled
+}
+
+/// Runs two tasks concurrently and returns as soon as either one completes.
+///
+/// Unlike `withConcurrentChildrenTask`, this helper is intentionally
+/// unstructured with respect to the competing operations: once one operation
+/// completes, the other is cancelled and the helper returns immediately without
+/// awaiting the cancelled task.
+///
+/// Use this helper when waiting for the loser to finish would block an
+/// important caller path, such as a timeout race.
+func withFirstTaskCompleted<First: Sendable, Second: Sendable>(
+    priority: TaskPriority? = nil,
+    _ first: @Sendable @escaping () async throws -> First,
+    _ second: @Sendable @escaping () async throws -> Second
+) async -> FirstTaskCompletedResult<First, Second> {
+    let coordinator = FirstTaskCompletedCoordinator<First, Second>()
+
+    return await withTaskCancellationHandler {
+        await withCheckedContinuation { continuation in
+            coordinator.install(continuation)
+
+            coordinator.setFirstTask(
+                Task(priority: priority) {
+                    let result: Result<First, Error>
+                    do {
+                        result = .success(try await first())
+                    } catch {
+                        result = .failure(error)
+                    }
+
+                    guard coordinator.resolve(.first(result)) else {
+                        return
+                    }
+
+                    coordinator.cancelSecondTask()
+                }
+            )
+
+            coordinator.setSecondTask(
+                Task(priority: priority) {
+                    let result: Result<Second, Error>
+                    do {
+                        result = .success(try await second())
+                    } catch {
+                        result = .failure(error)
+                    }
+
+                    guard coordinator.resolve(.second(result)) else {
+                        return
+                    }
+
+                    coordinator.cancelFirstTask()
+                }
+            )
+        }
+    } onCancel: {
+        guard coordinator.resolve(.cancelled) else {
+            return
+        }
+
+        coordinator.cancelAll()
+    }
+}
+
+private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Sendable>: @unchecked Sendable {
+    typealias Result = FirstTaskCompletedResult<First, Second>
+
+    private let queue = UnfairQueue()
+    private var continuation: CheckedContinuation<Result, Never>?
+    private var resolvedResult: Result?
+    private var firstTask: Task<Void, Never>?
+    private var secondTask: Task<Void, Never>?
+
+    func install(_ continuation: CheckedContinuation<Result, Never>) {
+        let resultToResume = queue.sync { () -> Result? in
+            if let resolvedResult {
+                return resolvedResult
+            } else {
+                self.continuation = continuation
+                return nil
+            }
+        }
+
+        if let resultToResume {
+            continuation.resume(returning: resultToResume)
+        }
+    }
+
+    @discardableResult
+    func resolve(_ result: Result) -> Bool {
+        let resolution = queue.sync { () -> (Bool, CheckedContinuation<Result, Never>?) in
+            guard resolvedResult == nil else {
+                return (false, nil)
+            }
+
+            resolvedResult = result
+            let continuationToResume = continuation
+            continuation = nil
+            return (true, continuationToResume)
+        }
+
+        guard resolution.0 else {
+            return false
+        }
+
+        resolution.1?.resume(returning: result)
+        return true
+    }
+
+    func setFirstTask(_ task: Task<Void, Never>) {
+        let shouldCancel = queue.sync { () -> Bool in
+            firstTask = task
+            return resolvedResult != nil
+        }
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func setSecondTask(_ task: Task<Void, Never>) {
+        let shouldCancel = queue.sync { () -> Bool in
+            secondTask = task
+            return resolvedResult != nil
+        }
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func cancelFirstTask() {
+        let task = queue.sync { firstTask }
+
+        task?.cancel()
+    }
+
+    func cancelSecondTask() {
+        let task = queue.sync { secondTask }
+
+        task?.cancel()
+    }
+
+    func cancelAll() {
+        cancelFirstTask()
+        cancelSecondTask()
+    }
+}

--- a/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+FirstTaskCompleted.swift
+++ b/Sources/StreamVideo/Utils/Extensions/Concurrency/Task+FirstTaskCompleted.swift
@@ -4,9 +4,11 @@
 
 import Foundation
 
-/// Indicates which of two concurrently started tasks completed first.
+/// Indicates how a two-task race completed.
 ///
-/// Completion means the task either returned a value or threw an error.
+/// `.first` and `.second` mean that side completed by returning a value or
+/// throwing an error. `.cancelled` means the parent task was cancelled before
+/// either side won the race.
 ///
 /// - Important: The losing task is cancelled but not awaited. If it does not
 /// cooperate with cancellation, it may continue running in the background after
@@ -17,12 +19,19 @@ enum FirstTaskCompletedResult<First: Sendable, Second: Sendable>: @unchecked Sen
     case cancelled
 }
 
-/// Runs two tasks concurrently and returns as soon as either one completes.
+/// Runs two tasks concurrently and returns as soon as the race is resolved.
+///
+/// The race resolves when either operation returns, throws, or the parent task
+/// is cancelled.
 ///
 /// Unlike `withConcurrentChildrenTask`, this helper is intentionally
-/// unstructured with respect to the competing operations: once one operation
-/// completes, the other is cancelled and the helper returns immediately without
-/// awaiting the cancelled task.
+/// unstructured with respect to the competing operations: once the race is
+/// resolved, the other operation is cancelled and the helper returns
+/// immediately without awaiting the cancelled task.
+///
+/// Task handles are registered through a coordinator so a task created after
+/// the race has already resolved is cancelled as soon as its handle is
+/// observed, instead of being left running indefinitely.
 ///
 /// Use this helper when waiting for the loser to finish would block an
 /// important caller path, such as a timeout race.
@@ -37,7 +46,8 @@ func withFirstTaskCompleted<First: Sendable, Second: Sendable>(
         await withCheckedContinuation { continuation in
             coordinator.install(continuation)
 
-            coordinator.setFirstTask(
+            coordinator.setTask(
+                for: .first,
                 Task(priority: priority) {
                     let result: Result<First, Error>
                     do {
@@ -50,11 +60,12 @@ func withFirstTaskCompleted<First: Sendable, Second: Sendable>(
                         return
                     }
 
-                    coordinator.cancelSecondTask()
+                    coordinator.cancelTask(for: .second)
                 }
             )
 
-            coordinator.setSecondTask(
+            coordinator.setTask(
+                for: .second,
                 Task(priority: priority) {
                     let result: Result<Second, Error>
                     do {
@@ -67,7 +78,7 @@ func withFirstTaskCompleted<First: Sendable, Second: Sendable>(
                         return
                     }
 
-                    coordinator.cancelFirstTask()
+                    coordinator.cancelTask(for: .first)
                 }
             )
         }
@@ -80,7 +91,13 @@ func withFirstTaskCompleted<First: Sendable, Second: Sendable>(
     }
 }
 
+/// Serializes result delivery and task-handle management for the race.
+///
+/// This closes the gap between result resolution and task registration by
+/// cancelling any task whose handle is installed after the race has already
+/// resolved.
 private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Sendable>: @unchecked Sendable {
+    enum TaskKey { case first, second }
     typealias Result = FirstTaskCompletedResult<First, Second>
 
     private let queue = UnfairQueue()
@@ -125,13 +142,18 @@ private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Senda
         return true
     }
 
-    func setFirstTask(_ task: Task<Void, Never>) {
+    func setTask(for taskKey: TaskKey, _ task: Task<Void, Never>) {
         let shouldCancel = queue.sync { () -> Bool in
             guard resolvedResult == nil else {
                 return true
             }
 
-            firstTask = task
+            switch taskKey {
+            case .first:
+                firstTask = task
+            case .second:
+                secondTask = task
+            }
             return false
         }
 
@@ -140,43 +162,25 @@ private final class FirstTaskCompletedCoordinator<First: Sendable, Second: Senda
         }
     }
 
-    func setSecondTask(_ task: Task<Void, Never>) {
-        let shouldCancel = queue.sync { () -> Bool in
-            guard resolvedResult == nil else {
-                return true
+    func cancelTask(for taskKey: TaskKey) {
+        let task = queue.sync {
+            switch taskKey {
+            case .first:
+                let task = firstTask
+                firstTask = nil
+                return task
+            case .second:
+                let task = secondTask
+                secondTask = nil
+                return task
             }
-
-            secondTask = task
-            return false
-        }
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func cancelFirstTask() {
-        let task = queue.sync {
-            let task = firstTask
-            firstTask = nil
-            return task
-        }
-
-        task?.cancel()
-    }
-
-    func cancelSecondTask() {
-        let task = queue.sync {
-            let task = secondTask
-            secondTask = nil
-            return task
         }
 
         task?.cancel()
     }
 
     func cancelAll() {
-        cancelFirstTask()
-        cancelSecondTask()
+        cancelTask(for: .first)
+        cancelTask(for: .second)
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -477,6 +477,16 @@ final class WebRTCCoordinator: @unchecked Sendable {
         await stateAdapter.trace(.init(action))
     }
 
+    // MARK: - Call Tracing
+
+    /// Forwards a call-level trace to the shared tracing adapter.
+    ///
+    /// This keeps call-flow diagnostics, such as intercepted joins, in the
+    /// same trace stream as lower-level WebRTC events.
+    func trace(_ trace: WebRTCTrace) async {
+        await stateAdapter.trace(trace)
+    }
+
     // MARK: - Private
 
     /// Creates the state machine for managing WebRTC stages.

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -559,7 +559,8 @@ open class CallViewModel: ObservableObject {
                     create: true,
                     options: options,
                     ring: false,
-                    callSettings: settings
+                    callSettings: settings,
+                    joinInterceptor: callJoinInterceptor
                 )
                 
                 temporaryCallSettings = call.state.callSettings

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -198,6 +198,14 @@ open class CallViewModel: ObservableObject {
     /// Returns the noiseCancellationFilter if available.
     public var noiseCancellationAudioFilter: AudioFilter? { streamVideo.videoConfig.noiseCancellationFilter }
 
+    /// Optional interceptor invoked after the call join response has been
+    /// applied locally but before the SDK treats the call as fully entered.
+    ///
+    /// Assign this when your app needs to perform readiness work during the
+    /// join flow, such as waiting for another participant or validating an
+    /// external precondition. Throw from the interceptor to fail the join.
+    public var callJoinInterceptor: CallJoinIntercepting?
+
     private var participantUpdates: AnyCancellable?
     private var blockedUserUpdates: AnyCancellable?
     private var reconnectionUpdates: AnyCancellable?
@@ -910,7 +918,8 @@ open class CallViewModel: ObservableObject {
                     options: options,
                     ring: ring,
                     callSettings: settings,
-                    policy: policy
+                    policy: policy,
+                    joinInterceptor: callJoinInterceptor
                 )
                 try Task.checkCancellation()
                 save(call: resolvedCall)
@@ -1085,6 +1094,11 @@ open class CallViewModel: ObservableObject {
                 setActiveCall(call)
             }
         case .outgoing where call?.cId == event.callCid:
+            // Mirror `joinCall` so the incoming UI is dismissed before
+            // `enterCall` finishes the async join flow, which may now be
+            // delayed by a `callJoinInterceptor`.
+            setCallingState(.joining)
+
             skipCallStateUpdates = false
             enterCall(
                 call: call,

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -851,6 +851,24 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    func test_joinAndRingCall_callJoinInterceptor_passesInterceptorToCall() async {
+        let interceptor = CallJoinInterceptor_Mock()
+
+        await prepare()
+        subject.callJoinInterceptor = interceptor
+
+        subject.joinAndRingCall(
+            callType: callType,
+            callId: callId,
+            members: participants
+        )
+
+        await fulfilmentInMainActor { self.mockCall.recordedJoinInterceptors.count == 1 }
+
+        let recordedInterceptor = mockCall.recordedJoinInterceptors.first as? CallJoinInterceptor_Mock
+        XCTAssertTrue(recordedInterceptor === interceptor)
+    }
+
     func test_joinAndRingCall_usesLocalCallSettingsOverrides() async throws {
         // Given
         await prepare()

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -137,6 +137,24 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         XCTAssert(callViewModel.callingState == .outgoing)
     }
 
+    func test_startCall_callJoinInterceptor_passesInterceptorToCall() async {
+        let interceptor = CallJoinInterceptor_Mock()
+
+        await prepare()
+        subject.callJoinInterceptor = interceptor
+
+        subject.startCall(
+            callType: callType,
+            callId: callId,
+            members: participants
+        )
+
+        await fulfilmentInMainActor { self.mockCall.recordedJoinInterceptors.count == 1 }
+
+        let recordedInterceptor = mockCall.recordedJoinInterceptors.first as? CallJoinInterceptor_Mock
+        XCTAssertTrue(recordedInterceptor === interceptor)
+    }
+
     func test_callKitJoiningEventOnInit_setsCallingStateToJoiningAndAssignsCall() async {
         // Given
         let callKitService = MockCallKitService()
@@ -1625,6 +1643,10 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         ) { self.subject.callingState == expected }
         #endif
     }
+}
+
+private final class CallJoinInterceptor_Mock: CallJoinIntercepting, @unchecked Sendable {
+    func callReadyToJoin(_ call: Call) async throws {}
 }
 
 extension User {

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -666,6 +666,26 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
+    func test_join_withJoinInterceptor_joinInterceptorWasInvoked() async throws {
+        let mockCallController = MockCallController()
+        let call = Call.dummy(callType: callType, callId: callId, callController: mockCallController)
+        let joinInterceptor = CallJoinInterceptor_Spy()
+        mockCallController.stub(
+            for: .join,
+            with: JoinCallResponse.dummy(
+                call: .dummy(
+                    cid: call.cId,
+                    id: call.callId,
+                    type: call.callType
+                )
+            )
+        )
+
+        _ = try await call.join(joinInterceptor: joinInterceptor)
+
+        XCTAssertEqual(joinInterceptor.invocationCount, 1)
+    }
+
     // MARK: - leave
 
     func test_leave_withReason_reasonWasPassedToCallController() {
@@ -856,6 +876,14 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
             .process(.coordinatorEvent(event))
 
         try await fulfillmentHandler(call)
+    }
+}
+
+private final class CallJoinInterceptor_Spy: CallJoinIntercepting, @unchecked Sendable {
+    @Atomic private(set) var invocationCount = 0
+
+    func callReadyToJoin(_ call: Call) async throws {
+        invocationCount += 1
     }
 }
 

--- a/StreamVideoTests/CallStateMachine/CallConfigurationTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallConfigurationTests.swift
@@ -13,5 +13,15 @@ final class CallConfigurationTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(timeout.join, 30)
         XCTAssertEqual(timeout.accept, 10)
         XCTAssertEqual(timeout.reject, 10)
+        XCTAssertEqual(timeout.joinInterception, 5)
+    }
+
+    func test_timeout_shouldReturnTestingTimeouts() {
+        let timeout = CallConfiguration.Timeout.testing
+
+        XCTAssertEqual(timeout.join, 10)
+        XCTAssertEqual(timeout.accept, 10)
+        XCTAssertEqual(timeout.reject, 10)
+        XCTAssertEqual(timeout.joinInterception, 10)
     }
 }

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -443,6 +443,59 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         }
     }
 
+    func test_execute_withoutRetries_joinInterceptorWaitingOnContinuation_transitionsToJoinedAfterTimeout(
+    ) async throws {
+        let originalTimeout = CallConfiguration.timeout
+        CallConfiguration.timeout.joinInterception = 0.1
+        defer { CallConfiguration.timeout = originalTimeout }
+
+        // This interceptor suspends on a continuation and does not react to
+        // cancellation on its own. It models the exact class of interceptor
+        // that used to keep the join flow blocked even after the timeout fired.
+        let interceptorStarted = expectation(description: "Join interceptor started.")
+        let joinInterceptor = NonCancellableJoinInterceptor_Spy {
+            interceptorStarted.fulfill()
+        }
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: .init(nil),
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+
+        callController.stub(for: .join, with: JoinCallResponse.dummy())
+        subject.transition = { self.transitionedToStage = $0 }
+        subject.context = context
+
+        _ = subject.transition(from: .idle(.init()))
+
+        // First confirm the interceptor actually entered its suspended state.
+        await fulfillment(of: [interceptorStarted], timeout: defaultTimeout)
+
+        // The join should now complete because the timeout path stops waiting
+        // for the blocked interceptor task, rather than waiting for it to
+        // finish cooperatively.
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            self.transitionedToStage?.id == .joined
+        }
+        XCTAssertEqual(self.streamVideo.state.activeCall?.cId, self.call.cId)
+
+        // Resume the interceptor only to clean up the background task that is
+        // still suspended on the continuation; this should not be required for
+        // the join transition itself anymore.
+        joinInterceptor.resume()
+        XCTAssertEqual(joinInterceptor.invocationCount, 1)
+    }
+
     func test_execute_withRetries_whenJoinFailsAndThereAreAvailableRetries_transitionsToJoining() async throws {
         let context = Call.StateMachine.Stage.Context(
             call: call,
@@ -605,6 +658,33 @@ private final class CallJoinInterceptor_Spy: CallJoinIntercepting, @unchecked Se
     func callReadyToJoin(_ call: Call) async throws {
         recordedCallCIds.append(call.cId)
         try await handler(call)
+    }
+
+    var invocationCount: Int {
+        recordedCallCIds.count
+    }
+}
+
+private final class NonCancellableJoinInterceptor_Spy: CallJoinIntercepting, @unchecked Sendable {
+    private let onEntered: @Sendable () -> Void
+    @Atomic private(set) var recordedCallCIds: [String] = []
+    @Atomic private var continuation: CheckedContinuation<Void, Never>?
+
+    init(onEntered: @escaping @Sendable () -> Void = {}) {
+        self.onEntered = onEntered
+    }
+
+    func callReadyToJoin(_ call: Call) async throws {
+        recordedCallCIds.append(call.cId)
+        onEntered()
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
     }
 
     var invocationCount: Int {

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -318,6 +318,131 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         }
     }
 
+    func test_execute_withoutRetries_joinInterceptorReturns_transitionsToJoined() async throws {
+        let joinInterceptor = CallJoinInterceptor_Spy()
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: .init(nil),
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .joined
+        ) { @MainActor in
+            XCTAssertEqual(joinInterceptor.invocationCount, 1)
+            XCTAssertEqual(joinInterceptor.recordedCallCIds, [self.call.cId])
+        }
+    }
+
+    func test_execute_withoutRetries_joinInterceptorThrows_tracesFailureAndTransitionsToError() async throws {
+        let deliverySubject = CurrentValueSubject<JoinCallResponse?, Error>(nil)
+        let deliveryExpectation = expectation(description: "DeliverySubject delivered failure.")
+        var deliveredError: Error?
+        let cancellable = deliverySubject
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case let .failure(error):
+                    deliveredError = error
+                    deliveryExpectation.fulfill()
+                }
+            } receiveValue: { _ in }
+        let joinInterceptor = CallJoinInterceptor_Spy { _ in
+            throw TestError()
+        }
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: deliverySubject,
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .error
+        ) { @MainActor in
+            await self.fulfillment(of: [deliveryExpectation], timeout: defaultTimeout)
+
+            let error = try XCTUnwrap(deliveredError as? CallJoinInterceptionError)
+            XCTAssertTrue(error.underlyingError is TestError)
+            XCTAssertEqual(joinInterceptor.invocationCount, 1)
+            XCTAssertNil(self.streamVideo.state.activeCall)
+            XCTAssertEqual(self.callController.timesCalled(.observeWebRTCStateUpdated), 0)
+            XCTAssertEqual(self.callController.timesCalled(.trace), 1)
+
+            let trace = try XCTUnwrap(
+                self.callController.recordedInputPayload(
+                    WebRTCTrace.self,
+                    for: .trace
+                )?.first
+            )
+            XCTAssertNil(trace.id)
+            XCTAssertEqual(trace.tag, "call.join.interception.failed")
+        }
+
+        cancellable.cancel()
+    }
+
+    func test_execute_withoutRetries_joinInterceptorExceedsConfiguredTimeout_transitionsToJoined() async throws {
+        let originalTimeout = CallConfiguration.timeout
+        CallConfiguration.timeout.joinInterception = 0.01
+        defer { CallConfiguration.timeout = originalTimeout }
+
+        let joinInterceptor = CallJoinInterceptor_Spy { _ in
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: .init(nil),
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+        let start = Date()
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .joined
+        ) { @MainActor in
+            XCTAssertLessThan(Date().timeIntervalSince(start), 2)
+            XCTAssertEqual(joinInterceptor.invocationCount, 1)
+            XCTAssertEqual(self.streamVideo.state.activeCall?.cId, self.call.cId)
+        }
+    }
+
     func test_execute_withRetries_whenJoinFailsAndThereAreAvailableRetries_transitionsToJoining() async throws {
         let context = Call.StateMachine.Stage.Context(
             call: call,
@@ -466,5 +591,23 @@ extension Call.StateMachine.Stage.Context.Input {
         default:
             return nil
         }
+    }
+}
+
+private final class CallJoinInterceptor_Spy: CallJoinIntercepting, @unchecked Sendable {
+    private let handler: @Sendable (Call) async throws -> Void
+    @Atomic private(set) var recordedCallCIds: [String] = []
+
+    init(handler: @escaping @Sendable (Call) async throws -> Void = { _ in }) {
+        self.handler = handler
+    }
+
+    func callReadyToJoin(_ call: Call) async throws {
+        recordedCallCIds.append(call.cId)
+        try await handler(call)
+    }
+
+    var invocationCount: Int {
+        recordedCallCIds.count
     }
 }

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -404,7 +404,7 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
             XCTAssertEqual(trace.tag, "call.join.interception.failed")
             XCTAssertEqual(
                 trace.data,
-                .init(["errorType": String(describing: TestError.self)])
+                .init(["error": String(describing: TestError())])
             )
         }
 

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -402,6 +402,10 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
             )
             XCTAssertNil(trace.id)
             XCTAssertEqual(trace.tag, "call.join.interception.failed")
+            XCTAssertEqual(
+                trace.data,
+                .init(["errorType": String(describing: TestError.self)])
+            )
         }
 
         cancellable.cancel()

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -84,6 +84,27 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         )
     }
 
+    func test_trace_forwardsTraceToStatsAdapter() async {
+        let statsAdapter = MockWebRTCStatsAdapter()
+        let expected = WebRTCTrace(status: .available(.great))
+
+        await mockWebRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(statsAdapter: statsAdapter)
+
+        await subject.trace(expected)
+
+        XCTAssertEqual(
+            statsAdapter.recordedInputPayload(
+                WebRTCTrace.self,
+                for: .trace
+            )?.first,
+            expected
+        )
+    }
+
     // MARK: - setCall
 
     func test_setCall_updatesSessionIdCorrectly() async throws {

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -76,6 +76,7 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
     var stubbedFunction: [FunctionKey: Any] = [:]
     @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey.allCases
         .reduce(into: [FunctionKey: [FunctionInputKey]]()) { $0[$1] = [] }
+    @Atomic var recordedJoinInterceptors: [CallJoinIntercepting?] = []
     var waitForJoinToResume = false
     var onJoinStarted: (@Sendable () -> Void)?
     var onJoinResumed: (@Sendable (MockCall) async -> Void)?
@@ -179,7 +180,8 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
         ring: Bool = false,
         notify: Bool = false,
         callSettings: CallSettings? = nil,
-        policy: WebRTCJoinPolicy = .default
+        policy: WebRTCJoinPolicy = .default,
+        joinInterceptor: CallJoinIntercepting? = nil
     ) async throws -> JoinCallResponse {
         stubbedFunctionInput[.join]?.append(
             .join(
@@ -191,6 +193,7 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
                 policy: policy
             )
         )
+        recordedJoinInterceptors.append(joinInterceptor)
         onJoinStarted?()
 
         if waitForJoinToResume {
@@ -216,7 +219,8 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
                 ring: ring,
                 notify: notify,
                 callSettings: callSettings,
-                policy: policy
+                policy: policy,
+                joinInterceptor: joinInterceptor
             )
         }
     }

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -12,6 +12,7 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         case leave
         case setDisconnectionTimeout
         case observeWebRTCStateUpdated
+        case trace
         case changeAudioState
         case changeVideoState
         case changeCameraMode
@@ -36,6 +37,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         case leave(reason: String?)
 
         case observeWebRTCStateUpdated
+
+        case trace(WebRTCTrace)
 
         case changeAudioState(Bool)
 
@@ -67,6 +70,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 return reason ?? ""
             case .observeWebRTCStateUpdated:
                 return ()
+            case let .trace(trace):
+                return trace
             case let .changeAudioState(value):
                 return value
             case let .changeVideoState(value):
@@ -165,6 +170,11 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
     override func observeWebRTCStateUpdated() {
         stubbedFunctionInput[.observeWebRTCStateUpdated]?
             .append(.observeWebRTCStateUpdated)
+    }
+
+    override func trace(_ trace: WebRTCTrace) async {
+        stubbedFunctionInput[.trace]?
+            .append(.trace(trace))
     }
 
     override func changeVideoState(isEnabled: Bool) async throws {

--- a/StreamVideoTests/Utils/Extensions/Concurrency/WithFirstTaskCompleted_Tests.swift
+++ b/StreamVideoTests/Utils/Extensions/Concurrency/WithFirstTaskCompleted_Tests.swift
@@ -1,0 +1,275 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class WithFirstTaskCompleted_Tests: XCTestCase, @unchecked Sendable {
+
+    private enum TestError: Error, Equatable {
+        case expected
+    }
+
+    func test_withFirstTaskCompleted_returnsFirstSuccess_whenFirstCompletesFirst() async throws {
+        let result = await withFirstTaskCompleted(
+            {
+                try await Task.sleep(nanoseconds: 10_000_000)
+                return 1
+            },
+            {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return "second"
+            }
+        )
+
+        switch result {
+        case let .first(.success(value)):
+            XCTAssertEqual(value, 1)
+        default:
+            XCTFail("Expected first task to complete successfully first.")
+        }
+    }
+
+    func test_withFirstTaskCompleted_returnsSecondSuccess_whenSecondCompletesFirst() async throws {
+        let result = await withFirstTaskCompleted(
+            {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return 1
+            },
+            {
+                try await Task.sleep(nanoseconds: 10_000_000)
+                return "second"
+            }
+        )
+
+        switch result {
+        case let .second(.success(value)):
+            XCTAssertEqual(value, "second")
+        default:
+            XCTFail("Expected second task to complete successfully first.")
+        }
+    }
+
+    func test_withFirstTaskCompleted_returnsFirstFailure_whenFirstThrowsFirst() async {
+        let result = await withFirstTaskCompleted(
+            { () async throws -> Int in
+                throw TestError.expected
+            },
+            {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return "second"
+            }
+        )
+
+        switch result {
+        case let .first(.failure(error)):
+            XCTAssertEqual(error as? TestError, .expected)
+        default:
+            XCTFail("Expected first task failure to win the race.")
+        }
+    }
+
+    func test_withFirstTaskCompleted_returnsSecondFailure_whenSecondThrowsFirst() async {
+        let result = await withFirstTaskCompleted(
+            {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return 1
+            },
+            { () async throws -> String in
+                throw TestError.expected
+            }
+        )
+
+        switch result {
+        case let .second(.failure(error)):
+            XCTAssertEqual(error as? TestError, .expected)
+        default:
+            XCTFail("Expected second task failure to win the race.")
+        }
+    }
+
+    func test_withFirstTaskCompleted_cancelsSecondTask_whenFirstCompletesFirst() async {
+        let secondTaskStarted = expectation(description: "Second task started.")
+        let cancellationObserved = expectation(description: "Second task observed cancellation.")
+        let didStartSecondTask = Atomic(wrappedValue: false)
+
+        _ = await withFirstTaskCompleted(
+            {
+                while !didStartSecondTask.wrappedValue {
+                    await Task.yield()
+                }
+                return 1
+            },
+            {
+                didStartSecondTask.wrappedValue = true
+                secondTaskStarted.fulfill()
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                    return "second"
+                } catch is CancellationError {
+                    cancellationObserved.fulfill()
+                    throw CancellationError()
+                }
+            }
+        )
+
+        await fulfillment(
+            of: [secondTaskStarted, cancellationObserved],
+            timeout: defaultTimeout
+        )
+    }
+
+    func test_withFirstTaskCompleted_cancelsFirstTask_whenSecondCompletesFirst() async {
+        let firstTaskStarted = expectation(description: "First task started.")
+        let cancellationObserved = expectation(description: "First task observed cancellation.")
+        let didStartFirstTask = Atomic(wrappedValue: false)
+
+        _ = await withFirstTaskCompleted(
+            {
+                didStartFirstTask.wrappedValue = true
+                firstTaskStarted.fulfill()
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                    return 1
+                } catch is CancellationError {
+                    cancellationObserved.fulfill()
+                    throw CancellationError()
+                }
+            },
+            {
+                while !didStartFirstTask.wrappedValue {
+                    await Task.yield()
+                }
+                return "second"
+            }
+        )
+
+        await fulfillment(
+            of: [firstTaskStarted, cancellationObserved],
+            timeout: defaultTimeout
+        )
+    }
+
+    func test_withFirstTaskCompleted_returnsCancelled_whenParentTaskIsCancelled() async throws {
+        let firstTaskStarted = expectation(description: "First task started.")
+        let secondTaskStarted = expectation(description: "Second task started.")
+        let firstCancellationObserved = expectation(description: "First task observed cancellation.")
+        let secondCancellationObserved = expectation(description: "Second task observed cancellation.")
+
+        let task = Task {
+            await withFirstTaskCompleted(
+                {
+                    firstTaskStarted.fulfill()
+                    do {
+                        try await Task.sleep(nanoseconds: 5_000_000_000)
+                        return 1
+                    } catch is CancellationError {
+                        firstCancellationObserved.fulfill()
+                        throw CancellationError()
+                    }
+                },
+                {
+                    secondTaskStarted.fulfill()
+                    do {
+                        try await Task.sleep(nanoseconds: 5_000_000_000)
+                        return "second"
+                    } catch is CancellationError {
+                        secondCancellationObserved.fulfill()
+                        throw CancellationError()
+                    }
+                }
+            )
+        }
+
+        await fulfillment(
+            of: [firstTaskStarted, secondTaskStarted],
+            timeout: defaultTimeout
+        )
+        task.cancel()
+
+        let result = await task.value
+
+        switch result {
+        case .cancelled:
+            break
+        default:
+            XCTFail("Expected cancelled result when parent task is cancelled.")
+        }
+
+        await fulfillment(
+            of: [firstCancellationObserved, secondCancellationObserved],
+            timeout: defaultTimeout
+        )
+    }
+
+    func test_withFirstTaskCompleted_returnsWithoutWaitingForNonCooperativeLoser() async {
+        let blockerEntered = expectation(description: "Non-cooperative task entered.")
+        let blockerCompleted = expectation(description: "Non-cooperative task completed.")
+        let blocker = NonCooperativeTaskBlocker {
+            blockerEntered.fulfill()
+        } onResume: {
+            blockerCompleted.fulfill()
+        }
+        let start = Date()
+
+        let result = await withFirstTaskCompleted(
+            {
+                while !blocker.didEnter {
+                    await Task.yield()
+                }
+                return 1
+            },
+            {
+                await blocker.wait()
+                return "second"
+            }
+        )
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1)
+        switch result {
+        case let .first(.success(value)):
+            XCTAssertEqual(value, 1)
+        default:
+            XCTFail("Expected first task to finish without waiting for the blocked loser.")
+        }
+
+        await fulfillment(of: [blockerEntered], timeout: defaultTimeout)
+        blocker.resume()
+        await fulfillment(of: [blockerCompleted], timeout: defaultTimeout)
+    }
+}
+
+private final class NonCooperativeTaskBlocker: @unchecked Sendable {
+    private let onEnter: @Sendable () -> Void
+    private let onResume: @Sendable () -> Void
+    @Atomic private var didEnterStorage = false
+    @Atomic private var continuation: CheckedContinuation<Void, Never>?
+
+    var didEnter: Bool {
+        didEnterStorage
+    }
+
+    init(
+        onEnter: @escaping @Sendable () -> Void = {},
+        onResume: @escaping @Sendable () -> Void = {}
+    ) {
+        self.onEnter = onEnter
+        self.onResume = onResume
+    }
+
+    func wait() async {
+        didEnterStorage = true
+        onEnter()
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+        onResume()
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1607/feature-requestincall-status-sync-between-participants

### 🎯 Goal

Add a join interception hook that lets apps delay or abort call entry after the join response has been applied locally, so participant readiness/status can be synchronized before the user is treated as fully in-call.

### 📝 Summary

- Added `CallJoinIntercepting` and `CallJoinInterceptionError` to support app-defined join interception.
- Extended `Call.join(...)` with an optional `joinInterceptor` parameter.
- Updated the call joining stage to run the interceptor after local join-state update and before setting `activeCall`.
- Added a bounded timeout path for interception using a new `withFirstTaskCompleted` concurrency helper.
- Ensured interception failures trace the error and leave the call cleanly with `join.interception.failed`.
- Exposed `callJoinInterceptor` on `CallViewModel` and forwarded it through both `enterCall` and `joinAndRingCall`.
- Added a demo-only `DemoCallJoinInterceptor` for ringing flows using a custom `participant.ready` event.
- Added unit coverage for interception success, failure, timeout, non-cooperative interception, and the new concurrency helper.
- Updated changelog for the new client-facing join interception API.

### 🛠 Implementation

The SDK now supports an optional interception step during `Call.join(...)`. The interceptor runs after the backend join request succeeds and the local `CallState` has been updated, but before the call is promoted to `StreamVideo.State.activeCall`.

To keep this step bounded, the join flow now races the interceptor against a timeout using `withFirstTaskCompleted`. This is intentionally implemented with unstructured tasks so the join flow can stop waiting even if the interceptor is suspended in a cancellation-insensitive operation (for example, a continuation-backed callback bridge). If the timeout wins, the join continues. If the interceptor throws, the flow surfaces a `CallJoinInterceptionError`, traces the failure, and leaves the call so the SDK does not remain joined underneath a failed UI flow.

On the SwiftUI side, `CallViewModel` exposes `callJoinInterceptor` and forwards it through both normal join/start paths and `joinAndRingCall`, so the feature is applied consistently. The demo app includes a sample interceptor that waits for another participant’s readiness signal via a custom event, but it is explicitly guarded to act only for ringing-call flows.

### 🧪 Manual Testing Notes

- Start a ringing call between two demo users and verify the local participant does not fully enter the call until the remote readiness event is observed.
- Verify that the demo interceptor does not affect non-ringing demo join flows.
- Force the interceptor to exceed the configured timeout and verify the join still completes.
- Force the interceptor to throw and verify the join fails cleanly without leaving an active/joined call behind.
- Verify both normal join/start flows and `joinAndRingCall` honor `callJoinInterceptor`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional join interception hook to delay or abort call entry
  * New CallJoinIntercepting protocol and per-call CallViewModel.callJoinInterceptor
  * Join interception timeout defaults (prod: 5s, test: 10s)
  * New call-level tracing API to submit WebRTC traces
  * Demo app includes a sample join interceptor

* **Documentation**
  * CHANGELOG updated with join interception details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->