### PR TITLE
[Enhancement]Prevent duplicate WebRTC create traces during reconnect

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter.swift
@@ -68,20 +68,26 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     /// data, and re-attach Combine publishers to new event streams.
     var sfuAdapter: SFUAdapter? { didSet { didUpdate(sfuAdapter) } }
 
-    /// The peer connection coordinator for the publisher/subscriber stream.
+    /// The peer connection coordinator for the publishing peer connection.
     ///
-    /// Updating these will reset trace event collection for the respective role,
-    /// flush prior traces, and attach to the new event stream.
+    /// Assigning a different coordinator instance rebinds tracing for the
+    /// publisher role and emits a synthetic `create` trace for that new
+    /// peer connection. Reassigning the same instance is ignored so reconnect
+    /// flows do not emit duplicate synthetic `create` traces. Setting this to
+    /// `nil` removes the current publisher subscription.
     var publisher: RTCPeerConnectionCoordinator? {
-        didSet { didUpdate(publisher: publisher) }
+        didSet { didUpdate(publisher: publisher, oldValue: oldValue) }
     }
 
-    /// The peer connection coordinator for the publisher/subscriber stream.
+    /// The peer connection coordinator for the subscribing peer connection.
     ///
-    /// Updating these will reset trace event collection for the respective role,
-    /// flush prior traces, and attach to the new event stream.
+    /// Assigning a different coordinator instance rebinds tracing for the
+    /// subscriber role and emits a synthetic `create` trace for that new
+    /// peer connection. Reassigning the same instance is ignored so reconnect
+    /// flows do not emit duplicate synthetic `create` traces. Setting this to
+    /// `nil` removes the current subscriber subscription.
     var subscriber: RTCPeerConnectionCoordinator? {
-        didSet { didUpdate(subscriber: subscriber) }
+        didSet { didUpdate(subscriber: subscriber, oldValue: oldValue) }
     }
 
     /// Buffers trace events related to publisher/subscriber peer connections.
@@ -273,14 +279,24 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
             .store(in: disposableBag, key: DisposableKey.error.rawValue)
     }
 
-    /// Handles changes to the publisher/subscriber peer connection.
+    /// Rebinds publisher tracing when the coordinator instance changes.
     ///
