### PR TITLE
[Fix]Delayed remote audio by replaying buffered subscriber ICE trickles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent repeated screen-sharing permission prompts on reconnection after screen capture is denied. [#1102](https://github.com/GetStream/stream-video-swift/pull/1102)
 - Prevent hanging up while a call is still joining from briefly showing the in-call UI after the join finishes in the background. [#1101](https://github.com/GetStream/stream-video-swift/pull/1101)
 - Delay microphone and camera permission prompts until the app is in the foreground and the WebRTC join has completed. [#1103](https://github.com/GetStream/stream-video-swift/pull/1103)
+- Replay buffered subscriber ICE trickles during join so remote audio does not wait for a later subscriber ICE restart before becoming audible. [#1111](https://github.com/GetStream/stream-video-swift/pull/1111)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
@@ -270,20 +270,27 @@ final class SFUAdapter: ConnectionStateDelegate, CustomStringConvertible, @unche
         subjectSendEvent.send(LeaveEvent(hostname: host, payload: payload))
     }
 
-    /// Consumes events of a specified type from the given event bucket.
+    /// Replays buffered SFU events of a specified type.
     ///
-    /// This method retrieves all events of the specified type from the provided
-    /// `SFUEventBucket` and sends them through the WebSocket's event subject.
+    /// The bucket may contain a mix of SFU payloads collected while another
+    /// part of the join flow was not ready to observe them yet. Replayed
+    /// events are forwarded through the WebSocket event subject so existing
+    /// typed publishers can process them as if they had just arrived from the
+    /// network.
     ///
     /// - Parameters:
-    ///   - eventType: The type of events to consume.
-    ///   - bucket: The `SFUEventBucket` from which to consume events.
+    ///   - eventType: The type of buffered events to replay.
+    ///   - bucket: The bucket that stores buffered SFU payloads.
+    ///   - flush: When `true`, clears the bucket as part of consumption.
+    ///     Pass `false` when additional event types still need to be replayed
+    ///     from the same mixed bucket.
     func consume<EventType>(
         _ eventType: EventType.Type,
-        bucket: ConsumableBucket<Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload>
+        bucket: ConsumableBucket<Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload>,
+        flush: Bool
     ) {
         let events = bucket
-            .consume(flush: true)
+            .consume(flush: flush)
             .filter { $0.payload(EventType.self) != nil }
 
         guard !events.isEmpty else {

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -403,17 +403,25 @@ extension WebRTCCoordinator.StateMachine.Stage {
 
                 try Task.checkCancellation()
 
-                // Once our PeerConnection have been created we consume the
-                // eventBucket we created above in order to re-apply any event
-                // that our PeerConnections missed during the initialisation.
+                // Once our PeerConnections have been created we replay the
+                // buffered SFU events that may have arrived before the
+                // subscriber stack was ready to observe them.
                 //
-                // Specifically, below we are consuming any SubscriberOffer event
-                // that has being received before our Subscriber was ready to
-                // process it. This scenario is possible to occur if we join
-                // a call where another user is already publishing audio.
+                // This is especially important when we join a call where
+                // another participant is already publishing audio. In that
+                // case the SFU can send both a subscriber offer and the
+                // associated subscriber ICE trickles before the subscriber
+                // peer connection and ICE adapter are fully configured.
                 sfuAdapter.consume(
                     Stream_Video_Sfu_Event_SubscriberOffer.self,
-                    bucket: subscriberEventBucket
+                    bucket: subscriberEventBucket,
+                    flush: false
+                )
+
+                sfuAdapter.consume(
+                    Stream_Video_Sfu_Models_ICETrickle.self,
+                    bucket: subscriberEventBucket,
+                    flush: true
                 )
 
                 try Task.checkCancellation()

--- a/StreamVideoTests/WebRTC/SFU/SFUAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUAdapter_Tests.swift
@@ -539,6 +539,83 @@ final class SFUAdapterTests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    // MARK: - consume
+
+    func test_subscriberOfferAndSubscriberICETrickle_bufferedOnSharedPublisher_replayedAcrossSeparateConsumes() async throws {
+        _ = subject
+
+        let bucket = ConsumableBucket(
+            subject.publisher.eraseToAnyPublisher()
+        )
+
+        var offer = Stream_Video_Sfu_Event_SubscriberOffer()
+        offer.sdp = .unique
+
+        var trickle = Stream_Video_Sfu_Models_ICETrickle()
+        trickle.sessionID = .unique
+        trickle.peerType = .subscriber
+        trickle.iceCandidate = .unique
+
+        let healthCheck = Stream_Video_Sfu_Event_HealthCheckResponse()
+
+        var replayedOffers: [Stream_Video_Sfu_Event_SubscriberOffer] = []
+        var replayedTrickles: [Stream_Video_Sfu_Models_ICETrickle] = []
+        var replayedHealthChecks: [Stream_Video_Sfu_Event_HealthCheckResponse] = []
+
+        let offerCancellable = subject
+            .publisher(eventType: Stream_Video_Sfu_Event_SubscriberOffer.self)
+            .sink { replayedOffers.append($0) }
+        let trickleCancellable = subject
+            .publisher(eventType: Stream_Video_Sfu_Models_ICETrickle.self)
+            .sink { replayedTrickles.append($0) }
+        let healthCheckCancellable = subject
+            .publisher(eventType: Stream_Video_Sfu_Event_HealthCheckResponse.self)
+            .sink { replayedHealthChecks.append($0) }
+
+        defer {
+            offerCancellable.cancel()
+            trickleCancellable.cancel()
+            healthCheckCancellable.cancel()
+        }
+
+        mockWebSocket.eventSubject.send(.sfuEvent(.subscriberOffer(offer)))
+        mockWebSocket.eventSubject.send(.sfuEvent(.iceTrickle(trickle)))
+        mockWebSocket.eventSubject.send(.sfuEvent(.healthCheckResponse(healthCheck)))
+
+        await wait(for: 0.1)
+
+        replayedOffers.removeAll()
+        replayedTrickles.removeAll()
+        replayedHealthChecks.removeAll()
+
+        subject.consume(
+            Stream_Video_Sfu_Event_SubscriberOffer.self,
+            bucket: bucket,
+            flush: false
+        )
+
+        await wait(for: 0.1)
+
+        XCTAssertEqual(replayedOffers.map(\.sdp), [offer.sdp])
+        XCTAssertTrue(replayedTrickles.isEmpty)
+        XCTAssertTrue(replayedHealthChecks.isEmpty)
+
+        subject.consume(
+            Stream_Video_Sfu_Models_ICETrickle.self,
+            bucket: bucket,
+            flush: true
+        )
+
+        await wait(for: 0.1)
+
+        XCTAssertEqual(replayedOffers.map(\.sdp), [offer.sdp])
+        XCTAssertEqual(
+            replayedTrickles.map(\.iceCandidate),
+            [trickle.iceCandidate]
+        )
+        XCTAssertTrue(replayedHealthChecks.isEmpty)
+    }
+
     // MARK: - webSocketClient(_:didUpdateConnectionState:)
 
     func test_didUpdateConnectionState_connectionStateWasUpdated() {

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/Adapters/ICEAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/Adapters/ICEAdapter_Tests.swift
@@ -177,6 +177,77 @@ final class ICEAdapterTests: XCTestCase, @unchecked Sendable {
         XCTAssertNil(candidate.sdpMid)
     }
 
+    func test_subscriberICETrickle_receivedBeforeRemoteDescription_addsCandidateAfterHasRemoteDescription() async throws {
+        let subscriber = ICEAdapter(
+            sessionID: sessionId,
+            peerType: .subscriber,
+            peerConnection: mockPeerConnection,
+            sfuAdapter: mockSFUStack.adapter
+        )
+
+        mockSFUStack.setConnectionState(to: .connected(healthCheckInfo: .init()))
+        await wait(for: 0.5)
+
+        var event = Stream_Video_Sfu_Models_ICETrickle()
+        event.sessionID = sessionId
+        event.peerType = .subscriber
+        event.iceCandidate = """
+        {
+            "candidate":"\(String.unique)"
+        }
+        """
+
+        mockSFUStack.receiveEvent(.sfuEvent(.iceTrickle(event)))
+        await wait(for: 0.5)
+
+        XCTAssertEqual(mockPeerConnection.timesCalled(.addCandidate), 0)
+
+        mockPeerConnection
+            .subject
+            .send(
+                StreamRTCPeerConnection.HasRemoteDescription(
+                    sessionDescription: .init(type: .answer, sdp: .unique)
+                )
+            )
+
+        await fulfillment { self.mockPeerConnection.timesCalled(.addCandidate) == 1 }
+        _ = subscriber
+    }
+
+    func test_subscriberICETrickle_withPublisherPeerType_doesNotAddCandidateOnSubscriberAdapter() async throws {
+        let subscriber = ICEAdapter(
+            sessionID: sessionId,
+            peerType: .subscriber,
+            peerConnection: mockPeerConnection,
+            sfuAdapter: mockSFUStack.adapter
+        )
+
+        mockPeerConnection.stub(
+            for: \.remoteDescription,
+            with: RTCSessionDescription(
+                type: .answer,
+                sdp: .unique
+            )
+        )
+        mockSFUStack.setConnectionState(to: .connected(healthCheckInfo: .init()))
+        await wait(for: 0.5)
+
+        var event = Stream_Video_Sfu_Models_ICETrickle()
+        event.sessionID = sessionId
+        event.peerType = .publisherUnspecified
+        event.iceCandidate = """
+        {
+            "candidate":"\(String.unique)"
+        }
+        """
+
+        mockSFUStack.receiveEvent(.sfuEvent(.iceTrickle(event)))
+        await wait(for: 0.5)
+
+        XCTAssertEqual(mockPeerConnection.timesCalled(.addCandidate), 0)
+        _ = subscriber
+    }
+
     // MARK: - Private helpers
 
     private func assertSFUTrickleTriggered(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1621/bugtrack-subscription-failure

### 🎯 Goal

Prevent the long delay before remote audio becomes audible when the SFU sends the initial subscriber offer and subscriber ICE trickle candidates before the subscriber peer connection is ready to observe them.

### 📝 Summary

- Replay buffered subscriber ICE trickle events during `JoiningStage`, alongside the buffered subscriber offer.
- Update the SFU replay API so mixed buffered event buckets can be replayed across multiple event types without dropping later events on the first consume.
- Add focused unit coverage for shared-bucket replay behavior and for subscriber ICE buffering/draining in `ICEAdapter`.
- Add doc comments for the staged replay behavior and the new replay API semantics.

### 🛠 Implementation

The bug was caused by the join flow buffering all SFU events in a shared `ConsumableBucket`, but only replaying `SubscriberOffer` after peer connections were created. Any buffered `Stream_Video_Sfu_Models_ICETrickle` events for the subscriber were therefore lost, which left the subscriber peer connection waiting until the SFU later renegotiated and sent a fresh offer/trickle sequence.

This change updates `SFUAdapter.consume` to support non-flushing replay so the same mixed bucket can be replayed in multiple passes. `JoiningStage` now replays buffered `SubscriberOffer` events first and then replays buffered subscriber `ICETrickle` events from the same bucket.

Tests were added to verify:
- mixed buffered SFU events can be replayed across separate consumes,
- subscriber ICE trickles received before `remoteDescription` are buffered and drained once `HasRemoteDescription` arrives,
- publisher-typed ICE trickles are ignored by the subscriber ICE adapter.

### 🧪 Manual Testing Notes

#### Scenario 1

Steps to reproduce the original issue:
1. Run the demo app with two participants.
2. Use an audio-only call.
3. Connect Bluetooth headphones on the joining device (for example AirPods Pro).
4. Have participant A join first, publish audio, and start speaking continuously.
5. Have participant B accept/join the call.
6. Observe that the call reaches `joined` quickly, but remote audio is not audible for about 20 seconds.
7. Check logs and note that the initial subscriber setup happens early, but subscriber ICE only becomes healthy after a later renegotiation / ICE restart.

How to validate the fix:
1. Repeat the same scenario above.
2. Confirm remote audio becomes audible within a few seconds of join rather than after a long delay.
3. Confirm there is no need to wait for a second subscriber offer / ICE restart before hearing the remote participant.

#### Scenario 2
- Join a call with another participant
- Trigger a manual rejoin/migration
- Once rejoined/migrated tracks should be available as soon as possible

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)