### PR TITLE
[Enhancement]Limit WebRTC rejoin bursts after repeated disconnects

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Disconnected.swift
@@ -156,11 +156,11 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         try transition?(.fastReconnecting(context))
                     } else {
                         context.fastReconnectionAttempts = 0
-                        try transition?(.rejoining(context))
+                        try transitionToRejoiningIfPossible()
                     }
                 case .rejoin:
                     context.fastReconnectionAttempts = 0
-                    try transition?(.rejoining(context))
+                    try transitionToRejoiningIfPossible()
                 case .migrate:
                     context.fastReconnectionAttempts = 0
                     try transition?(.migrating(context))
@@ -181,6 +181,44 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     transitionOrDisconnect(.disconnected(context))
                 }
             }
+        }
+
+        /// Attempts a rejoin while enforcing a rolling limit to prevent
+        /// repeated backend join loops after unstable disconnects.
+        ///
+        /// Important:
+        /// - This does not cap the total number of rejoins for the whole call.
+        /// - It only caps how many rejoins may happen inside the recent rolling
+        ///   window tracked by `Context.registerRejoinAttempt`.
+        /// - When attempts are spaced far enough apart, earlier attempts age out
+        ///   of the window and new rejoins are allowed.
+        ///
+        /// With the default configuration, a call that rejoins once every
+        /// 6 minutes will continue to rejoin successfully, because each prior
+        /// rejoin has already fallen out of the 120-second window. What gets
+        /// blocked is the pathological case where the SDK keeps cycling through
+        /// `.rejoin` repeatedly in a short time span and would otherwise keep
+        /// issuing backend `joinCall` requests.
+        ///
+        /// Once the burst limit is reached, we leave the call instead of
+        /// attempting another rejoin. That makes the failure mode explicit and
+        /// stops the internal reconnect/rejoin loop from continuing silently.
+        private func transitionToRejoiningIfPossible() throws {
+            guard context.registerRejoinAttempt() else {
+                log.warning(
+                    """
+                    Rejoin attempts exceeded \(context.rejoinMaxAttempts) within \
+                    \(context.rejoinAttemptWindow) seconds. Leaving call.
+                    """,
+                    subsystems: .webRTC
+                )
+                try transition?(
+                    .leaving(context, reason: "rejoin_attempt_limit_exceeded")
+                )
+                return
+            }
+
+            try transition?(.rejoining(context))
         }
 
         /// Observes internet connection status and triggers reconnection when

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -57,12 +57,12 @@ extension WebRTCCoordinator.StateMachine {
             /// from occasional isolated rejoin events.
             ///
             /// Example:
-            /// - If 5 rejoins happen within 2 minutes, the 6th rejoin inside
-            ///   that same 2-minute window is rejected.
+            /// - If 10 rejoins happen within 2 minutes, the 11th rejoin
+            ///   inside that same 2-minute window is rejected.
             /// - If rejoins are 6 minutes apart, older attempts have already
             ///   aged out of the rolling window before the next one happens, so
             ///   each rejoin is treated as an isolated recovery and is allowed.
-            var rejoinMaxAttempts: Int = 5
+            var rejoinMaxAttempts: Int = 10
             /// Size of the rolling window used by `rejoinMaxAttempts`.
             ///
             /// Only rejoin attempts whose timestamps are newer than
@@ -110,9 +110,9 @@ extension WebRTCCoordinator.StateMachine {
             ///
             /// Example with the default configuration:
             /// - Window: 120 seconds
-            /// - Max attempts: 5
-            /// - Attempts at `00:00`, `00:30`, `01:00`, `01:30`, `01:50`
-            ///   consume the full budget, so another rejoin at `01:55` is
+            /// - Max attempts: 10
+            /// - 10 attempts inside the last 120 seconds consume the full
+            ///   budget, so the 11th attempt inside that same window is
             ///   rejected.
             /// - A later rejoin at `06:00` is allowed, because all prior
             ///   timestamps are outside the 120-second window and are pruned

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -47,6 +47,34 @@ extension WebRTCCoordinator.StateMachine {
             // https://www.notion.so/stream-wiki/Improved-Reconnects-and-ICE-connection-handling-2186a5d7f9f680c29236c2c37cfa11a3?source=copy_link#2186a5d7f9f68088a9b1d6ecf67e5aad
             var fastReconnectionMaxAttempts: Int = 3
             var fastReconnectionAttempts: Int = 0
+            /// Maximum number of `.rejoin` transitions allowed inside the
+            /// rolling `rejoinAttemptWindow`.
+            ///
+            /// This is intentionally a burst guard, not a lifetime cap. The
+            /// goal is to stop pathological loops that keep issuing backend
+            /// `joinCall` requests in a short period of time after unstable
+            /// disconnects, while still allowing long-running calls to recover
+            /// from occasional isolated rejoin events.
+            ///
+            /// Example:
+            /// - If 5 rejoins happen within 2 minutes, the 6th rejoin inside
+            ///   that same 2-minute window is rejected.
+            /// - If rejoins are 6 minutes apart, older attempts have already
+            ///   aged out of the rolling window before the next one happens, so
+            ///   each rejoin is treated as an isolated recovery and is allowed.
+            var rejoinMaxAttempts: Int = 5
+            /// Size of the rolling window used by `rejoinMaxAttempts`.
+            ///
+            /// Only rejoin attempts whose timestamps are newer than
+            /// `now - rejoinAttemptWindow` count toward the limit.
+            var rejoinAttemptWindow: TimeInterval = 120
+            /// Timestamps for recent rejoin attempts that are still inside the
+            /// rolling window.
+            ///
+            /// Entries older than `rejoinAttemptWindow` are pruned before each
+            /// new rejoin decision, so the array models "recent rejoin burst
+            /// pressure" rather than "all rejoins since the call started".
+            var rejoinAttemptTimestamps: [Date] = []
 
             var healthCheckInterval: TimeInterval = 5
             var webSocketHealthTimeout: TimeInterval = 15
@@ -69,6 +97,43 @@ extension WebRTCCoordinator.StateMachine {
                 default:
                     return reconnectionStrategy
                 }
+            }
+
+            /// Registers a rejoin attempt if the rolling rejoin limit has not
+            /// been reached yet.
+            ///
+            /// Before checking the limit, this prunes any timestamps that are
+            /// older than `rejoinAttemptWindow`.
+            ///
+            /// This means the limit is evaluated against only recent activity.
+            /// Rejoins that happened far enough in the past stop counting.
+            ///
+            /// Example with the default configuration:
+            /// - Window: 120 seconds
+            /// - Max attempts: 5
+            /// - Attempts at `00:00`, `00:30`, `01:00`, `01:30`, `01:50`
+            ///   consume the full budget, so another rejoin at `01:55` is
+            ///   rejected.
+            /// - A later rejoin at `06:00` is allowed, because all prior
+            ///   timestamps are outside the 120-second window and are pruned
+            ///   first.
+            ///
+            /// - Parameter date: The date of the attempted rejoin.
+            /// - Returns: `true` when the attempt is allowed, otherwise `false`.
+            mutating func registerRejoinAttempt(
+                at date: Date = .init()
+            ) -> Bool {
+                let cutoff = date.addingTimeInterval(-rejoinAttemptWindow)
+                rejoinAttemptTimestamps = rejoinAttemptTimestamps.filter {
+                    $0 >= cutoff
+                }
+
+                guard rejoinAttemptTimestamps.count < rejoinMaxAttempts else {
+                    return false
+                }
+
+                rejoinAttemptTimestamps.append(date)
+                return true
             }
         }
 

--- a/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
+++ b/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
@@ -1,0 +1,398 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamVideo
+@preconcurrency import XCTest
+
+@MainActor
+final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
+
+    func test_join_afterInitialJoinAndSubscriberDisconnects_capsBackendJoinRequestsAfterFiveRejoins() async throws {
+        let mockPermissions = MockPermissionsStore()
+        defer { mockPermissions.dismantle() }
+        let maxRejoinAttempts = 5
+        let expectedJoinCallAttempts = maxRejoinAttempts + 1
+
+        let callType = "livestream"
+        let callId = String.unique
+        let defaultAPI = MockDefaultAPIEndpoints()
+        let videoConfig = VideoConfig.dummy()
+        let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
+            videoConfig: videoConfig
+        )
+        let controller = CallController(
+            defaultAPI: defaultAPI,
+            user: .dummy(),
+            callId: callId,
+            callType: callType,
+            apiKey: .unique,
+            videoConfig: videoConfig,
+            initialCallSettings: .default,
+            cachedLocation: .unique,
+            webRTCCoordinatorFactory: webRTCCoordinatorFactory
+        )
+        let subject = Call(
+            callType: callType,
+            callId: callId,
+            coordinatorClient: defaultAPI,
+            callController: controller
+        )
+        let joinResponse = JoinCallResponse.dummy(
+            call: .dummy(
+                cid: subject.cId,
+                id: subject.callId,
+                type: subject.callType
+            ),
+            credentials: .dummy(server: .dummy(edgeName: "test-sfu")),
+            ownCapabilities: [.sendAudio, .sendVideo]
+        )
+        let subscriberDisconnected = PassthroughSubject<Void, Never>()
+        let subscriber = try XCTUnwrap(
+            MockRTCPeerConnectionCoordinator(
+                peerType: .subscriber,
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+        )
+        subscriber.stub(
+            for: \.disconnectedPublisher,
+            with: subscriberDisconnected.eraseToAnyPublisher()
+        )
+        defaultAPI.stub(for: .joinCall, with: joinResponse)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .rtcPeerConnectionCoordinatorFactory
+            .stubbedBuildCoordinatorResult[.subscriber] = subscriber
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .authenticator = CallAuthenticationBackedWebRTCAuthenticator(
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+
+        let joinTask = Task {
+            try await subject.join(
+                create: false,
+                ring: false,
+                notify: false,
+                callSettings: .init(audioOn: false, videoOn: false)
+            )
+        }
+
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joining
+        }
+
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+        webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+        _ = try await joinTask.value
+
+        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), 1)
+
+        for _ in 0..<maxRejoinAttempts {
+            subscriberDisconnected.send(())
+
+            let nextJoinCallCount = defaultAPI.timesCalled(.joinCall) + 1
+            await fulfilmentInMainActor(timeout: defaultTimeout + 2) {
+                defaultAPI.timesCalled(.joinCall) >= nextJoinCallCount
+                    && webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .coordinator
+                    .stateMachine
+                    .currentStage
+                    .id == .joining
+            }
+
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .sfuStack
+                .setConnectionState(to: .connected(healthCheckInfo: .init()))
+            webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+            await fulfilmentInMainActor(timeout: defaultTimeout) {
+                webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .coordinator
+                    .stateMachine
+                    .currentStage
+                    .id == .joined
+            }
+        }
+
+        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), expectedJoinCallAttempts)
+
+        subscriberDisconnected.send(())
+
+        await fulfilmentInMainActor(timeout: defaultTimeout + 3) {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .idle
+        }
+
+        let joinCallRequests = try XCTUnwrap(
+            defaultAPI.recordedInputPayload(
+                (String, String, JoinCallRequest).self,
+                for: .joinCall
+            )
+        )
+
+        XCTAssertEqual(joinCallRequests.count, expectedJoinCallAttempts)
+        XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.create == false })
+        XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.ring == false })
+        XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.notify == false })
+    }
+
+    func test_join_afterAbnormalWebSocketClosure_issuesAdditionalBackendJoinRequest() async throws {
+        let mockPermissions = MockPermissionsStore()
+        defer { mockPermissions.dismantle() }
+
+        let callType = "livestream"
+        let callId = String.unique
+        let defaultAPI = MockDefaultAPIEndpoints()
+        let videoConfig = VideoConfig.dummy()
+        let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
+            videoConfig: videoConfig
+        )
+        let controller = CallController(
+            defaultAPI: defaultAPI,
+            user: .dummy(),
+            callId: callId,
+            callType: callType,
+            apiKey: .unique,
+            videoConfig: videoConfig,
+            initialCallSettings: .default,
+            cachedLocation: .unique,
+            webRTCCoordinatorFactory: webRTCCoordinatorFactory
+        )
+        let subject = Call(
+            callType: callType,
+            callId: callId,
+            coordinatorClient: defaultAPI,
+            callController: controller
+        )
+        let joinResponse = JoinCallResponse.dummy(
+            call: .dummy(
+                cid: subject.cId,
+                id: subject.callId,
+                type: subject.callType
+            ),
+            credentials: .dummy(server: .dummy(edgeName: "test-sfu")),
+            ownCapabilities: [.sendAudio, .sendVideo]
+        )
+        let publisher = try XCTUnwrap(
+            MockRTCPeerConnectionCoordinator(
+                peerType: .publisher,
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+        )
+        let subscriber = try XCTUnwrap(
+            MockRTCPeerConnectionCoordinator(
+                peerType: .subscriber,
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+        )
+        let refreshedWebSocket = MockWebSocketClient(webSocketClientType: .sfu)
+        defaultAPI.stub(for: .joinCall, with: joinResponse)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .rtcPeerConnectionCoordinatorFactory
+            .stubbedBuildCoordinatorResult[.publisher] = publisher
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .rtcPeerConnectionCoordinatorFactory
+            .stubbedBuildCoordinatorResult[.subscriber] = subscriber
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .webSocketFactory
+            .stub(for: .build, with: refreshedWebSocket)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .authenticator = CallAuthenticationBackedWebRTCAuthenticator(
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+
+        let joinTask = Task {
+            try await subject.join(
+                create: false,
+                ring: false,
+                notify: false,
+                callSettings: .init(audioOn: false, videoOn: false)
+            )
+        }
+
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joining
+        }
+
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+        webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+        _ = try await joinTask.value
+
+        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), 1)
+
+        webRTCCoordinatorFactory.mockCoordinatorStack.sfuStack.setConnectionState(
+            to: .disconnected(source: .serverInitiated())
+        )
+        refreshedWebSocket.simulate(state: .connected(healthCheckInfo: .init()))
+        refreshedWebSocket.eventSubject.send(.sfuEvent(.joinResponse(.init())))
+
+        await fulfilmentInMainActor(timeout: defaultTimeout + 2) {
+            defaultAPI.timesCalled(.joinCall) >= 2
+        }
+
+        let joinCallRequests = try XCTUnwrap(
+            defaultAPI.recordedInputPayload(
+                (String, String, JoinCallRequest).self,
+                for: .joinCall
+            )
+        )
+
+        XCTAssertGreaterThanOrEqual(joinCallRequests.count, 2)
+        XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.create == false })
+        XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.ring == false })
+        XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.notify == false })
+    }
+}
+
+private final class CallAuthenticationBackedWebRTCAuthenticator:
+    WebRTCAuthenticating,
+    @unchecked Sendable {
+    @Injected(\.audioStore) private var audioStore
+
+    private let sfuAdapter: SFUAdapter
+
+    init(sfuAdapter: SFUAdapter) {
+        self.sfuAdapter = sfuAdapter
+    }
+
+    func authenticate(
+        coordinator: WebRTCCoordinator,
+        currentSFU: String?,
+        migratingFromList: [String]?,
+        create: Bool,
+        ring: Bool,
+        notify: Bool,
+        options: CreateCallOptions?
+    ) async throws -> (sfuAdapter: SFUAdapter, response: JoinCallResponse) {
+        let response = try await coordinator.callAuthentication(
+            create,
+            ring,
+            currentSFU,
+            migratingFromList,
+            notify,
+            options
+        )
+
+        await coordinator.stateAdapter.set(token: response.credentials.token)
+        await coordinator.stateAdapter.enqueueOwnCapabilities {
+            Set(response.ownCapabilities)
+        }
+        await coordinator.stateAdapter.set(
+            audioSettings: response.call.settings.audio
+        )
+        await coordinator.stateAdapter.set(
+            connectOptions: ConnectOptions(
+                iceServers: response.credentials.iceServers
+            )
+        )
+
+        let initialCallSettings = await coordinator.stateAdapter.initialCallSettings
+        let remoteCallSettings = CallSettings(response.call.settings)
+        let callSettings = {
+            var result = initialCallSettings ?? remoteCallSettings
+            if audioStore.state.currentRoute.isExternal, result.speakerOn {
+                result = result.withUpdatedSpeakerState(false)
+            }
+            if result.audioOn, !response.ownCapabilities.contains(.sendAudio) {
+                result = result.withUpdatedAudioState(false)
+            }
+            if result.videoOn, !response.ownCapabilities.contains(.sendVideo) {
+                result = result.withUpdatedVideoState(false)
+            }
+            return result
+        }()
+
+        await coordinator.stateAdapter.enqueueCallSettings { _ in callSettings }
+        await coordinator.stateAdapter.set(
+            videoOptions: .init(preferredCameraPosition: {
+                switch response.call.settings.video.cameraFacing {
+                case .back:
+                    return .back
+                case .external, .front, .unknown:
+                    return .front
+                }
+            }())
+        )
+        await coordinator.stateAdapter.set(
+            isTracingEnabled: response.statsOptions.enableRtcStats
+        )
+
+        let statsReportingInterval = response.statsOptions.reportingIntervalMs
+            / 1000
+        if let statsReporter = await coordinator.stateAdapter.statsAdapter {
+            statsReporter.deliveryInterval = TimeInterval(statsReportingInterval)
+        } else {
+            let unifiedSessionID = await coordinator.stateAdapter.unifiedSessionId
+            let trackStorage = await coordinator.stateAdapter.trackStorage
+            let statsReporter = WebRTCStatsAdapter(
+                sessionID: await coordinator.stateAdapter.sessionID,
+                unifiedSessionID: unifiedSessionID,
+                isTracingEnabled: await coordinator.stateAdapter.isTracingEnabled,
+                trackStorage: trackStorage
+            )
+            statsReporter.deliveryInterval = TimeInterval(statsReportingInterval)
+            await coordinator.stateAdapter.set(statsAdapter: statsReporter)
+        }
+
+        return (sfuAdapter, response)
+    }
+
+    func waitForAuthentication(on sfuAdapter: SFUAdapter) async throws {}
+
+    func waitForConnect(on sfuAdapter: SFUAdapter) async throws {}
+}

