### PR TITLE
[Enhancement]Respect participantAutoLeavePolicy in CallKitService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Added optional leave reasons to `Call.leave` and `CallViewModel.hangUp`, and propagated them through the WebRTC leave flow so SFU leave requests include explicit end-of-call context. [#1100](https://github.com/GetStream/stream-video-swift/pull/1100)
 - Added an optional join interception hook so apps can delay or abort call entry after the join response is applied locally. [#1108](https://github.com/GetStream/stream-video-swift/pull/1108)
+- Exposed `participantAutoLeavePolicy` on `CallKitAdapter` and `CallKitService` so CallKit flows can share the same auto-leave rules as `CallViewModel`.
 
 ### 🐞 Fixed
 - Prevent abrupt call endings caused by audio-session readiness timing. [#1098](https://github.com/GetStream/stream-video-swift/pull/1098)
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent outgoing ringing time from being counted toward call duration. [#1106](https://github.com/GetStream/stream-video-swift/pull/1106)
 - Replay buffered subscriber ICE trickles during join so remote audio does not wait for a later subscriber ICE restart before becoming audible. [#1111](https://github.com/GetStream/stream-video-swift/pull/1111)
 - Fix join-call timeout caused by a `PassthroughSubject` race where the response was emitted before the subscription was established. [#1113](https://github.com/GetStream/stream-video-swift/pull/1113)
+- CallKit-managed calls now respect the configured `participantAutoLeavePolicy`
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent outgoing ringing time from being counted toward call duration. [#1106](https://github.com/GetStream/stream-video-swift/pull/1106)
 - Replay buffered subscriber ICE trickles during join so remote audio does not wait for a later subscriber ICE restart before becoming audible. [#1111](https://github.com/GetStream/stream-video-swift/pull/1111)
 - Fix join-call timeout caused by a `PassthroughSubject` race where the response was emitted before the subscription was established. [#1113](https://github.com/GetStream/stream-video-swift/pull/1113)
-- CallKit-managed calls now respect the configured `participantAutoLeavePolicy`
+- CallKit-managed calls now respect the configured `participantAutoLeavePolicy`. [#1112](https://github.com/GetStream/stream-video-swift/pull/1112)
 
 # [1.45.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.45.0)
 _March 31, 2026_

--- a/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
@@ -71,6 +71,8 @@ struct DemoCallingViewModifier: ViewModifier {
             }
             .onAppear {
                 guard !isAnonymous else { return }
+                callKitAdapter.participantAutoLeavePolicy =
+                    AppEnvironment.autoLeavePolicy.policy
                 callKitAdapter.registerForIncomingCalls()
                 callKitAdapter.iconTemplateImageData = UIImage(named: "logo")?.pngData()
                 configureVideoRenderingOptions()

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/03-callkit-integration.swift
@@ -106,6 +106,12 @@ private func content() {
     }
 
     container {
+        @Injected(\.callKitAdapter) var callKitAdapter
+        callKitAdapter.participantAutoLeavePolicy =
+            LastParticipantAutoLeavePolicy()
+    }
+
+    container {
         struct MyCustomView: View {
             @Injected(\.streamVideo) var streamVideo
             @Injected(\.callKitAdapter) var callKitAdapter

--- a/Sources/StreamVideo/CallKit/CallKitAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitAdapter.swift
@@ -39,6 +39,13 @@ open class CallKitAdapter {
         didSet { callKitService.callSettings = callSettings }
     }
 
+    /// The policy that decides if a CallKit-managed call should leave
+    /// automatically when participant state changes.
+    open var participantAutoLeavePolicy: ParticipantAutoLeavePolicy {
+        get { callKitService.participantAutoLeavePolicy }
+        set { callKitService.participantAutoLeavePolicy = newValue }
+    }
+
     /// The policy defining the availability of CallKit services.
     ///
     /// - Default: `.regionBased`

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -740,18 +740,44 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         ringingTimedOut: Bool,
         leaveReason: String? = nil
     ) {
-        guard let callEndedEntry = callEntry(for: cId) else {
+        // Inspect and mark the entry as ended while holding the storage lock so
+        // competing end requests cannot overwrite the original end cause.
+        let result: (CallEntry, Bool)? = storageAccessQueue.sync {
+            guard
+                let callEndedEntry = _storage.first(where: { $0.value.call.cId == cId })?.value
+            else {
+                return nil
+            }
+
+            let wasAlreadyMarkedEnded = callEndedEntry.leaveReason != nil
+                || callEndedEntry.isEndedElsewhere
+                || callEndedEntry.ringingTimedOut
+
+            guard wasAlreadyMarkedEnded == false else {
+                // A previous caller already decided why this call ended.
+                return (callEndedEntry, false)
+            }
+
+            if ringingTimedOut {
+                callEndedEntry.ringingTimedOut = true
+            } else {
+                callEndedEntry.isEndedElsewhere = true
+            }
+
+            if let leaveReason {
+                callEndedEntry.leaveReason = leaveReason
+            }
+
+            _storage[callEndedEntry.callUUID] = callEndedEntry
+
+            return (callEndedEntry, true)
+        }
+
+        guard let result else {
             return
         }
-        if ringingTimedOut {
-            callEndedEntry.ringingTimedOut = ringingTimedOut
-        } else {
-            callEndedEntry.isEndedElsewhere = true
-        }
-        if let leaveReason {
-            callEndedEntry.leaveReason = leaveReason
-        }
-        set(callEndedEntry, for: callEndedEntry.callUUID)
+
+        let (callEndedEntry, shouldRequestTransaction) = result
 
         log.debug(
             """
@@ -765,6 +791,12 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             """,
             subsystems: .callKit
         )
+        guard shouldRequestTransaction else {
+            return
+        }
+
+        // Only the first transition to ended should enqueue a CallKit end
+        // action. Later callers reuse the stored end state and exit above.
         Task(disposableBag: disposableBag) { [weak self] in
             do {
                 // End the call.

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -384,10 +384,13 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         endCall(cId, ringingTimedOut: ringingTimedOut)
     }
 
-    /// Handle when a participant leaves the call.
+    /// Called when a participant leaves the call.
     ///
-    /// The default implementation delegates auto-leave decisions to
-    /// `participantAutoLeavePolicy`.
+    /// The default implementation is a **no-op**. Auto-leave
+    /// decisions are handled independently by the configured
+    /// ``participantAutoLeavePolicy``, which observes participant
+    /// state on its own. Override this method in a subclass if
+    /// you need custom handling for participant-left events.
     open func callParticipantLeft(
         _ response: CallSessionParticipantLeftEvent
     ) {

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -32,6 +32,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         var isActive: Bool = false
         var ringingTimedOut: Bool = false
         var isEndedElsewhere: Bool = false
+        var leaveReason: String?
 
         init(
             call: Call,
@@ -121,6 +122,19 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// runs in the background. See `CallKitMissingPermissionPolicy`.
     open var missingPermissionPolicy: CallKitMissingPermissionPolicy = .none
 
+    /// The policy that decides whether CallKit-managed calls should leave
+    /// automatically when participant state changes.
+    open var participantAutoLeavePolicy: ParticipantAutoLeavePolicy =
+        DefaultParticipantAutoLeavePolicy() {
+        didSet {
+            var oldValue = oldValue
+            oldValue.onPolicyTriggered = nil
+            participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in
+                self?.participantAutoLeavePolicyTriggered()
+            }
+        }
+    }
+
     var callSettings: CallSettings?
 
     /// The call controller used for managing calls.
@@ -170,6 +184,10 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             .filter { [weak self] _ in self?.applicationStateAdapter.state != .foreground }
             .debounce(for: 0.5, scheduler: DispatchQueue.global(qos: .userInteractive))
             .sink { [weak self] in self?.performMuteRequest($0) }
+
+        participantAutoLeavePolicy.onPolicyTriggered = { [weak self] in
+            self?.participantAutoLeavePolicyTriggered()
+        }
     }
 
     /// Report an incoming call to CallKit.
@@ -360,60 +378,17 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         _ cId: String,
         ringingTimedOut: Bool
     ) {
-        guard let callEndedEntry = callEntry(for: cId) else {
-            return
-        }
-        if ringingTimedOut {
-            callEndedEntry.ringingTimedOut = ringingTimedOut
-        } else {
-            callEndedEntry.isEndedElsewhere = true
-        }
-        set(callEndedEntry, for: callEndedEntry.callUUID)
-
-        log.debug(
-            """
-            CallEnded
-            callId:\(callEndedEntry.call.callId)
-            callType:\(callEndedEntry.call.callType)
-            callerId:\(callEndedEntry.createdBy?.id)
-            ringingTimedOut:\(callEndedEntry.ringingTimedOut)
-            isEndedElsewhere:\(callEndedEntry.isEndedElsewhere)
-            """,
-            subsystems: .callKit
-        )
-        Task(disposableBag: disposableBag) { [weak self] in
-            do {
-                // End the call.
-                try await self?.requestTransaction(
-                    CXEndCallAction(
-                        call: callEndedEntry.callUUID
-                    )
-                )
-            } catch {
-                log.error(error, subsystems: .callKit)
-            }
-        }
+        endCall(cId, ringingTimedOut: ringingTimedOut)
     }
 
     /// Handle when a participant leaves the call.
+    ///
+    /// The default implementation delegates auto-leave decisions to
+    /// `participantAutoLeavePolicy`.
     open func callParticipantLeft(
         _ response: CallSessionParticipantLeftEvent
     ) {
-        // End the call if only one participant remains.
-        /// in the call, we leave.
-        Task(disposableBag: disposableBag) { @MainActor [weak self] in
-            guard let self else {
-                return
-            }
-            if let call = callEntry(for: response.callCid)?.call,
-               call.state.participants.count == 1 {
-                log.debug(
-                    "Call will end as only one participant left in the call",
-                    subsystems: .callKit
-                )
-                callEnded(response.callCid, ringingTimedOut: false)
-            }
-        }
+        _ = response
     }
 
     // MARK: - CXProviderDelegate
@@ -585,7 +560,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 // is ended before or during the join flow.
                 eventPipelineSubject.send(.reject)
                 stackEntry.call.didPerform(.performEndCall)
-                stackEntry.call.leave()
+                stackEntry.call.leave(reason: stackEntry.leaveReason)
             } else {
                 do {
                     let rejectionReason = await streamVideo?
@@ -751,6 +726,65 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         log.debug(
             "\(type(of: self)) is now subscribed to CallEvent updates.",
             subsystems: .callKit
+        )
+    }
+
+    private func endCall(
+        _ cId: String,
+        ringingTimedOut: Bool,
+        leaveReason: String? = nil
+    ) {
+        guard let callEndedEntry = callEntry(for: cId) else {
+            return
+        }
+        if ringingTimedOut {
+            callEndedEntry.ringingTimedOut = ringingTimedOut
+        } else {
+            callEndedEntry.isEndedElsewhere = true
+        }
+        if let leaveReason {
+            callEndedEntry.leaveReason = leaveReason
+        }
+        set(callEndedEntry, for: callEndedEntry.callUUID)
+
+        log.debug(
+            """
+            CallEnded
+            callId:\(callEndedEntry.call.callId)
+            callType:\(callEndedEntry.call.callType)
+            callerId:\(callEndedEntry.createdBy?.id)
+            ringingTimedOut:\(callEndedEntry.ringingTimedOut)
+            isEndedElsewhere:\(callEndedEntry.isEndedElsewhere)
+            leaveReason:\(callEndedEntry.leaveReason ?? "nil")
+            """,
+            subsystems: .callKit
+        )
+        Task(disposableBag: disposableBag) { [weak self] in
+            do {
+                // End the call.
+                try await self?.requestTransaction(
+                    CXEndCallAction(
+                        call: callEndedEntry.callUUID
+                    )
+                )
+            } catch {
+                log.error(error, subsystems: .callKit)
+            }
+        }
+    }
+
+    private func participantAutoLeavePolicyTriggered() {
+        guard
+            let active,
+            let activeCallEntry = callEntry(for: active)
+        else {
+            return
+        }
+
+        endCall(
+            activeCallEntry.call.cId,
+            ringingTimedOut: false,
+            leaveReason: "auto-leave"
         )
     }
 

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -122,10 +122,13 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// runs in the background. See `CallKitMissingPermissionPolicy`.
     open var missingPermissionPolicy: CallKitMissingPermissionPolicy = .none
 
-    /// The policy that decides whether CallKit-managed calls should leave
-    /// automatically when participant state changes.
-    open var participantAutoLeavePolicy: ParticipantAutoLeavePolicy =
-        DefaultParticipantAutoLeavePolicy() {
+    /// The policy that decides whether CallKit-managed calls
+    /// should leave automatically when participant state changes.
+    ///
+    /// - Important: Assign a **dedicated** policy instance.
+    ///   Do not share the same instance with ``CallViewModel``
+    ///   because each consumer overwrites `onPolicyTriggered`.
+    open var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = LastParticipantAutoLeavePolicy() {
         didSet {
             var oldValue = oldValue
             oldValue.onPolicyTriggered = nil

--- a/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/ParticipantAutoLeavePolicy.swift
+++ b/Sources/StreamVideo/Utils/ParticipantAutoLeavePolicy/ParticipantAutoLeavePolicy.swift
@@ -4,10 +4,23 @@
 
 import Foundation
 
-/// A policy that can be used to apply certain business logic depending on the participants state during
-/// a call.
+/// A policy that decides whether the local user should
+/// automatically leave a call based on participant state.
+///
+/// Both ``CallViewModel`` and ``CallKitService`` accept a
+/// policy instance and wire `onPolicyTriggered` internally.
+/// Because the protocol exposes a **single** closure slot,
+/// each consumer **must** receive its own policy instance.
+/// Sharing one instance between two consumers will cause the
+/// later assignment to silently disconnect the earlier one.
 public protocol ParticipantAutoLeavePolicy: Sendable {
 
-    /// A closure that will be called once the rules evaluated in the policy have been triggered.
+    /// Called by the policy implementation when its rules are
+    /// satisfied (e.g. only one participant remains).
+    ///
+    /// - Important: Only one consumer should set this closure
+    ///   per policy instance. Create a dedicated instance for
+    ///   each consumer (``CallViewModel``, ``CallKitService``,
+    ///   etc.) to avoid overwriting another consumer's handler.
     var onPolicyTriggered: (() -> Void)? { get set }
 }

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -258,8 +258,13 @@ open class CallViewModel: ObservableObject {
 
     private var automaticLayoutHandling = true
 
-    /// The policy to whenever call events occur in order to decide if the current user should remain
-    /// in the call or not. Default value is the no operation policy `DefaultParticipantAutoLeavePolicy`,
+    /// The policy that decides whether the local user should
+    /// automatically leave based on participant state changes.
+    /// Defaults to ``DefaultParticipantAutoLeavePolicy`` (no-op).
+    ///
+    /// - Important: Assign a **dedicated** policy instance.
+    ///   Do not share the same instance with ``CallKitService``
+    ///   because each consumer overwrites `onPolicyTriggered`.
     public var participantAutoLeavePolicy: ParticipantAutoLeavePolicy = DefaultParticipantAutoLeavePolicy() {
         didSet {
             var oldValue = oldValue

--- a/StreamVideoTests/CallKit/CallKitAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitAdapterTests.swift
@@ -14,6 +14,7 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
     @MainActor
     override func setUp() async throws {
         try await super.setUp()
+        _ = MockStreamVideo()
         InjectedValues[\.callKitPushNotificationAdapter] = callKitPushNotificationAdapter
         InjectedValues[\.callKitService] = callKitService
         CurrentDevice.currentValue.didUpdate(.phone)

--- a/StreamVideoTests/CallKit/CallKitAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitAdapterTests.swift
@@ -79,7 +79,7 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(callKitService.callSettings, callSettings)
     }
 
-    func test_participantAutoLeavePolicy_callKitServiceReceivedTheUpdatedValue() {
+    func test_participantAutoLeavePolicy_whenSet_forwardsValueToCallKitService() {
         let policy = MockParticipantAutoLeavePolicy()
 
         subject.participantAutoLeavePolicy = policy

--- a/StreamVideoTests/CallKit/CallKitAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitAdapterTests.swift
@@ -79,6 +79,17 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(callKitService.callSettings, callSettings)
     }
 
+    func test_participantAutoLeavePolicy_callKitServiceReceivedTheUpdatedValue() {
+        let policy = MockParticipantAutoLeavePolicy()
+
+        subject.participantAutoLeavePolicy = policy
+
+        XCTAssertEqual(
+            ObjectIdentifier(callKitService.participantAutoLeavePolicy as AnyObject),
+            ObjectIdentifier(policy)
+        )
+    }
+
     // MARK: - Private Helpers
 
     private func makeStreamVideo() async throws -> StreamVideo {
@@ -100,4 +111,10 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
 
         return client
     }
+}
+
+private final class MockParticipantAutoLeavePolicy:
+    ParticipantAutoLeavePolicy,
+    @unchecked Sendable {
+    var onPolicyTriggered: (() -> Void)?
 }

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -797,7 +797,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     // MARK: - callParticipantLeft
 
     @MainActor
-    func test_callParticipantLeft_participantsLeftMoreThanOne_callWasNotEnded() async throws {
+    func test_callParticipantLeft_defaultParticipantAutoLeavePolicy_callWasNotEnded() async throws {
         let firstCallUUID = UUID()
         uuidFactory.getResult = firstCallUUID
         let call = stubCall(response: defaultGetCallResponse)
@@ -820,26 +820,18 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             )
         )
 
-        let callState = CallState(.dummy())
-        callState.participants = [.dummy(), .dummy()]
-        call.stub(for: \.state, with: callState)
         try await assertNotRequestTransaction(CXEndCallAction.self) {
             subject.callParticipantLeft(.dummy(callCid: call.cId))
         }
     }
 
     @MainActor
-    func test_callParticipantLeft_participantsLeftOnlyOne_callNotEnded() async throws {
+    func test_participantAutoLeavePolicyTriggered_activeCallEnded() async throws {
         let firstCallUUID = UUID()
         uuidFactory.getResult = firstCallUUID
-        let call = stubCall(
-            response: .dummy(
-                call: defaultGetCallResponse.call,
-                duration: "100",
-                members: [],
-                ownCapabilities: []
-            )
-        )
+        let call = stubCall(response: defaultGetCallResponse)
+        let participantAutoLeavePolicy = MockParticipantAutoLeavePolicy()
+        subject.participantAutoLeavePolicy = participantAutoLeavePolicy
         subject.streamVideo = mockedStreamVideo
 
         subject.reportIncomingCall(
@@ -859,13 +851,21 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             )
         )
 
-        let callState = CallState(.dummy())
-        callState.participants = [.dummy()]
-        call.stub(for: \.state, with: callState)
-
         try await assertRequestTransaction(CXEndCallAction.self) {
-            subject.callParticipantLeft(.dummy(callCid: cid))
+            participantAutoLeavePolicy.trigger()
         }
+
+        subject.provider(
+            callProvider,
+            perform: CXEndCallAction(
+                call: firstCallUUID
+            )
+        )
+
+        let reason = try XCTUnwrap(
+            call.recordedInputPayload(String.self, for: .leave)?.first
+        )
+        XCTAssertEqual(reason, "auto-leave")
     }
 
     // MARK: - didActivate
@@ -1163,5 +1163,15 @@ private class MockUUIDFactory: UUIDProviding {
 
     func get() -> UUID {
         getResult ?? .init()
+    }
+}
+
+private final class MockParticipantAutoLeavePolicy:
+    ParticipantAutoLeavePolicy,
+    @unchecked Sendable {
+    var onPolicyTriggered: (() -> Void)?
+
+    func trigger() {
+        onPolicyTriggered?()
     }
 }

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -803,7 +803,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     // MARK: - callParticipantLeft
 
     @MainActor
-    func test_callParticipantLeft_defaultParticipantAutoLeavePolicy_callWasNotEnded() async throws {
+    func test_defaultParticipantAutoLeavePolicy_whenParticipantLeaves_doesNotEndCall() async throws {
         let firstCallUUID = UUID()
         uuidFactory.getResult = firstCallUUID
         let call = stubCall(response: defaultGetCallResponse)
@@ -832,7 +832,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     }
 
     @MainActor
-    func test_participantAutoLeavePolicyTriggered_activeCallEnded() async throws {
+    func test_activeCall_whenParticipantAutoLeavePolicyTriggers_endsCall() async throws {
         let firstCallUUID = UUID()
         uuidFactory.getResult = firstCallUUID
         let call = stubCall(response: defaultGetCallResponse)

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -855,12 +855,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             participantAutoLeavePolicy.trigger()
         }
 
-        subject.provider(
-            callProvider,
-            perform: CXEndCallAction(
-                call: firstCallUUID
-            )
-        )
+        await fulfillment { call.timesCalled(.leave) == 1 }
 
         let reason = try XCTUnwrap(
             call.recordedInputPayload(String.self, for: .leave)?.first

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -67,6 +67,12 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         super.tearDown()
     }
 
+    // MARK: - participantAutoLeavePolicy
+
+    func test_participantAutoLeavePolicy_hasExpectedDefaultValue() {
+        XCTAssertTrue(subject.participantAutoLeavePolicy is LastParticipantAutoLeavePolicy)
+    }
+
     // MARK: - reportIncomingCall
 
     @MainActor

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -800,6 +800,51 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(reason, "timeout")
     }
 
+    @MainActor
+    func test_callEnded_whenAlreadyMarkedEnded_doesNotRequestSecondTransaction()
+        async throws {
+        let call = stubCall(response: defaultGetCallResponse)
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        subject.callEnded(cid, ringingTimedOut: true)
+
+        await fulfillment(timeout: defaultTimeout) {
+            (self.callController.requestWasCalledWith?.0.actions.last
+                as? CXEndCallAction
+            ) != nil
+        }
+
+        let firstAction = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXEndCallAction
+        )
+
+        callController.reset()
+        subject.callEnded(cid, ringingTimedOut: false)
+
+        await waitExpectation(
+            timeout: 1,
+            description: "Wait for duplicate endCall tasks to complete."
+        )
+
+        XCTAssertNil(callController.requestWasCalledWith)
+
+        subject.provider(callProvider, perform: firstAction)
+
+        await fulfillment { call.timesCalled(.reject) == 1 }
+
+        let reason = try XCTUnwrap(
+            call.recordedInputPayload(String.self, for: .reject)?.first
+        )
+        XCTAssertEqual(reason, "timeout")
+    }
+
     // MARK: - callParticipantLeft
 
     @MainActor


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1622/enhancementcallkitservice-use-of-participantleavepolicy

### 📚 Docs

https://github.com/GetStream/docs-content/pull/1203

### 🎯 Goal

Keep CallKit-managed call teardown aligned with the same participant auto-leave rules used by `CallViewModel`, instead of hard-coding a last-participant end-call behavior inside `CallKitService`.

### 📝 Summary

- Add `participantAutoLeavePolicy` to `CallKitService` and wire its trigger callback similarly to `CallViewModel`.
- Remove the hard-coded participant-left end-call logic from `CallKitService`.
- Preserve the `"auto-leave"` leave reason through the CallKit end-call flow.
- Expose the policy through `CallKitAdapter`.
- Update demo and documentation examples to show CallKit configuration with `LastParticipantAutoLeavePolicy`.

### 🛠 Implementation

`CallKitService` now owns a configurable `participantAutoLeavePolicy` with a default `DefaultParticipantAutoLeavePolicy`, and registers the policy trigger during initialization and on reassignment. Instead of ending the call directly from `callParticipantLeft`, the service now waits for the configured policy to fire and routes that through a shared internal `endCall` helper.

To preserve backend context, the service stores an optional leave reason on the active CallKit entry and forwards `"auto-leave"` when the matching `CXEndCallAction` is executed. `CallKitAdapter` exposes the same policy so app code can configure CallKit and SwiftUI flows consistently.

### 🧪 Manual Testing Notes

1. Configure `callKitAdapter.participantAutoLeavePolicy = LastParticipantAutoLeavePolicy()`.
2. Receive and accept a ringing call through CallKit.
3. Verify the call does not end just because a `participant_left` event arrives unless the configured policy triggers.
4. Verify that when the policy does trigger, the CallKit-managed call ends cleanly.
5. Verify the leave reason forwarded from the CallKit end flow is `"auto-leave"`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CallKit exposes a configurable auto-leave policy so CallKit flows share the same auto-leave rules as the in-app call view.

* **Bug Fixes**
  * CallKit-managed calls now honor the configured auto-leave policy instead of always ending when only one participant remains.

* **Documentation**
  * Examples and docs updated to show configuring the CallKit auto-leave policy and warn against sharing a single policy instance across consumers.

* **Tests**
  * Added tests verifying policy propagation and that policy-triggered auto-leave ends calls with the expected leave reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->