### PR TITLE
Iliaspavlidakis/ios 1613 investigationtimeout issues second attempt

### DIFF
--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -144,6 +144,9 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     /// `joinInterceptor` is provided, the SDK waits for it after the join
     /// response has been applied locally but before the call is marked as the
     /// active call.
+    ///
+    /// If the final handoff times out, the SDK leaves the call with reason
+    /// `join.timeout` before rethrowing the timeout error.
     /// - Parameters:
     ///  - create: whether the call should be created if it doesn't exist.
     ///  - options: configuration options for the call.
@@ -155,7 +158,8 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
     ///    final joined transition after the join response has been received and
     ///    applied to local state.
     /// - Throws: An error if the call could not be joined or if
-    ///   `joinInterceptor` throws.
+    ///   `joinInterceptor` throws. Throws `TimeOutError` when the final joined
+    ///   handoff does not complete in time.
     @discardableResult
     public func join(
         create: Bool = false,
@@ -246,10 +250,16 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         if let joinResponse = result as? JoinCallResponse {
             return joinResponse
         } else if let publisher = result as? AnyPublisher<JoinCallResponse?, Error> {
-            let result = try await publisher
-                .compactMap { $0 }
-                .nextValue(timeout: CallConfiguration.timeout.join)
-            return result
+            do {
+                return try await publisher
+                    .compactMap { $0 }
+                    .nextValue(timeout: CallConfiguration.timeout.join)
+            } catch {
+                if error is TimeOutError {
+                    leave(reason: "join.timeout")
+                }
+                throw error
+            }
         } else {
             throw ClientError("Call was unable to join call.")
         }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -63,6 +63,11 @@ extension Call.StateMachine.Stage {
             }
         }
 
+        /// Cancels in-flight join work when the state machine leaves `.joining`.
+        override func willTransitionAway() {
+            disposableBag.removeAll()
+        }
+
         // MARK: - Private Helpers
 
         /// Executes the call joining process asynchronously.
@@ -85,6 +90,9 @@ extension Call.StateMachine.Stage {
                 do {
                     let response = try await executeJoin(call: call, input: input)
                     transitionOrError(.joined(context, response: response))
+                } catch is CancellationError {
+                    // A replacement stage already owns the call lifecycle.
+                    return
                 } catch let error as CallJoinInterceptionError {
                     // Interception failures are terminal for this join attempt,
                     // so they are surfaced to the original caller without

--- a/Sources/StreamVideo/Utils/Extensions/Combine/Publisher+AsyncStream.swift
+++ b/Sources/StreamVideo/Utils/Extensions/Combine/Publisher+AsyncStream.swift
@@ -55,7 +55,7 @@ public extension Publisher where Output: Sendable {
         }
 
         if Task<Never, Never>.isCancelled {
-            throw _Concurrency.CancellationError()
+            throw CancellationError()
         }
         throw ClientError("Task produced no value.", file, line)
     }

--- a/Sources/StreamVideo/Utils/Extensions/Combine/Publisher+AsyncStream.swift
+++ b/Sources/StreamVideo/Utils/Extensions/Combine/Publisher+AsyncStream.swift
@@ -30,6 +30,16 @@ public extension Publisher where Output: Sendable {
         }
     }
 
+    /// Waits for the first value emitted by the publisher.
+    ///
+    /// If the publisher completes before emitting a value, the method throws
+    /// `ClientError`. If the awaiting task is cancelled before a value is
+    /// emitted, the method throws `CancellationError`.
+    ///
+    /// - Parameters:
+    ///   - file: The file captured for error reporting.
+    ///   - line: The line captured for error reporting.
+    /// - Returns: The first emitted output value.
     func firstValue(
         file: StaticString = #file,
         line: UInt = #line
@@ -44,9 +54,24 @@ public extension Publisher where Output: Sendable {
             }
         }
 
+        if Task<Never, Never>.isCancelled {
+            throw _Concurrency.CancellationError()
+        }
         throw ClientError("Task produced no value.", file, line)
     }
 