--- a/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
+++ b/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
@@ -9,10 +9,10 @@ import Combine
 @MainActor
 final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
 
-    func test_join_afterInitialJoinAndSubscriberDisconnects_capsBackendJoinRequestsAfterFiveRejoins() async throws {
+    func test_join_afterInitialJoinAndSubscriberDisconnects_capsBackendJoinRequestsAfterTenRejoins() async throws {
         let mockPermissions = MockPermissionsStore()
         defer { mockPermissions.dismantle() }
-        let maxRejoinAttempts = 5
+        let maxRejoinAttempts = 10
         let expectedJoinCallAttempts = maxRejoinAttempts + 1
 
         let callType = "livestream"

--- a/StreamVideoTests/Mock/MockCallAuthenticator.swift
+++ b/StreamVideoTests/Mock/MockCallAuthenticator.swift
@@ -6,7 +6,17 @@
 
 final class MockCallAuthenticator: @unchecked Sendable {
 
+    typealias AuthenticateHandler = (
+        Bool,
+        Bool,
+        String?,
+        [String]?,
+        Bool,
+        CreateCallOptions?
+    ) async throws -> JoinCallResponse
+
     var authenticateResult: Result<JoinCallResponse, Error> = .failure(ClientError.Unknown())
+    var authenticateHandler: AuthenticateHandler?
 
     private(set) var authenticateCalledWithInput: [(
         create: Bool,
@@ -35,6 +45,16 @@ final class MockCallAuthenticator: @unchecked Sendable {
                 options
             )
         )
+        if let authenticateHandler {
+            return try await authenticateHandler(
+                create,
+                ring,
+                migratingFrom,
+                migratingFromList,
+                notify,
+                options
+            )
+        }
         switch authenticateResult {
         case let .success(result):
             return result

--- a/StreamVideoTests/Mock/MockWebRTCCoordinatorFactory.swift
+++ b/StreamVideoTests/Mock/MockWebRTCCoordinatorFactory.swift
@@ -37,6 +37,7 @@ final class MockWebRTCCoordinatorFactory: WebRTCCoordinatorProviding, @unchecked
             callSettings,
             callAuthentication
         )
+        mockCoordinatorStack.callAuthenticator.authenticateHandler = callAuthentication
         return mockCoordinatorStack.coordinator
     }
 }

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_CleanUpStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_CleanUpStageTests.swift
@@ -163,7 +163,7 @@ final class WebRTCCoordinatorStateMachine_CleanUpStageTests: XCTestCase, @unchec
         XCTAssertEqual(subject.context.reconnectionStrategy, .unknown)
         XCTAssertNil(subject.context.disconnectionSource)
         XCTAssertNil(subject.context.flowError)
-        XCTAssertEqual(subject.context.rejoinMaxAttempts, 5)
+        XCTAssertEqual(subject.context.rejoinMaxAttempts, 10)
         XCTAssertEqual(subject.context.rejoinAttemptWindow, 120)
         XCTAssertTrue(subject.context.rejoinAttemptTimestamps.isEmpty)
         XCTAssertNil(subject.context.isRejoiningFromSessionID)

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_CleanUpStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_CleanUpStageTests.swift
@@ -134,6 +134,9 @@ final class WebRTCCoordinatorStateMachine_CleanUpStageTests: XCTestCase, @unchec
         subject.context.reconnectionStrategy = .rejoin
         subject.context.disconnectionSource = .userInitiated
         subject.context.flowError = ClientError()
+        subject.context.rejoinMaxAttempts = 2
+        subject.context.rejoinAttemptWindow = 30
+        subject.context.rejoinAttemptTimestamps = [.init()]
         subject.context.isRejoiningFromSessionID = .unique
         subject.context.migratingFromSFU = .unique
         subject.context.migrationStatusObserver = .init(
@@ -160,6 +163,9 @@ final class WebRTCCoordinatorStateMachine_CleanUpStageTests: XCTestCase, @unchec
         XCTAssertEqual(subject.context.reconnectionStrategy, .unknown)
         XCTAssertNil(subject.context.disconnectionSource)
         XCTAssertNil(subject.context.flowError)
+        XCTAssertEqual(subject.context.rejoinMaxAttempts, 5)
+        XCTAssertEqual(subject.context.rejoinAttemptWindow, 120)
+        XCTAssertTrue(subject.context.rejoinAttemptTimestamps.isEmpty)
         XCTAssertNil(subject.context.isRejoiningFromSessionID)
         XCTAssertTrue(subject.context.migratingFromSFU.isEmpty)
         XCTAssertNil(subject.context.migrationStatusObserver)

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_DisconnectedStageTests.swift
@@ -238,6 +238,69 @@ final class WebRTCCoordinatorStateMachine_DisconnectedStageTests: XCTestCase, @u
         ) { _ in }
     }
 
+    func test_transition_connectionRestoresWithRejoinStrategy_registersRejoinAttempt() async {
+        subject.context.reconnectionStrategy = .rejoin
+        subject.context.rejoinMaxAttempts = 3
+        subject.context.rejoinAttemptTimestamps = [.init(timeIntervalSinceNow: -10)]
+
+        await assertTransitionAfterTrigger(
+            expectedTarget: .rejoining,
+            trigger: { [mockCoordinatorStack] in
+                mockCoordinatorStack?
+                    .internetConnection
+                    .subject
+                    .send(.available(.great))
+            }
+        ) { target in
+            XCTAssertEqual(target.context.rejoinAttemptTimestamps.count, 2)
+        }
+    }
+
+    func test_transition_connectionRestoresWithRejoinStrategy_prunesExpiredAttempts() async {
+        subject.context.reconnectionStrategy = .rejoin
+        subject.context.rejoinMaxAttempts = 1
+        subject.context.rejoinAttemptWindow = 60
+        subject.context.rejoinAttemptTimestamps = [.init(timeIntervalSinceNow: -120)]
+
+        await assertTransitionAfterTrigger(
+            expectedTarget: .rejoining,
+            trigger: { [mockCoordinatorStack] in
+                mockCoordinatorStack?
+                    .internetConnection
+                    .subject
+                    .send(.available(.great))
+            }
+        ) { target in
+            XCTAssertEqual(target.context.rejoinAttemptTimestamps.count, 1)
+            XCTAssertTrue(
+                target.context.rejoinAttemptTimestamps.allSatisfy {
+                    abs($0.timeIntervalSinceNow) < 5
+                }
+            )
+        }
+    }
+
+    func test_transition_connectionRestoresWithRejoinStrategyWhenLimitIsReached_landsOnLeaving() async {
+        subject.context.reconnectionStrategy = .rejoin
+        subject.context.rejoinMaxAttempts = 2
+        subject.context.rejoinAttemptTimestamps = [
+            .init(timeIntervalSinceNow: -10),
+            .init(timeIntervalSinceNow: -5)
+        ]
+
+        await assertTransitionAfterTrigger(
+            expectedTarget: .leaving,
+            trigger: { [mockCoordinatorStack] in
+                mockCoordinatorStack?
+                    .internetConnection
+                    .subject
+                    .send(.available(.great))
+            }
+        ) { target in
+            XCTAssertEqual(target.context.rejoinAttemptTimestamps.count, 2)
+        }
+    }
+
     func test_transition_connectionRestoresWithFastStrategyWithoutExpiredDeadline_landsOnFastReconnection() async throws {
         subject.context.reconnectionStrategy = .fast(disconnectedSince: .init(), deadline: 10)
         let publisher =
@@ -263,6 +326,27 @@ final class WebRTCCoordinatorStateMachine_DisconnectedStageTests: XCTestCase, @u
                     .send(.available(.great))
             }
         ) { _ in }