-    /// Sets up Combine event pipeline for trace collection for the specified role,
-    /// emits a "Created" event for the new peer connection, and clears prior traces.
-    private func didUpdate(publisher: RTCPeerConnectionCoordinator?) {
-        guard let peerConnection = publisher else {
+    /// Reassigning the same coordinator instance is ignored so reconnect
+    /// bookkeeping does not emit duplicate synthetic `create` traces. Setting
+    /// the coordinator to `nil` removes the active publisher subscription.
+    private func didUpdate(
+        publisher: RTCPeerConnectionCoordinator?,
+        oldValue: RTCPeerConnectionCoordinator?
+    ) {
+        guard publisher !== oldValue else {
             return
         }
+
+        guard let peerConnection = publisher else {
+            disposableBag.remove(DisposableKey.publisher.rawValue)
+            return
+        }
+
         disposableBag.remove(DisposableKey.publisher.rawValue)
         peerConnection
             .eventPublisher
@@ -301,14 +317,24 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
         )
     }
 
-    /// Handles changes to the publisher/subscriber peer connection.
+    /// Rebinds subscriber tracing when the coordinator instance changes.
     ///
-    /// Sets up Combine event pipeline for trace collection for the specified role,
-    /// emits a "Created" event for the new peer connection, and clears prior traces.
-    private func didUpdate(subscriber: RTCPeerConnectionCoordinator?) {
-        guard let peerConnection = subscriber else {
+    /// Reassigning the same coordinator instance is ignored so reconnect
+    /// bookkeeping does not emit duplicate synthetic `create` traces. Setting
+    /// the coordinator to `nil` removes the active subscriber subscription.
+    private func didUpdate(
+        subscriber: RTCPeerConnectionCoordinator?,
+        oldValue: RTCPeerConnectionCoordinator?
+    ) {
+        guard subscriber !== oldValue else {
             return
         }
+
+        guard let peerConnection = subscriber else {
+            disposableBag.remove(DisposableKey.subscriber.rawValue)
+            return
+        }
+
         disposableBag.remove(DisposableKey.subscriber.rawValue)
         peerConnection
             .eventPublisher

--- a/StreamVideoTests/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter_Tests.swift
@@ -86,4 +86,77 @@ final class WebRTCTracesAdapter_Tests: XCTestCase, @unchecked Sendable {
         }
         XCTAssertTrue(idx1 < idx3 && idx2 < idx3)
     }
+
+    func test_publisher_whenSameCoordinatorIsReassigned_doesNotEmitDuplicateCreateTrace_() throws {
+        let coordinator = try makeCoordinator(peerType: .publisher)
+
+        subject.publisher = coordinator
+
+        XCTAssertEqual(createTraces(for: "publisher", in: subject.flushTraces()).count, 1)
+
+        subject.publisher = coordinator
+
+        XCTAssertTrue(createTraces(for: "publisher", in: subject.flushTraces()).isEmpty)
+    }
+
+    func test_subscriber_whenSameCoordinatorIsReassigned_doesNotEmitDuplicateCreateTrace_() throws {
+        let coordinator = try makeCoordinator(peerType: .subscriber)
+
+        subject.subscriber = coordinator
+
+        XCTAssertEqual(createTraces(for: "subscriber", in: subject.flushTraces()).count, 1)
+
+        subject.subscriber = coordinator
+
+        XCTAssertTrue(createTraces(for: "subscriber", in: subject.flushTraces()).isEmpty)
+    }
+
+    func test_publisher_whenCoordinatorChanges_emitsCreateTraceForReplacement_() throws {
+        let first = try makeCoordinator(peerType: .publisher)
+        let second = try makeCoordinator(peerType: .publisher)
+
+        subject.publisher = first
+        _ = subject.flushTraces()
+
+        subject.publisher = second
+
+        XCTAssertEqual(createTraces(for: "publisher", in: subject.flushTraces()).count, 1)
+    }
+
+    func test_subscriber_whenCleared_stopsObservingEventsFromPreviousCoordinator_() throws {
+        let coordinator = try makeCoordinator(peerType: .subscriber)
+
+        subject.subscriber = coordinator
+        _ = subject.flushTraces()
+
+        subject.subscriber = nil
+        coordinator.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
+
+        XCTAssertFalse(
+            subject.flushTraces().contains {
+                $0.id == "subscriber" && $0.tag == "close"
+            }
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator(
+        peerType: PeerConnectionType
+    ) throws -> MockRTCPeerConnectionCoordinator {
+        let sfuStack = MockSFUStack()
+        return try XCTUnwrap(
+            MockRTCPeerConnectionCoordinator(
+                peerType: peerType,
+                sfuAdapter: sfuStack.adapter
+            )
+        )
+    }
+
+    private func createTraces(
+        for id: String,
+        in traces: [WebRTCTrace]
+    ) -> [WebRTCTrace] {
+        traces.filter { $0.id == id && $0.tag == "create" }
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1630/enhancementtrace-pc-creation-only-once

### 🎯 Goal

Prevent `WebRTCTracesAdapter` from emitting duplicate synthetic `create`
traces when reconnect flow rebinds the same publisher/subscriber
coordinator instance, while preserving real `create` traces for actual
peer connection replacements.

### 📝 Summary

- Pass `oldValue` into the publisher/subscriber `didUpdate(...)` paths.
- Ignore same-instance coordinator rebinds using identity checks.
- Remove role-specific subscriptions when a coordinator is cleared.
- Add regression tests for same-instance rebinds, coordinator swaps, and
  teardown behavior.
- Update adapter documentation to describe reconnect and cleanup
  semantics.

### 🛠 Implementation

`WebRTCTracesAdapter` now compares the new publisher/subscriber
coordinator against `oldValue` using identity before rebinding trace
observation. If reconnect flow assigns the exact same coordinator
instance again, the adapter returns early and does not append another
synthetic `create` trace.

When the publisher or subscriber is set to `nil`, the adapter removes the
corresponding disposable bag entry before returning. This ensures stale
coordinators stop emitting events after teardown.

Real coordinator swaps still rebuild the subscription and append a new
synthetic `create` trace, so true peer connection replacements continue
to be represented in the trace stream.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)