+    /// Waits for the first value emitted by the publisher within the provided
+    /// timeout.
+    ///
+    /// Cancellation is propagated immediately to the underlying timed task so a
+    /// cancelled caller does not continue waiting until the timeout elapses.
+    ///
+    /// - Parameters:
+    ///   - timeoutInSeconds: The maximum time to wait for the first value.
+    ///   - file: The file captured for error reporting.
+    ///   - function: The function captured for error reporting.
+    ///   - line: The line captured for error reporting.
+    /// - Returns: The first emitted output value.
     func firstValue(
         timeoutInSeconds: TimeInterval,
         file: StaticString = #file,
@@ -55,16 +80,34 @@ public extension Publisher where Output: Sendable {
     ) async throws -> Output {
         // Invariant: publisher used read-only in this async path.
         let erasedPublisher = eraseToAnyPublisher()
-        return try await Task(
+        let timeoutTask = Task(
             timeoutInSeconds: timeoutInSeconds,
             file: file,
             function: function,
             line: line
         ) {
             try await erasedPublisher.firstValue(file: file, line: line)
-        }.value
+        }
+
+        // Ensure callers that cancel while awaiting a timed publisher do not
+        // leave the underlying timeout task running until the deadline.
+        return try await withTaskCancellationHandler {
+            try await timeoutTask.value
+        } onCancel: {
+            timeoutTask.cancel()
+        }
     }
 
+    /// Waits for the next emitted value, optionally skipping a number of
+    /// earlier values first.
+    ///
+    /// - Parameters:
+    ///   - dropFirst: The number of values to ignore before returning.
+    ///   - timeout: An optional timeout for receiving the value.
+    ///   - file: The file captured for error reporting.
+    ///   - function: The function captured for error reporting.
+    ///   - line: The line captured for error reporting.
+    /// - Returns: The next emitted output value after applying `dropFirst`.
     func nextValue(
         dropFirst: Int = 0,
         timeout: TimeInterval? = nil,

--- a/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Task+Timeout.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Task+Timeout.swift
@@ -16,7 +16,7 @@ extension Task where Failure == any Error {
         line: UInt = #line,
         operation: @Sendable @escaping () async throws -> Success
     ) {
-        self = Task(priority: priority) {
+        self = Task<Success, Failure>(priority: priority) {
             try await withThrowingTaskGroup(of: Success.self) { group in
 
                 /// Add the operation to perform as the first task.
@@ -39,7 +39,7 @@ extension Task where Failure == any Error {
                 /// This is default for task groups to account for when there aren't any pending tasks.
                 /// Awaiting on an empty group immediately returns 'nil' without suspending.
                 guard let result = try await group.next() else {
-                    throw ClientError("Task produced no value", file, line)
+                    throw _Concurrency.CancellationError()
                 }
 
                 /// If we reach this, it means we have a value before the timeout.

--- a/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Task+Timeout.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Task+Timeout.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 
+private typealias SwiftCancellationError = CancellationError
+
 /// An extension to the `Task` type that adds timeout functionality.
 extension Task where Failure == any Error {
     @discardableResult
@@ -39,7 +41,7 @@ extension Task where Failure == any Error {
                 /// This is default for task groups to account for when there aren't any pending tasks.
                 /// Awaiting on an empty group immediately returns 'nil' without suspending.
                 guard let result = try await group.next() else {
-                    throw Swift.CancellationError()
+                    throw SwiftCancellationError()
                 }
 
                 /// If we reach this, it means we have a value before the timeout.

--- a/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Task+Timeout.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Extensions/Foundation/Task+Timeout.swift
@@ -39,7 +39,7 @@ extension Task where Failure == any Error {
                 /// This is default for task groups to account for when there aren't any pending tasks.
                 /// Awaiting on an empty group immediately returns 'nil' without suspending.
                 guard let result = try await group.next() else {
-                    throw _Concurrency.CancellationError()
+                    throw Swift.CancellationError()
                 }
 
                 /// If we reach this, it means we have a value before the timeout.

--- a/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
+++ b/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
@@ -9,11 +9,140 @@ import Combine
 @MainActor
 final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
 
+    func test_join_whenOuterJoinTimeouts_leavesAndStopsRetrying() async throws {
+        let previousTimeout = CallConfiguration.timeout
+        CallConfiguration.timeout.join = 3
+        defer { CallConfiguration.timeout = previousTimeout }
+
+        let mockPermissions = MockPermissionsStore()
+        defer { mockPermissions.dismantle() }
+
+        let callType = "livestream"
+        let callId = String.unique
+        let defaultAPI = MockDefaultAPIEndpoints()
+        let videoConfig = VideoConfig.dummy()
+        let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
+            videoConfig: videoConfig
+        )
+        let controller = CallController(
+            defaultAPI: defaultAPI,
+            user: .dummy(),
+            callId: callId,
+            callType: callType,
+            apiKey: .unique,
+            videoConfig: videoConfig,
+            initialCallSettings: .default,
+            cachedLocation: .unique,
+            webRTCCoordinatorFactory: webRTCCoordinatorFactory
+        )
+        let subject = Call(
+            callType: callType,
+            callId: callId,
+            coordinatorClient: defaultAPI,
+            callController: controller
+        )
+        let joinResponse = JoinCallResponse.dummy(
+            call: .dummy(
+                cid: subject.cId,
+                id: subject.callId,
+                type: subject.callType
+            ),
+            credentials: .dummy(server: .dummy(edgeName: "test-sfu")),
+            ownCapabilities: [.sendAudio, .sendVideo]
+        )
+        let unexpectedJoined = expectation(
+            description: "Join should not complete after timing out"
+        )
+        unexpectedJoined.isInverted = true
+        let joinedObserver = webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .publisher
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink {
+                if $0.id == .joined {
+                    unexpectedJoined.fulfill()
+                }
+            }
+        defer { joinedObserver.cancel() }
+        defaultAPI.stub(for: .joinCall, with: joinResponse)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .authenticator = CallAuthenticationBackedWebRTCAuthenticator(
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+
+        let joinTask = Task {
+            try await subject.join(
+                create: false,
+                ring: false,
+                notify: false,
+                callSettings: .init(audioOn: false, videoOn: false)
+            )
+        }
+
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joining
+                && (
+                    webRTCCoordinatorFactory
+                        .mockCoordinatorStack
+                        .coordinator
+                        .stateMachine
+                        .currentStage
+                        .context
+                        .sfuEventObserver != nil
+                )
+        }
+
+        await wait(for: 0.5)
+
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+
+        do {
+            _ = try await joinTask.value
+            XCTFail("Expected join to time out.")
+        } catch {
+            XCTAssertTrue(error is TimeOutError)
+        }
+
+        webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .idle
+        }
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            self.streamVideo?.state.activeCall == nil
+        }
+        await fulfillment(of: [unexpectedJoined], timeout: 3)
+
+        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), 1)
+    }
+
     func test_join_afterInitialJoinAndSubscriberDisconnects_capsBackendJoinRequestsAfterTenRejoins() async throws {
         let mockPermissions = MockPermissionsStore()
         defer { mockPermissions.dismantle() }
-        let maxRejoinAttempts = 10
-        let expectedJoinCallAttempts = maxRejoinAttempts + 1
 
         let callType = "livestream"
         let callId = String.unique
@@ -107,40 +236,60 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
 
         _ = try await joinTask.value
 
-        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), 1)
-
-        for _ in 0..<maxRejoinAttempts {
-            subscriberDisconnected.send(())
-
-            let nextJoinCallCount = defaultAPI.timesCalled(.joinCall) + 1
-            await fulfilmentInMainActor(timeout: defaultTimeout + 2) {
-                defaultAPI.timesCalled(.joinCall) >= nextJoinCallCount
-                    && webRTCCoordinatorFactory
-                    .mockCoordinatorStack
-                    .coordinator
-                    .stateMachine
-                    .currentStage
-                    .id == .joining
-            }
-
-            await wait(for: 0.5)
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
             webRTCCoordinatorFactory
                 .mockCoordinatorStack
-                .sfuStack
-                .setConnectionState(to: .connected(healthCheckInfo: .init()))
-            webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
-
-            await fulfilmentInMainActor(timeout: defaultTimeout) {
-                webRTCCoordinatorFactory
-                    .mockCoordinatorStack
-                    .coordinator
-                    .stateMachine
-                    .currentStage
-                    .id == .joined
-            }
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joined
         }
 
-        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), expectedJoinCallAttempts)
+        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), 1)
+
+        let recentAttempts = { (count: Int) in
+            let now = Date()
+            return (0..<count).map { now.addingTimeInterval(TimeInterval(-$0)) }
+        }
+
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .rejoinAttemptTimestamps = recentAttempts(9)
+
+        let joinCallCountBeforeAllowedRejoin = defaultAPI.timesCalled(.joinCall)
+        subscriberDisconnected.send(())
+
+        await fulfilmentInMainActor(timeout: defaultTimeout + 2) {
+            defaultAPI.timesCalled(.joinCall) == joinCallCountBeforeAllowedRejoin + 1
+        }
+
+        await wait(for: 0.5)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+        webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+        await fulfilmentInMainActor(timeout: defaultTimeout) {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joined
+        }
+
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .rejoinAttemptTimestamps = recentAttempts(10)
 
         subscriberDisconnected.send(())
 