+    }
+
+    func test_transition_connectionRestoresWithFastStrategyWhenRejoinLimitIsReached_landsOnLeaving() async {
+        subject.context.reconnectionStrategy = .fast(
+            disconnectedSince: .init(timeIntervalSinceNow: -30),
+            deadline: 10
+        )
+        subject.context.rejoinMaxAttempts = 1
+        subject.context.rejoinAttemptTimestamps = [.init()]
+
+        await assertTransitionAfterTrigger(
+            expectedTarget: .leaving,
+            trigger: { [mockCoordinatorStack] in
+                mockCoordinatorStack?
+                    .internetConnection
+                    .subject
+                    .send(.available(.great))
+            }
+        ) { target in
+            XCTAssertEqual(target.context.rejoinAttemptTimestamps.count, 1)
+        }
     }
 
     func test_transition_connectionRestoresWithFastStrategyPublisherNotHealthy_landsOnRejoin() async throws {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1626/investigationmultiple-joinrequest

### 🎯 Goal

Stop pathological internal WebRTC rejoin loops from issuing repeated backend `joinCall` requests after unstable or abnormal disconnects, while still allowing isolated valid rejoins over the lifetime of a call.

### 📝 Summary

- Add a rolling rejoin-attempt limit to the internal WebRTC reconnect path
- Enforce the limit only when the reconnection strategy resolves to `.rejoin`
- Leave the call cleanly once the rejoin burst limit is exceeded instead of continuing the loop
- Add production documentation explaining that this is a rolling-window burst guard, not a lifetime cap
- Add focused state-machine tests for rejoin attempt tracking, pruning, limit enforcement, and cleanup reset

### 🛠 Implementation

This change introduces a rolling rejoin window in `WebRTCCoordinator.StateMachine.Stage.Context` with a default of 5 rejoin attempts within 120 seconds.

The enforcement point is in `WebRTCCoordinator+Disconnected.swift`. When the reconnect flow resolves to `.rejoin` directly, or when a fast reconnect is no longer possible and the SDK falls back to `.rejoin`, the coordinator now calls `registerRejoinAttempt()` before transitioning into `RejoiningStage`.

If the attempt is still within budget, the existing rejoin flow continues unchanged. If the recent rejoin budget is exhausted, the SDK stops the internal loop and transitions to `LeavingStage` with reason `rejoin_attempt_limit_exceeded`. This prevents repeated backend `joinCall` bursts without changing the top-level `Call.join()` retry behavior and without changing successful fast reconnect behavior.

The production comments were expanded to make the semantics explicit:
- this is not a lifetime cap on rejoins for the whole call
- old attempts are pruned before each decision
- rejoins spaced far apart, for example 6 minutes apart, remain valid because they fall outside the 120-second window

Test coverage was added at two levels:
- low-level `WebRTCCoordinatorStateMachine_DisconnectedStageTests` verify registration, pruning, and limit enforcement
- higher-level `Call_JoinRecovery_Tests` verify that real `Call.join()` flows still issue legitimate follow-up backend joins, and that the repeated subscriber-disconnect scenario now stops after the configured cap

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guarded rejoin logic that enforces a rolling limit on rejoin attempts during recovery.

* **Bug Fixes**
  * Prevents uncontrolled rejoin loops by capping attempts within a time window; excess attempts log a warning and end the reconnection flow.

* **Tests**
  * Added and extended tests verifying rejoin-rate limiting, fast/normal reconnect behavior, and backend join request patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->