### PR TITLE
[Fix]Support server-side pinning on participant join

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUEventAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUEventAdapter.swift
@@ -246,8 +246,18 @@ final class SFUEventAdapter: @unchecked Sendable {
             }
 
             let showTrack = updatedParticipants.count < participantsThreshold
-            let participant = event.participant.toCallParticipant()
+            var participant = event.participant.toCallParticipant()
                 .withUpdated(showTrack: showTrack)
+
+            if event.isPinned {
+                participant = participant.withUpdated(
+                    pin: .init(
+                        isLocal: false,
+                        pinnedAt: Date()
+                    )
+                )
+            }
+
             updatedParticipants[event.participant.sessionID] = participant
             log.debug("Enqueue participant joined event: \(event.participant.name) success!")
 
@@ -459,11 +469,12 @@ final class SFUEventAdapter: @unchecked Sendable {
             let sessionIds = event.pins.map(\.sessionID)
 
             for (key, participant) in updatedParticipants {
-                if
-                    sessionIds.contains(key),
-                    (participant.pin == nil || participant.pin?.isLocal == true) {
-                    updatedParticipants[key] = participant
-                        .withUpdated(pin: .init(isLocal: false, pinnedAt: .init()))
+                if sessionIds.contains(key) {
+                    updatedParticipants[key] = participant.pin?.isLocal == false
+                        ? participant
+                        : participant.withUpdated(
+                            pin: .init(isLocal: false, pinnedAt: .init())
+                        )
                 } else {
                     updatedParticipants[key] = participant.withUpdated(pin: nil)
                 }

--- a/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
@@ -164,6 +164,88 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_handleParticipantJoined_givenPinnedEvent_whenPublished_thenAddsParticipantWithRemotePin() async throws {
+        let participant = CallParticipant.dummy()
+        var event = Stream_Video_Sfu_Event_ParticipantJoined()
+        event.participant = .init()
+        event.participant.userID = participant.sessionId
+        event.participant.sessionID = participant.sessionId
+        event.isPinned = true
+        let joinedAt = Date()
+
+        try await assert(
+            event,
+            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            initialState: [.dummy()].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
+        ) {
+            guard let pin = $0[participant.sessionId]?.pin else {
+                return false
+            }
+
+            return $0[participant.sessionId]?.showTrack == true
+                && pin.isLocal == false
+                && pin.pinnedAt >= joinedAt
+        }
+    }
+
+    func test_handleParticipantJoined_givenUnpinnedEvent_whenPublished_thenAddsParticipantWithoutPin() async throws {
+        let participant = CallParticipant.dummy()
+        var event = Stream_Video_Sfu_Event_ParticipantJoined()
+        event.participant = .init()
+        event.participant.userID = participant.sessionId
+        event.participant.sessionID = participant.sessionId
+        event.isPinned = false
+
+        try await assert(
+            event,
+            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            initialState: [.dummy()].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
+        ) {
+            $0[participant.sessionId] != nil
+                && $0[participant.sessionId]?.showTrack == true
+                && $0[participant.sessionId]?.pin == nil
+        }
+    }
+
+    func test_handlePinsChanged_givenParticipantJoinedWhilePinned_whenPublished_thenKeepsRemotePin() async throws {
+        let participant = CallParticipant.dummy()
+        var joinedEvent = Stream_Video_Sfu_Event_ParticipantJoined()
+        joinedEvent.participant = .init()
+        joinedEvent.participant.userID = participant.sessionId
+        joinedEvent.participant.sessionID = participant.sessionId
+        joinedEvent.isPinned = true
+
+        try await assert(
+            joinedEvent,
+            wrappedEvent: .sfuEvent(.participantJoined(joinedEvent)),
+            initialState: [:]
+        ) {
+            $0[participant.sessionId]?.pin?.isLocal == false
+        }
+
+        let participantsAfterJoin = await stateAdapter.participants
+        let joinedPinnedAt = try XCTUnwrap(
+            participantsAfterJoin[participant.sessionId]?.pin?.pinnedAt
+        )
+
+        var pinsChangedEvent = Stream_Video_Sfu_Event_PinsChanged()
+        var pinInfo = Stream_Video_Sfu_Models_Pin()
+        pinInfo.sessionID = participant.sessionId
+        pinsChangedEvent.pins = [pinInfo]
+
+        try await assert(
+            pinsChangedEvent,
+            wrappedEvent: .sfuEvent(.pinsUpdated(pinsChangedEvent)),
+            initialState: participantsAfterJoin
+        ) {
+            guard let pin = $0[participant.sessionId]?.pin else {
+                return false
+            }
+
+            return pin.isLocal == false && pin.pinnedAt >= joinedPinnedAt
+        }
+    }
+
     func test_handleParticipantJoined_givenEventWithRecording_whenPublished_thenDoesNotAddParticipant() async throws {
         let participant = CallParticipant.dummy()
         var event = Stream_Video_Sfu_Event_ParticipantJoined()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1615/enhancementrespect-sfu-is-pinned-on-participantjoined-event

### 🎯 Goal

Support server-side pinning when a participant joins a call already pinned, and keep that remote pin stable after the next full `PinsChanged` event.

### 📝 Summary

- Apply a remote pin to participants who join with `ParticipantJoined.isPinned == true`
- Preserve that remote pin when the server sends the full pins snapshot
- Add focused SFU adapter coverage for pinned join, unpinned join, and pinned join followed by `PinsChanged`

### 🛠 Implementation

`SFUEventAdapter.handleParticipantJoined` now sets `participant.pin` to a remote pin when the SFU join event includes `isPinned == true`.

`SFUEventAdapter.handlePinsChanged` was adjusted so participants that are already remotely pinned and still present in the server's full pin list keep their pin instead of being cleared on the next snapshot. This keeps the new join-time behavior consistent with subsequent server updates.

Added unit tests in `SFUEventAdapter_Tests` for:
- participant joins with `isPinned == true`
- participant joins with `isPinned == false`
- participant joins pinned, then remains pinned after `PinsChanged`

### 🧪 Manual Testing Notes

1. Use another client with `pin-for-everyone` capability to pin a participant before or during join.
2. Join the same call from the iOS SDK.
3. Confirm the participant appears pinned immediately if the join event includes `isPinned == true`.
4. Trigger a subsequent pins update and confirm the participant remains remotely pinned.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant pinning behavior to correctly apply pin metadata when participants join video calls.
  * Enhanced pin state consistency during participant join and pin update events.

* **Tests**
  * Added comprehensive test coverage for participant pinning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->