@@ -153,6 +302,8 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
                 .id == .idle
         }
 
+        XCTAssertEqual(defaultAPI.timesCalled(.joinCall), 2)
+
         let joinCallRequests = try XCTUnwrap(
             defaultAPI.recordedInputPayload(
                 (String, String, JoinCallRequest).self,
@@ -160,7 +311,7 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
             )
         )
 
-        XCTAssertEqual(joinCallRequests.count, expectedJoinCallAttempts)
+        XCTAssertEqual(joinCallRequests.count, 2)
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.create == false })
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.ring == false })
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.notify == false })

--- a/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
+++ b/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
@@ -98,6 +98,7 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
                 .id == .joining
         }
 
+        await wait(for: 0.5)
         webRTCCoordinatorFactory
             .mockCoordinatorStack
             .sfuStack
@@ -122,6 +123,7 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
                     .id == .joining
             }
 
+            await wait(for: 0.5)
             webRTCCoordinatorFactory
                 .mockCoordinatorStack
                 .sfuStack

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -689,6 +689,47 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertEqual(joinInterceptor.invocationCount, 1)
     }
 
+    func test_join_whenJoinCompletionTimesOut_leavesCallWithJoinTimeoutReason() async throws {
+        let originalTimeout = CallConfiguration.timeout
+        CallConfiguration.timeout.join = 0.1
+        defer { CallConfiguration.timeout = originalTimeout }
+
+        let mockCallController = MockCallController()
+        let call = Call.dummy(
+            callType: callType,
+            callId: callId,
+            callController: mockCallController
+        )
+        let joinInterceptor = CallJoinInterceptor_Spy { _ in
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        mockCallController.stub(
+            for: .join,
+            with: JoinCallResponse.dummy(
+                call: .dummy(
+                    cid: call.cId,
+                    id: call.callId,
+                    type: call.callType
+                )
+            )
+        )
+
+        do {
+            _ = try await call.join(joinInterceptor: joinInterceptor)
+            XCTFail("Expected join to time out.")
+        } catch {
+            XCTAssertTrue(error is TimeOutError)
+        }
+
+        XCTAssertEqual(
+            mockCallController.recordedInputPayload(
+                String.self,
+                for: .leave
+            )?.first,
+            "join.timeout"
+        )
+    }
+
     // MARK: - leave
 
     func test_leave_withReason_reasonWasPassedToCallController() {
@@ -883,10 +924,16 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
 }
 
 private final class CallJoinInterceptor_Spy: CallJoinIntercepting, @unchecked Sendable {
+    private let handler: @Sendable (Call) async throws -> Void
     @Atomic private(set) var invocationCount = 0
+
+    init(handler: @escaping @Sendable (Call) async throws -> Void = { _ in }) {
+        self.handler = handler
+    }
 
     func callReadyToJoin(_ call: Call) async throws {
         invocationCount += 1
+        try await handler(call)
     }
 }
 

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -500,6 +500,70 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         XCTAssertEqual(joinInterceptor.invocationCount, 1)
     }
 
