### PR TITLE
[Fix]Premature CallViewModel.callingState transitions from participan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replay buffered subscriber ICE trickles during join so remote audio does not wait for a later subscriber ICE restart before becoming audible. [#1111](https://github.com/GetStream/stream-video-swift/pull/1111)
 - Fix join-call timeout caused by a `PassthroughSubject` race where the response was emitted before the subscription was established. [#1113](https://github.com/GetStream/stream-video-swift/pull/1113)
 - CallKit-managed calls now respect the configured `participantAutoLeavePolicy`. [#1112](https://github.com/GetStream/stream-video-swift/pull/1112)
+- Prevent `CallViewModel` from entering `.inCall` from participant updates before the call is ready, while preserving the CallKit join handoff to `.inCall`. [#1109](https://github.com/GetStream/stream-video-swift/pull/1109)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -147,11 +147,7 @@ open class CallViewModel: ObservableObject {
     @Published public var outgoingCallMembers = [Member]()
 
     /// Dictionary of the call participants.
-    @Published public private(set) var callParticipants = [String: CallParticipant]() {
-        didSet {
-            updateCallStateIfNeeded()
-        }
-    }
+    @Published public private(set) var callParticipants = [String: CallParticipant]()
 
     /// Contains info about a participant event. It's reset to nil after 2 seconds.
     @Published public var participantEvent: ParticipantEvent?
@@ -297,17 +293,22 @@ open class CallViewModel: ObservableObject {
         callKitServiceObserver
             .publisher
             .receive(on: DispatchQueue.main)
-            .compactMap {
-                switch $0 {
+            .sink { [weak self] event in
+                guard let self else { return }
+
+                switch event {
                 case let .joining(call):
-                    return call
+                    setCallingState(.joining)
+                    self.call = call
+                case .joined:
+                    guard let call else { return }
+                    // CallKit can report the active call while it still marks
+                    // the bridge as `.joining`. Once `.joined` arrives we need
+                    // an explicit handoff to let the regular in-call UI take over.
+                    setActiveCall(call)
                 default:
-                    return nil
+                    break
                 }
-            }
-            .sink { [weak self] in
-                self?.setCallingState(.joining)
-                self?.call = $0
             }
             .store(in: disposableBag)
     }
@@ -1192,33 +1193,6 @@ open class CallViewModel: ObservableObject {
         default:
             if call?.cId == event.callCid {
                 leaveCall(reason: "ended")
-            }
-        }
-    }
-
-    private func updateCallStateIfNeeded() {
-        guard !skipCallStateUpdates else { return }
-        if callingState == .outgoing {
-            if !callParticipants.isEmpty {
-                setCallingState(.inCall)
-            }
-            return
-        }
-        guard call != nil || !callParticipants.isEmpty else { return }
-        if callingState != .reconnecting, callingState != .inCall {
-            // Participant updates can arrive before the CallKit-driven join
-            // flow finishes. Keep .joining visible until the observer reports
-            // that the temporary CallKit sync state has ended.
-            switch callKitServiceObserver.value {
-            case .joining:
-                setCallingState(.joining)
-            default:
-                setCallingState(.inCall)
-            }
-        } else {
-            let shouldGoInCall = callParticipants.count > 1
-            if shouldGoInCall, callingState != .inCall {
-                setCallingState(.inCall)
             }
         }
     }

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -188,6 +188,37 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         await assertCallingState(.joining)
     }
 
+    func test_callKitJoin_whenActiveCallIsRestoredBeforeCallKitFinishes_thenJoinedEventTransitionsCallingStateToInCall() async {
+        // Given
+        let callKitService = MockCallKitService()
+        InjectedValues[\.callKitService] = callKitService
+        callKitService.send(.joining(mockCall))
+        subject = .init()
+        await assertCallingState(.joining)
+
+        // When
+        let remoteParticipant = CallParticipant.dummy(id: "remote-participant")
+        subject.call?.state.participantsMap = [remoteParticipant.id: remoteParticipant]
+
+        // Then
+        await fulfilmentInMainActor {
+            self.subject.callParticipants[remoteParticipant.id] != nil
+        }
+        await assertCallingState(.joining)
+
+        // When
+        subject.setActiveCall(mockCall)
+
+        // Then
+        await assertCallingState(.joining)
+
+        // When
+        callKitService.send(.joined)
+
+        // Then
+        await assertCallingState(.inCall)
+    }
+
     func test_setActiveCallNil_whileCallKitJoinIsInProgress_keepsCallingStateJoining() async {
         // Given
         let callKitService = MockCallKitService()
@@ -212,6 +243,29 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         subject.call?.state.reconnectionStatus = .migrating
 
         // Then
+        await assertCallingState(.reconnecting)
+
+        // When
+        subject.call?.state.reconnectionStatus = .connected
+
+        // Then
+        await assertCallingState(.inCall)
+    }
+
+    func test_reconnectingCall_whenParticipantsUpdate_thenCallingStateRemainsReconnectingUntilConnectionRestores() async {
+        // Given
+        await prepareMediaScenario()
+        subject.call?.state.reconnectionStatus = .migrating
+        await assertCallingState(.reconnecting)
+
+        // When
+        let remoteParticipant = CallParticipant.dummy(id: "remote-participant")
+        subject.call?.state.participantsMap = [remoteParticipant.id: remoteParticipant]
+
+        // Then
+        await fulfilmentInMainActor {
+            self.subject.callParticipants[remoteParticipant.id] != nil
+        }
         await assertCallingState(.reconnecting)
 
         // When
@@ -252,6 +306,44 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
 
         // Then
         await assertCallingState(.idle)
+    }
+
+    func test_outgoingCall_whenParticipantsUpdateBeforeAcceptedEvent_thenCallingStateRemainsOutgoingUntilJoinCompletes(
+    ) async throws {
+        // Given
+        await prepare()
+        subject.startCall(
+            callType: .default,
+            callId: callId,
+            members: participants,
+            ring: true
+        )
+        await assertCallingState(.outgoing)
+
+        // When
+        let remoteParticipant = CallParticipant.dummy(id: "remote-participant")
+        subject.call?.state.participantsMap = [remoteParticipant.id: remoteParticipant]
+
+        // Then
+        await fulfilmentInMainActor {
+            self.subject.callParticipants[remoteParticipant.id] != nil
+        }
+        await assertCallingState(.outgoing)
+
+        // When
+        streamVideo.process(
+            .coordinatorEvent(
+                .typeCallAcceptedEvent(
+                    .dummy(
+                        callCid: cId,
+                        user: secondUser.user.toUserResponse()
+                    )
+                )
+            )
+        )
+
+        // Then
+        await assertCallingState(.inCall)
     }
 
     func test_outgoingCall_rejectedEventThreeParticipants() async throws {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1614/enhancementcallviewmodelcallingstate-is-driven-only-by-events-and

### 🎯 Goal

Prevent `CallViewModel.callingState` from moving forward before the call is actually ready, especially when participant updates arrive while the app is backgrounded or while a CallKit-accepted join is still restoring.

### 📝 Summary

- Removed participant-driven `callingState` transitions from `CallViewModel`
- Kept participant updates purely as participant data updates
- Added an explicit CallKit `.joined` -> `.inCall` handoff so CallKit-accepted joins do not remain stuck in `.joining`
- Added unit coverage for CallKit join ordering, reconnect ordering, and outgoing ringing ordering

### 🛠 Implementation

`CallViewModel` previously updated `callingState` from `callParticipants.didSet`, which meant background participant refreshes could push the UI into `.inCall` before the join flow had actually completed.

This PR removes that participant-driven fallback and keeps state progression tied to readiness-related signals instead. While doing that, it also fixes the CallKit restore path: if the active call is restored while the temporary CallKit bridge is still in `.joining`, the later `.joined` event now explicitly hands control back to the regular `setActiveCall` flow so the UI transitions to `.inCall` at the right time.

The test coverage added in `CallViewModel_Tests` verifies:
- participant updates do not advance `.joining` during the CallKit flow
- a later CallKit `.joined` event transitions the view model to `.inCall`
- participant churn does not collapse `.reconnecting` or `.outgoing` early
- the real acceptance / connection restoration path still transitions to `.inCall`

### 🧪 Manual Testing Notes

- Accept a ringing call while the app is in background and screen is unlocked
- Accept from the CallKit notification / system UI and verify the UI goes to `.joining` first and then `.inCall`
- Repeat with a cold-start accept from CallKit
- Verify participant updates while backgrounded do not surface the in-call UI before the call is actually ready
- Verify ringing / reconnect flows still end in `.inCall` once readiness is reached

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed calling state management to prevent premature transitions to "in call" when participants update before the call initialization is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->