+    func test_willTransitionAway_whenJoinInterceptorIsSuspended_cancelsPendingJoinTask(
+    ) async throws {
+        let deliverySubject = CurrentValueSubject<JoinCallResponse?, Error>(nil)
+        let interceptorStarted = expectation(description: "Join interceptor started.")
+        let unexpectedTransition = expectation(
+            description: "Join should not transition after cancellation."
+        )
+        unexpectedTransition.isInverted = true
+        let unexpectedDelivery = expectation(
+            description: "Join should not deliver after cancellation."
+        )
+        unexpectedDelivery.isInverted = true
+        let cancellable = deliverySubject
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .sink { _ in
+                unexpectedDelivery.fulfill()
+            } receiveValue: { _ in
+                unexpectedDelivery.fulfill()
+            }
+        let joinInterceptor = NonCancellableJoinInterceptor_Spy {
+            interceptorStarted.fulfill()
+        }
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: deliverySubject,
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+
+        callController.stub(for: .join, with: JoinCallResponse.dummy())
+        subject.transition = { _ in
+            unexpectedTransition.fulfill()
+        }
+        subject.context = context
+
+        _ = subject.transition(from: .idle(.init()))
+
+        await fulfillment(of: [interceptorStarted], timeout: defaultTimeout)
+
+        subject.willTransitionAway()
+        joinInterceptor.resume()
+
+        await fulfillment(
+            of: [unexpectedTransition, unexpectedDelivery],
+            timeout: 0.2
+        )
+
+        XCTAssertEqual(joinInterceptor.invocationCount, 1)
+        XCTAssertNil(streamVideo.state.activeCall)
+        XCTAssertEqual(callController.timesCalled(.observeWebRTCStateUpdated), 0)
+
+        cancellable.cancel()
+    }
+
     func test_execute_withRetries_whenJoinFailsAndThereAreAvailableRetries_transitionsToJoining() async throws {
         let context = Call.StateMachine.Stage.Context(
             call: call,

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -364,30 +364,22 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     func test_end_whenCreatorEndsCall_thenParticipantAutomaticallyLeaves() async throws {
         let callId = String.unique
-        let creatorUserId = "user-a"
-        let participantUserId = "user-b"
+        let creatorUserId = String.unique
+        let participantUserId = String.unique
         helpers.duringDismantleObservedAllCallEnded = false
-
-        let apiKey = "hd8szvscpxvd"
-        let userAToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NzY2ODczNDMsInVzZXJfaWQiOiJ1c2VyLWEifQ.1ZgWONVUFKEB6vneFKfyPt9Ht1VrXIEpRzR877dF7gw"
-        let userBToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NzY2ODczNTUsInVzZXJfaWQiOiJ1c2VyLWIifQ.ggHutnqzYYd3e_p1VZkgQpgnjAwMTqRMoomhNadRCzE"
 
         let creatorUserFlow = try await helpers
             .callFlow(
                 id: callId,
                 type: .default,
-                userId: creatorUserId,
-                overrideAPIKey: apiKey,
-                overrideToken: userAToken
+                userId: creatorUserId
             )
 
         let participantUserFlow = try await helpers
             .callFlow(
                 id: callId,
                 type: .default,
-                userId: participantUserId,
-                overrideAPIKey: apiKey,
-                overrideToken: userBToken
+                userId: participantUserId
             )
 
         let creatorFlow = try await creatorUserFlow

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -364,15 +364,31 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     func test_end_whenCreatorEndsCall_thenParticipantAutomaticallyLeaves() async throws {
         let callId = String.unique
-        let creatorUserId = String.unique
-        let participantUserId = String.unique
+        let creatorUserId = "user-a"
+        let participantUserId = "user-b"
         helpers.duringDismantleObservedAllCallEnded = false
 
+        let apiKey = "hd8szvscpxvd"
+        let userAToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NzY2ODczNDMsInVzZXJfaWQiOiJ1c2VyLWEifQ.1ZgWONVUFKEB6vneFKfyPt9Ht1VrXIEpRzR877dF7gw"
+        let userBToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NzY2ODczNTUsInVzZXJfaWQiOiJ1c2VyLWIifQ.ggHutnqzYYd3e_p1VZkgQpgnjAwMTqRMoomhNadRCzE"
+
         let creatorUserFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: creatorUserId)
+            .callFlow(
+                id: callId,
+                type: .default,
+                userId: creatorUserId,
+                overrideAPIKey: apiKey,
+                overrideToken: userAToken
+            )
 
         let participantUserFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: participantUserId)
+            .callFlow(
+                id: callId,
+                type: .default,
+                userId: participantUserId,
+                overrideAPIKey: apiKey,
+                overrideToken: userBToken
+            )
 
         let creatorFlow = try await creatorUserFlow
             .perform { try await $0.call.create(memberIds: [creatorUserId, participantUserId]) }
@@ -1032,6 +1048,97 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         try await flow
             .assertEventuallyInMainActor { $0.call.streamVideo.state.activeCall == nil }
+    }
+
+    func test_join_whenParticipantCancelsJoinAttemptAndRetries_thenSecondJoinSucceedsWithoutTimeoutErrors() async throws {
+        let callId = String.unique
+        let creator = String.unique
+        let participant = String.unique
+
+        let creatorCallFlow = try await helpers
+            .callFlow(id: callId, type: .default, userId: creator)
+
+        let participantCallFlow = try await helpers
+            .callFlow(id: callId, type: .default, userId: participant)
+
+        let creatorJoinedCallFlow = try await creatorCallFlow
+            .perform {
+                try await $0.call.create(
+                    memberIds: [creator, participant]
+                )
+            }
+            .perform {
+                try await $0.call.join(
+                    policy: .peerConnectionReadinessAware
+                )
+            }
+
+        let participantJoinedEvents = creatorJoinedCallFlow
+            .subscribe(for: CallSessionParticipantJoinedEvent.self)
+        let participantLeftEvents = creatorJoinedCallFlow
+            .subscribe(for: CallSessionParticipantLeftEvent.self)
+
+        let cancelledJoinTask = Task {
+            try await participantCallFlow.call.join()
+        }
+
+        try await participantJoinedEvents
+            .assertEventually {
+                $0.callCid == creatorJoinedCallFlow.call.cId &&
+                    $0.participant.user.id == participant
+            }
+
+        cancelledJoinTask.cancel()
+        participantCallFlow.call.leave(reason: "join.cancelled")
+
+        do {
+            _ = try await cancelledJoinTask.value
+            XCTFail("Expected cancellation.")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        try await participantLeftEvents
+            .assertEventually {
+                $0.callCid == creatorJoinedCallFlow.call.cId &&
+                    $0.participant.user.id == participant
+            }
+
+        let participantRejoinedFlow = try await participantCallFlow
+            .perform {
+                try await $0.call.join()
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.reconnectionStatus == .connected
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.participants.endIndex == 2
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.participants.first {
+                    $0.userId == creator
+                } != nil
+            }
+
+        try await creatorJoinedCallFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participants.endIndex == 2
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.participants.first {
+                    $0.userId == participant
+                } != nil
+            }
+            .delay(CallConfiguration.timeout.join + 0.5)
+            .assertInMainActor {
+                $0.call.state.participants.endIndex == 2
+            }
+
+        try await participantRejoinedFlow
+            .assertInMainActor {
+                $0.call.state.reconnectionStatus == .connected
+            }
     }
 
     // MARK: - Pin

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
@@ -84,13 +84,15 @@ extension Call_IntegrationTests {
             type: String,
             userId: String,
             environment: String = "pronto",
-            clientResolutionMode: StreamVideoHelper.ClientResolutionMode = .ignoreCache
+            clientResolutionMode: StreamVideoHelper.ClientResolutionMode = .ignoreCache,
+            overrideAPIKey: String? = nil,
+            overrideToken: String? = nil
         ) async throws -> CallFlow<Void> {
             let authentication = try await authentication
                 .authenticate(userId: userId, environment: environment)
             let client = try await client.buildClient(
-                apiKey: authentication.apiKey,
-                token: authentication.token,
+                apiKey: overrideAPIKey ?? authentication.apiKey,
+                token: overrideToken ?? authentication.token,
                 userId: userId,
                 connectMode: .afterInit,
                 clientResolutionMode: clientResolutionMode,

--- a/StreamVideoTests/Utils/Extensions/Combine/PublisherAsyncStreamTests.swift
+++ b/StreamVideoTests/Utils/Extensions/Combine/PublisherAsyncStreamTests.swift
@@ -243,6 +243,55 @@ final class PublisherAsyncStreamTests: XCTestCase, @unchecked Sendable {
             XCTAssertTrue(error is ClientError)
         }
     }
+
+    /// Tests firstValue propagates cancellation while waiting for a value.
+    func test_firstValue_whenTaskIsCancelled_throwsCancellationError() async {
+        // Given
+        let publisher = PassthroughSubject<Int, Never>()
+        let task = Task {
+            try await publisher.firstValue()
+        }
+
+        // When
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation.")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    /// Tests firstValue with timeout propagates cancellation immediately.
+    func test_firstValue_withTimeout_whenTaskIsCancelled_throwsCancellationError() async {
+        // Given
+        let publisher = PassthroughSubject<Int, Never>()
+        let startTime = Date()
+        let task = Task {
+            try await publisher.firstValue(timeoutInSeconds: 1.0)
+        }
+
+        // When
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation.")
+        } catch is CancellationError {
+            let elapsed = Date().timeIntervalSince(startTime)
+            XCTAssertLessThan(
+                elapsed,
+                0.5,
+                "Cancellation should not wait for the timeout to elapse."
+            )
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
     
     // MARK: - nextValue Tests
     
@@ -311,6 +360,34 @@ final class PublisherAsyncStreamTests: XCTestCase, @unchecked Sendable {
         } catch {
             // Expected timeout
             XCTAssertTrue(error is ClientError)
+        }
+    }
+
+    /// Tests nextValue propagates cancellation instead of waiting for timeout.
+    func test_nextValue_withTimeout_whenTaskIsCancelled_throwsCancellationError() async {
+        // Given
+        let publisher = PassthroughSubject<Int, Never>()
+        let startTime = Date()
+        let task = Task {
+            try await publisher.nextValue(timeout: 1.0)
+        }
+
+        // When
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation.")
+        } catch is CancellationError {
+            let elapsed = Date().timeIntervalSince(startTime)
+            XCTAssertLessThan(
+                elapsed,
+                0.5,
+                "Cancellation should not wait for the timeout to elapse."
+            )
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
     }
     

--- a/StreamVideoTests/WebRTC/Extensions/Foundation/Task_TimeoutTests.swift
+++ b/StreamVideoTests/WebRTC/Extensions/Foundation/Task_TimeoutTests.swift
@@ -178,8 +178,10 @@ final class TaskTimeoutTests: XCTestCase, @unchecked Sendable {
         do {
             _ = try await task.value
             XCTFail("Cancelled task should not complete successfully")
-        } catch {
+        } catch is CancellationError {
             return
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
     }
     
@@ -202,8 +204,10 @@ final class TaskTimeoutTests: XCTestCase, @unchecked Sendable {
         do {
             _ = try await task.value
             XCTFail("Task should have been cancelled")
-        } catch {
+        } catch is CancellationError {
             XCTAssertTrue(operationStarted, "Operation should have started")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1613/investigationtimeout-issues

### 🎯 Goal

Prevent cancelled join attempts from lingering until the join timeout expires, which could surface stale `TimeOutError`s even when a later retry succeeds.

### 📝 Summary

- Propagate cancellation immediately through the Combine-to-async publisher bridge used by call join flows.
- Ensure timed publisher waits cancel their underlying timeout task instead of waiting for the full deadline.
- Add direct cancellation regressions for `firstValue(...)` and `nextValue(...)`.
- Add an integration regression covering: participant joins, cancels a join attempt in progress, retries, and successfully rejoins without later timeout fallout.
- Add docC comments to the changed public async publisher helpers.

### 🛠 Implementation

The fix keeps the join timeout behavior intact for genuine timeout cases, but changes cancellation semantics so a cancelled caller exits promptly with `CancellationError`.

In the async publisher bridge:
- `firstValue()` now treats cancellation during stream consumption as cancellation instead of a generic “Task produced no value” client error.
- `firstValue(timeoutInSeconds:)` wraps the timeout task in a cancellation handler so cancelling the caller also cancels the underlying timed wait immediately.
- `nextValue(...)` inherits that behavior through the shared helper path.

Test coverage now exists at three levels:
- unit coverage for direct publisher cancellation behavior
- timeout helper cancellation coverage
- an end-to-end integration scenario for cancelling a join in progress and retrying successfully
- 
### 🧪 Manual Testing Notes

- Start a 1:1 call.
- Let participant A join.
- Start participant B join, cancel it mid-join, then retry.
- Confirm both participants join successfully and no delayed timeout error appears afterward.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so cancelled operations stop promptly and report cancellation instead of generic failures.
  * Ensured timeout tasks are cancelled immediately when an awaiting operation is cancelled.
  * Joining now leaves the call on final handoff timeout and stops retrying, preserving call state.

* **Tests**
  * Added and updated tests covering cancellation, timeout, join timeout leave behavior, and join/retry recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->