### PR TITLE
[Enhancement]Add startCall high-scale livestream publisher hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
 - Added `CreateCallOptions.highScaleLivestreamPublisherHint` so `Call.join(options: ...)` can mark publishers for high-scale livestream join routing. [#1134](https://github.com/GetStream/stream-video-swift/pull/1134)
 
 # [1.46.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.46.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Added `CreateCallOptions.highScaleLivestreamPublisherHint` so `Call.join(options: ...)` can mark publishers for high-scale livestream join routing. [#1134](https://github.com/GetStream/stream-video-swift/pull/1134)
 
 # [1.46.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.46.0)
 _April 20, 2026_

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/HighScaleLivestreamPublisherHint.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/HighScaleLivestreamPublisherHint.swift
@@ -1,0 +1,53 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension AppEnvironment {
+
+    enum HighScaleLivestreamPublisherHintToggle: Hashable, Debuggable {
+        case enabled, disabled
+
+        var title: String {
+            switch self {
+            case .enabled:
+                return "Enabled"
+            case .disabled:
+                return "Disabled"
+            }
+        }
+
+        var value: Bool? {
+            switch self {
+            case .enabled:
+                return true
+            case .disabled:
+                return nil
+            }
+        }
+    }
+
+    nonisolated(unsafe) static var highScaleLivestreamPublisherHint: HighScaleLivestreamPublisherHintToggle = .disabled
+}
+
+extension DebugMenu {
+
+    struct HighScaleLivestreamPublisherHintToggleView: View {
+
+        @State private var value = AppEnvironment.highScaleLivestreamPublisherHint {
+            didSet { AppEnvironment.highScaleLivestreamPublisherHint = value }
+        }
+
+        var body: some View {
+            ItemMenuView(
+                items: [.enabled, .disabled],
+                currentValue: value,
+                label: "High-Scale Livestream Hint",
+                availableAfterLogin: true,
+                updater: { value = $0 }
+            )
+        }
+    }
+}

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/HighScaleLivestreamPublisherHint.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/Components/HighScaleLivestreamPublisherHint.swift
@@ -7,9 +7,11 @@ import SwiftUI
 
 extension AppEnvironment {
 
+    /// Controls whether demo joins send the publisher hint or omit it.
     enum HighScaleLivestreamPublisherHintToggle: Hashable, Debuggable {
         case enabled, disabled
 
+        /// Label consumed by the shared debug menu renderer.
         var title: String {
             switch self {
             case .enabled:
@@ -19,6 +21,7 @@ extension AppEnvironment {
             }
         }
 
+        /// `nil` omits the hint, which keeps regular demo joins unchanged.
         var value: Bool? {
             switch self {
             case .enabled:
@@ -29,7 +32,9 @@ extension AppEnvironment {
         }
     }
 
-    nonisolated(unsafe) static var highScaleLivestreamPublisherHint: HighScaleLivestreamPublisherHintToggle = .disabled
+    /// Omitting by default keeps regular demo joins on the standard path.
+    nonisolated(unsafe) static var highScaleLivestreamPublisherHint:
+        HighScaleLivestreamPublisherHintToggle = .disabled
 }
 
 extension DebugMenu {

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
@@ -17,7 +17,8 @@ extension AppEnvironment {
         .init { .init(DebugMenu.VideoProcessingPipelineToggleView()) },
         .init { .init(DebugMenu.CapturingPipelineToggleView()) },
         .init { .init(DebugMenu.VideoRenderingMenuView()) },
-        .init { .init(DebugMenu.CallJoinInterceptorSelector()) }
+        .init { .init(DebugMenu.CallJoinInterceptorSelector()) },
+        .init { .init(DebugMenu.HighScaleLivestreamPublisherHintToggleView()) }
     ]
 }
 

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -173,6 +173,7 @@ struct DetailedCallingView<Factory: ViewFactory>: View {
                                 callId: text,
                                 members: members,
                                 ring: callFlow == .ringEvents,
+                                highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value,
                                 video: viewModel.callSettings.videoOn
                             )
                         }

--- a/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DetailedCallingView.swift
@@ -168,12 +168,15 @@ struct DetailedCallingView<Factory: ViewFactory>: View {
                                 video: viewModel.callSettings.videoOn
                             )
                         } else {
+                            let highScaleHint = AppEnvironment
+                                .highScaleLivestreamPublisherHint
+                                .value
                             viewModel.startCall(
                                 callType: callType,
                                 callId: text,
                                 members: members,
                                 ring: callFlow == .ringEvents,
-                                highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value,
+                                highScaleLivestreamPublisherHint: highScaleHint,
                                 video: viewModel.callSettings.videoOn
                             )
                         }

--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -253,6 +253,7 @@ struct SimpleCallingView: View {
                 members: [],
                 ring: false,
                 maxDuration: AppEnvironment.callExpiration.duration,
+                highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value,
                 video: viewModel.callSettings.videoOn
             )
         }

--- a/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/SimpleCallingView.swift
@@ -247,13 +247,16 @@ struct SimpleCallingView: View {
             await setPreferredVideoCodec(for: callId)
             try? await setAudioSessionPolicyOverride(for: callId)
             await setClientCapabilities(for: callId)
+            let highScaleHint = AppEnvironment
+                .highScaleLivestreamPublisherHint
+                .value
             viewModel.startCall(
                 callType: callType,
                 callId: callId,
                 members: [],
                 ring: false,
                 maxDuration: AppEnvironment.callExpiration.duration,
-                highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value,
+                highScaleLivestreamPublisherHint: highScaleHint,
                 video: viewModel.callSettings.videoOn
             )
         }

--- a/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
@@ -55,12 +55,15 @@ internal struct DemoCallContainerView: View {
             let contact = callIntent.contacts?.first
 
             guard let name = contact?.personHandle?.value else { return }
+            let highScaleHint = AppEnvironment
+                .highScaleLivestreamPublisherHint
+                .value
             viewModel.startCall(
                 callType: callType,
                 callId: .unique,
                 members: [.init(user: .init(id: name))],
                 ring: true,
-                highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value
+                highScaleLivestreamPublisherHint: highScaleHint
             )
         }
     }

--- a/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallContainerView.swift
@@ -55,7 +55,13 @@ internal struct DemoCallContainerView: View {
             let contact = callIntent.contacts?.first
 
             guard let name = contact?.personHandle?.value else { return }
-            viewModel.startCall(callType: callType, callId: .unique, members: [.init(user: .init(id: name))], ring: true)
+            viewModel.startCall(
+                callType: callType,
+                callId: .unique,
+                members: [.init(user: .init(id: name))],
+                ring: true,
+                highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value
+            )
         }
     }
 }

--- a/DemoApp/Sources/Views/CallView/DemoCallsViewModel.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallsViewModel.swift
@@ -71,7 +71,8 @@ class DemoCallsViewModel: ObservableObject {
             callType: .default,
             callId: UUID().uuidString,
             members: members,
-            ring: true
+            ring: true,
+            highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value
         )
     }
 }

--- a/DemoApp/Sources/Views/CallView/DemoCallsViewModel.swift
+++ b/DemoApp/Sources/Views/CallView/DemoCallsViewModel.swift
@@ -67,12 +67,15 @@ class DemoCallsViewModel: ObservableObject {
     func startCall(with employees: [StreamEmployee]) {
         var members = employees.map { Member(user: User(id: $0.id, name: $0.name, imageURL: $0.imageURL)) }
         members.append(Member(user: streamVideo.user))
+        let highScaleHint = AppEnvironment
+            .highScaleLivestreamPublisherHint
+            .value
         callViewModel.startCall(
             callType: .default,
             callId: UUID().uuidString,
             members: members,
             ring: true,
-            highScaleLivestreamPublisherHint: AppEnvironment.highScaleLivestreamPublisherHint.value
+            highScaleLivestreamPublisherHint: highScaleHint
         )
     }
 }

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -117,8 +117,6 @@ class CallController: @unchecked Sendable {
     ///   - callSettings: The current call settings.
     ///   - videoOptions: Configuration options about the video.
     ///   - options: Create call options.
-    ///              `CreateCallOptions.highScaleLivestreamPublisherHint` is
-    ///              forwarded only to backend join requests.
     ///   - migratingFrom: If SFU migration is being performed.
     ///   - ring: Whether ringing events should be handled.
     ///   - notify: Whether users should be notified about the call.

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -56,7 +56,6 @@ class CallController: @unchecked Sendable {
     private let videoConfig: VideoConfig
     private let webRTCCoordinatorFactory: WebRTCCoordinatorProviding
     private var cachedLocation: String?
-    private var cachedHighScaleLivestreamPublisherHint: Bool?
     private let initialCallSettings: CallSettings
 
     private var webRTCClientSessionIDObserver: AnyCancellable?
@@ -135,8 +134,6 @@ class CallController: @unchecked Sendable {
         source: JoinSource,
         policy: WebRTCJoinPolicy = .default
     ) async throws -> JoinCallResponse {
-        cachedHighScaleLivestreamPublisherHint = options?.highScaleLivestreamPublisherHint
-
         /// Each join attempt creates a fresh `PassthroughSubject` so
         /// that a failure from a previous attempt cannot accidentally
         /// complete a future retry on the same controller.
@@ -653,7 +650,7 @@ class CallController: @unchecked Sendable {
         let joinCall = JoinCallRequest(
             create: create,
             data: callRequest,
-            hintHighScaleLivestreamPublisher: cachedHighScaleLivestreamPublisherHint,
+            hintHighScaleLivestreamPublisher: options?.highScaleLivestreamPublisherHint,
             location: location,
             migratingFrom: migratingFrom,
             migratingFromList: migratingFromList?.isEmpty == false ? migratingFromList : nil,

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -56,6 +56,7 @@ class CallController: @unchecked Sendable {
     private let videoConfig: VideoConfig
     private let webRTCCoordinatorFactory: WebRTCCoordinatorProviding
     private var cachedLocation: String?
+    private var cachedHighScaleLivestreamPublisherHint: Bool?
     private let initialCallSettings: CallSettings
 
     private var webRTCClientSessionIDObserver: AnyCancellable?
@@ -116,6 +117,8 @@ class CallController: @unchecked Sendable {
     ///   - callSettings: The current call settings.
     ///   - videoOptions: Configuration options about the video.
     ///   - options: Create call options.
+    ///              `CreateCallOptions.highScaleLivestreamPublisherHint` is
+    ///              forwarded only to backend join requests.
     ///   - migratingFrom: If SFU migration is being performed.
     ///   - ring: Whether ringing events should be handled.
     ///   - notify: Whether users should be notified about the call.
@@ -134,6 +137,8 @@ class CallController: @unchecked Sendable {
         source: JoinSource,
         policy: WebRTCJoinPolicy = .default
     ) async throws -> JoinCallResponse {
+        cachedHighScaleLivestreamPublisherHint = options?.highScaleLivestreamPublisherHint
+
         /// Each join attempt creates a fresh `PassthroughSubject` so
         /// that a failure from a previous attempt cannot accidentally
         /// complete a future retry on the same controller.
@@ -619,7 +624,7 @@ class CallController: @unchecked Sendable {
     ///   - migratingFrom: The immediate SFU edge this flow is migrating from.
     ///   - migratingFromList: All exhausted SFU edges that should be avoided.
     ///   - notify: Whether the backend should notify call members.
-    ///   - options: Additional call creation options.
+    ///   - options: Additional call creation options and join-only hints.
     /// - Returns: The backend join response used to continue the WebRTC flow.
     /// - Throws: An error if location fetch or join request fails.
     private func authenticateCall(
@@ -650,6 +655,7 @@ class CallController: @unchecked Sendable {
         let joinCall = JoinCallRequest(
             create: create,
             data: callRequest,
+            hintHighScaleLivestreamPublisher: cachedHighScaleLivestreamPublisherHint,
             location: location,
             migratingFrom: migratingFrom,
             migratingFromList: migratingFromList?.isEmpty == false ? migratingFromList : nil,

--- a/Sources/StreamVideo/Models/CoordinatorModels.swift
+++ b/Sources/StreamVideo/Models/CoordinatorModels.swift
@@ -19,8 +19,8 @@ public struct CreateCallOptions: Sendable, Hashable {
     public var settings: CallSettingsRequest?
     public var startsAt: Date?
     public var team: String?
-    /// Join-only hint that marks the participant as publishing to a large
-    /// livestream audience.
+    /// Marks this join as a high-scale livestream publisher for backend
+    /// routing.
     public var highScaleLivestreamPublisherHint: Bool?
     
     public init(

--- a/Sources/StreamVideo/Models/CoordinatorModels.swift
+++ b/Sources/StreamVideo/Models/CoordinatorModels.swift
@@ -19,6 +19,9 @@ public struct CreateCallOptions: Sendable, Hashable {
     public var settings: CallSettingsRequest?
     public var startsAt: Date?
     public var team: String?
+    /// Join-only hint that marks the participant as publishing to a large
+    /// livestream audience.
+    public var highScaleLivestreamPublisherHint: Bool?
     
     public init(
         memberIds: [String]? = nil,
@@ -26,7 +29,8 @@ public struct CreateCallOptions: Sendable, Hashable {
         custom: [String: RawJSON]? = nil,
         settings: CallSettingsRequest? = nil,
         startsAt: Date? = nil,
-        team: String? = nil
+        team: String? = nil,
+        highScaleLivestreamPublisherHint: Bool? = nil
     ) {
         self.memberIds = memberIds
         self.members = members
@@ -34,6 +38,7 @@ public struct CreateCallOptions: Sendable, Hashable {
         self.settings = settings
         self.startsAt = startsAt
         self.team = team
+        self.highScaleLivestreamPublisherHint = highScaleLivestreamPublisherHint
     }
 }
 

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
@@ -13,8 +13,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
     ///   - ring: A Boolean indicating whether to ring the other participants.
     /// - Returns: A `ConnectingStage` instance representing the connecting
     ///   state of the WebRTC coordinator.
-    /// - Important: When transitioning from `.rejoining` values for ``ring``,
-    /// ``notify`` & ``options`` are nullified as are not relevant to the `rejoining` flow.
+    /// - Important: Rejoining transitions ignore ringing side effects.
+    ///   They rebuild only recovery-safe join options from context.
     static func connecting(
         _ context: Context,
         create: Bool,
@@ -70,14 +70,19 @@ extension WebRTCCoordinator.StateMachine.Stage {
         ///   occurring.
         /// - Returns: This `ConnectingStage` instance if the transition is
         ///   valid, otherwise `nil`.
-        /// - Important: When transitioning from `.rejoining` values for ``ring``,
-        /// ``notify`` & ``options`` are nullified as are not relevant to the `rejoining` flow.
+        /// - Important: Rejoining transitions ignore ringing side effects.
+        ///   They rebuild only recovery-safe join options from context.
         /// - Note: Valid transition from: `.idle`,  `.rejoining`
         override func transition(
             from previousStage: WebRTCCoordinator.StateMachine.Stage
         ) -> Self? {
             switch previousStage.id {
             case .idle:
+                /// The join hint is captured only after the explicit
+                /// `.idle -> .connecting` transition is accepted. Failed
+                /// transition attempts must not mutate the active context.
+                context.highScaleLivestreamPublisherHint =
+                    options?.highScaleLivestreamPublisherHint
                 execute(
                     create: create,
                     ring: ring,
@@ -88,16 +93,15 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 )
                 return self
             case .rejoining:
-                if ring || notify || options != nil {
+                if ring || notify {
                     log.assert(ring == false, "Ring cannot be true when rejoining.")
                     log.assert(notify == false, "Notify cannot be true when rejoining.")
-                    log.assert(options == nil, "CreateCallOptions cannot be non-nil when rejoining.")
                 }
                 execute(
                     create: false,
                     ring: false,
                     notify: false,
-                    options: nil,
+                    options: options,
                     updateSession: true,
                     onErrorDisconnect: true
                 )

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrated.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Migrated.swift
@@ -79,7 +79,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                             create: false,
                             ring: false,
                             notify: false,
-                            options: nil
+                            options: context.recoveryJoinOptions()
                         )
 
                     // Start observing SFU-full errors on the newly assigned SFU

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Rejoining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Rejoining.swift
@@ -117,7 +117,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         .connecting(
                             context,
                             create: false,
-                            options: nil,
+                            options: context.recoveryJoinOptions(),
                             ring: false,
                             notify: false
                         )

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -24,6 +24,9 @@ extension WebRTCCoordinator.StateMachine {
             var flowError: Error?
             var joinSource: JoinSource?
             var joinPolicy: WebRTCJoinPolicy = .default
+            /// Preserves explicit join routing hints for recovery requests that
+            /// no longer carry the original `CreateCallOptions`.
+            var highScaleLivestreamPublisherHint: Bool?
             /// Shared adapter handling SFU track subscriptions updates across
             /// stage transitions.
             var updateSubscriptionsAdapter: WebRTCUpdateSubscriptionsAdapter?
@@ -97,6 +100,15 @@ extension WebRTCCoordinator.StateMachine {
                 default:
                     return reconnectionStrategy
                 }
+            }
+
+            /// Builds the minimal options payload used when recovery
+            /// authentication no longer has the original join options.
+            func recoveryJoinOptions() -> CreateCallOptions? {
+                guard let hint = highScaleLivestreamPublisherHint else {
+                    return nil
+                }
+                return .init(highScaleLivestreamPublisherHint: hint)
             }
 
             /// Registers a rejoin attempt if the rolling rejoin limit has not

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -417,9 +417,8 @@ open class CallViewModel: ObservableObject {
     ///  - maxParticipants: An optional integer representing the maximum number of participants allowed in the call.
     ///  - startsAt: An optional date when the call starts.
     ///  - backstage: An optional request for setting up backstage.
-    ///  - highScaleLivestreamPublisherHint: Optional join-only hint forwarded
-    ///    through `CreateCallOptions` when the call is started via the
-    ///    create-and-join flow.
+    ///  - highScaleLivestreamPublisherHint: Marks this join as a
+    ///   high-scale livestream publisher when backend routing needs it.
     ///  - video: A boolean indicating if the call will be video or only audio. Still requires appropriate
     ///   setting of ``CallSettings`.`
     public func startCall(

--- a/Sources/StreamVideoSwiftUI/CallViewModel.swift
+++ b/Sources/StreamVideoSwiftUI/CallViewModel.swift
@@ -417,6 +417,9 @@ open class CallViewModel: ObservableObject {
     ///  - maxParticipants: An optional integer representing the maximum number of participants allowed in the call.
     ///  - startsAt: An optional date when the call starts.
     ///  - backstage: An optional request for setting up backstage.
+    ///  - highScaleLivestreamPublisherHint: Optional join-only hint forwarded
+    ///    through `CreateCallOptions` when the call is started via the
+    ///    create-and-join flow.
     ///  - video: A boolean indicating if the call will be video or only audio. Still requires appropriate
     ///   setting of ``CallSettings`.`
     public func startCall(
@@ -429,6 +432,7 @@ open class CallViewModel: ObservableObject {
         maxParticipants: Int? = nil,
         startsAt: Date? = nil,
         backstage: BackstageSettingsRequest? = nil,
+        highScaleLivestreamPublisherHint: Bool? = nil,
         customData: [String: RawJSON]? = nil,
         video: Bool? = nil
     ) {
@@ -448,6 +452,7 @@ open class CallViewModel: ObservableObject {
                 maxParticipants: maxParticipants,
                 startsAt: startsAt,
                 backstage: backstage,
+                highScaleLivestreamPublisherHint: highScaleLivestreamPublisherHint,
                 customData: customData
             )
         } else {
@@ -887,6 +892,7 @@ open class CallViewModel: ObservableObject {
         maxParticipants: Int? = nil,
         startsAt: Date? = nil,
         backstage: BackstageSettingsRequest? = nil,
+        highScaleLivestreamPublisherHint: Bool? = nil,
         customData: [String: RawJSON]? = nil,
         policy: WebRTCJoinPolicy = .default
     ) {
@@ -914,7 +920,8 @@ open class CallViewModel: ObservableObject {
                     custom: customData,
                     settings: settingsRequest,
                     startsAt: startsAt,
-                    team: team
+                    team: team,
+                    highScaleLivestreamPublisherHint: highScaleLivestreamPublisherHint
                 )
                 let settings = localCallSettingsChange ? callSettings : nil
 

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -785,6 +785,38 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         await assertCallingState(.inCall)
     }
 
+    func test_startCall_withHighScaleLivestreamPublisherHint_forwardsHintInJoinOptions() async throws {
+        await prepare()
+        mockCall.resetRecords(for: .join)
+
+        subject.startCall(
+            callType: callType,
+            callId: callId,
+            members: participants,
+            highScaleLivestreamPublisherHint: true
+        )
+
+        await fulfilmentInMainActor { self.mockCall.timesCalled(.join) == 1 }
+
+        let joinPayload = try XCTUnwrap(
+            mockCall
+                .recordedInputPayload(
+                    (
+                        Bool,
+                        CreateCallOptions?,
+                        Bool,
+                        Bool,
+                        CallSettings?,
+                        WebRTCJoinPolicy
+                    ).self,
+                    for: .join
+                )?
+                .last
+        )
+
+        XCTAssertEqual(joinPayload.1?.highScaleLivestreamPublisherHint, true)
+    }
+
     func test_joinCall_whenHangingUpWhileJoinIsInProgress_thenCallingStateDoesNotBecomeInCall() async throws {
         let joinStartedExpectation = expectation(
             description: "Join flow should start before hang up."

--- a/StreamVideoSwiftUITests/CallViewModel_Tests.swift
+++ b/StreamVideoSwiftUITests/CallViewModel_Tests.swift
@@ -785,7 +785,7 @@ final class CallViewModel_Tests: XCTestCase, @unchecked Sendable {
         await assertCallingState(.inCall)
     }
 
-    func test_startCall_withHighScaleLivestreamPublisherHint_forwardsHintInJoinOptions() async throws {
+    func test_startCall_forwardsHighScalePublisherHint() async throws {
         await prepare()
         mockCall.resetRecords(for: .join)
 

--- a/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
+++ b/StreamVideoTests/Call/Call_JoinRecovery_Tests.swift
@@ -41,6 +41,9 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
             coordinatorClient: defaultAPI,
             callController: controller
         )
+        let options = CreateCallOptions(
+            highScaleLivestreamPublisherHint: true
+        )
         let joinResponse = JoinCallResponse.dummy(
             call: .dummy(
                 cid: subject.cId,
@@ -84,6 +87,7 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
         let joinTask = Task {
             try await subject.join(
                 create: false,
+                options: options,
                 ring: false,
                 notify: false,
                 callSettings: .init(audioOn: false, videoOn: false)
@@ -168,6 +172,9 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
             coordinatorClient: defaultAPI,
             callController: controller
         )
+        let options = CreateCallOptions(
+            highScaleLivestreamPublisherHint: true
+        )
         let joinResponse = JoinCallResponse.dummy(
             call: .dummy(
                 cid: subject.cId,
@@ -212,6 +219,7 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
         let joinTask = Task {
             try await subject.join(
                 create: false,
+                options: options,
                 ring: false,
                 notify: false,
                 callSettings: .init(audioOn: false, videoOn: false)
@@ -315,6 +323,11 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.create == false })
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.ring == false })
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.notify == false })
+        XCTAssertTrue(
+            joinCallRequests.allSatisfy {
+                $0.2.hintHighScaleLivestreamPublisher == true
+            }
+        )
     }
 
     func test_join_afterAbnormalWebSocketClosure_issuesAdditionalBackendJoinRequest() async throws {
@@ -344,6 +357,9 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
             callId: callId,
             coordinatorClient: defaultAPI,
             callController: controller
+        )
+        let options = CreateCallOptions(
+            highScaleLivestreamPublisherHint: true
         )
         let joinResponse = JoinCallResponse.dummy(
             call: .dummy(
@@ -403,6 +419,7 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
         let joinTask = Task {
             try await subject.join(
                 create: false,
+                options: options,
                 ring: false,
                 notify: false,
                 callSettings: .init(audioOn: false, videoOn: false)
@@ -449,10 +466,15 @@ final class Call_JoinRecovery_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.create == false })
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.ring == false })
         XCTAssertTrue(joinCallRequests.allSatisfy { $0.2.notify == false })
+        XCTAssertTrue(
+            joinCallRequests.allSatisfy {
+                $0.2.hintHighScaleLivestreamPublisher == true
+            }
+        )
     }
 }
 
-private final class CallAuthenticationBackedWebRTCAuthenticator:
+final class CallAuthenticationBackedWebRTCAuthenticator:
     WebRTCAuthenticating,
     @unchecked Sendable {
     @Injected(\.audioStore) private var audioStore

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -638,16 +638,16 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         )
     }
 
-    func test_join_withHighScaleLivestreamPublisherHint_optionsWerePassedToCallController() async throws {
+    func test_join_passesHighScalePublisherHintToCallController() async throws {
         let mockCallController = MockCallController()
-        let call = MockCall(.dummy(callController: mockCallController))
-        call.stub(for: \.state, with: .init(.dummy()))
+        let subject = MockCall(.dummy(callController: mockCallController))
+        subject.stub(for: \.state, with: .init(.dummy()))
         mockCallController.stub(for: .join, with: JoinCallResponse.dummy())
         let options = CreateCallOptions(
             highScaleLivestreamPublisherHint: true
         )
 
-        _ = try await call.join(options: options)
+        _ = try await subject.join(options: options)
 
         XCTAssertEqual(
             mockCallController.recordedInputPayload(

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -638,6 +638,34 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         )
     }
 
+    func test_join_withHighScaleLivestreamPublisherHint_optionsWerePassedToCallController() async throws {
+        let mockCallController = MockCallController()
+        let call = MockCall(.dummy(callController: mockCallController))
+        call.stub(for: \.state, with: .init(.dummy()))
+        mockCallController.stub(for: .join, with: JoinCallResponse.dummy())
+        let options = CreateCallOptions(
+            highScaleLivestreamPublisherHint: true
+        )
+
+        _ = try await call.join(options: options)
+
+        XCTAssertEqual(
+            mockCallController.recordedInputPayload(
+                (
+                    Bool,
+                    CallSettings?,
+                    CreateCallOptions?,
+                    Bool,
+                    Bool,
+                    JoinSource,
+                    WebRTCJoinPolicy
+                ).self,
+                for: .join
+            )?.first?.2?.highScaleLivestreamPublisherHint,
+            true
+        )
+    }
+
     func test_join_withPolicy_policyWasPassedToCallController() async throws {
         let mockCallController = MockCallController()
         let call = MockCall(.dummy(callController: mockCallController))

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -166,6 +166,139 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
+    func test_joinCall_withHighScaleLivestreamPublisherHint_setsJoinRequestHint() async throws {
+        let defaultAPI = MockDefaultAPIEndpoints()
+        let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
+            videoConfig: Self.videoConfig
+        )
+        let subject = CallController(
+            defaultAPI: defaultAPI,
+            user: user,
+            callId: callId,
+            callType: callType,
+            apiKey: apiKey,
+            videoConfig: Self.videoConfig,
+            initialCallSettings: initialCallSettings,
+            cachedLocation: cachedLocation,
+            webRTCCoordinatorFactory: webRTCCoordinatorFactory
+        )
+        let expectedResponse = JoinCallResponse.dummy()
+        let options = CreateCallOptions(
+            highScaleLivestreamPublisherHint: true
+        )
+        defaultAPI.stub(for: .joinCall, with: expectedResponse)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .authenticator = CallAuthenticationBackedWebRTCAuthenticator(
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+
+        let joinTask = Task {
+            try await subject.joinCall(
+                create: true,
+                callSettings: nil,
+                options: options,
+                ring: false,
+                notify: false,
+                source: .inApp
+            )
+        }
+
+        await fulfillment {
+            defaultAPI.timesCalled(.joinCall) == 1
+        }
+
+        await wait(for: 0.5)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+        webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+        _ = try await joinTask.value
+
+        let request = try XCTUnwrap(
+            defaultAPI.recordedInputPayload(
+                (String, String, JoinCallRequest).self,
+                for: .joinCall
+            )?.first?.2
+        )
+
+        XCTAssertEqual(request.hintHighScaleLivestreamPublisher, true)
+    }
+
+    func test_joinCall_withoutHighScaleLivestreamPublisherHint_clearsJoinRequestHint() async throws {
+        let defaultAPI = MockDefaultAPIEndpoints()
+        let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
+            videoConfig: Self.videoConfig
+        )
+        let subject = CallController(
+            defaultAPI: defaultAPI,
+            user: user,
+            callId: callId,
+            callType: callType,
+            apiKey: apiKey,
+            videoConfig: Self.videoConfig,
+            initialCallSettings: initialCallSettings,
+            cachedLocation: cachedLocation,
+            webRTCCoordinatorFactory: webRTCCoordinatorFactory
+        )
+        let expectedResponse = JoinCallResponse.dummy()
+        defaultAPI.stub(for: .joinCall, with: expectedResponse)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .coordinator
+            .stateMachine
+            .currentStage
+            .context
+            .authenticator = CallAuthenticationBackedWebRTCAuthenticator(
+                sfuAdapter: webRTCCoordinatorFactory
+                    .mockCoordinatorStack
+                    .sfuStack
+                    .adapter
+            )
+
+        let joinTask = Task {
+            try await subject.joinCall(
+                create: true,
+                callSettings: nil,
+                options: nil,
+                ring: false,
+                notify: false,
+                source: .inApp
+            )
+        }
+
+        await fulfillment {
+            defaultAPI.timesCalled(.joinCall) == 1
+        }
+
+        await wait(for: 0.5)
+        webRTCCoordinatorFactory
+            .mockCoordinatorStack
+            .sfuStack
+            .setConnectionState(to: .connected(healthCheckInfo: .init()))
+        webRTCCoordinatorFactory.mockCoordinatorStack.joinResponse([])
+
+        _ = try await joinTask.value
+
+        let request = try XCTUnwrap(
+            defaultAPI.recordedInputPayload(
+                (String, String, JoinCallRequest).self,
+                for: .joinCall
+            )?.first?.2
+        )
+
+        XCTAssertNil(request.hintHighScaleLivestreamPublisher)
+    }
+
     func test_joinCall_whenAuthenticationFails_rethrowsOriginalError() async {
         let expectedError = ClientError("auth failed")
         mockWebRTCCoordinatorFactory

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -166,7 +166,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
-    func test_joinCall_withHighScaleLivestreamPublisherHint_setsJoinRequestHint() async throws {
+    func test_joinCall_withHighScaleHint_setsJoinRequestHint() async throws {
         let defaultAPI = MockDefaultAPIEndpoints()
         let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
             videoConfig: Self.videoConfig
@@ -215,7 +215,14 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
             defaultAPI.timesCalled(.joinCall) == 1
         }
 
-        await wait(for: 0.5)
+        await fulfillment {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joining
+        }
         webRTCCoordinatorFactory
             .mockCoordinatorStack
             .sfuStack
@@ -234,7 +241,7 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertEqual(request.hintHighScaleLivestreamPublisher, true)
     }
 
-    func test_joinCall_withoutHighScaleLivestreamPublisherHint_clearsJoinRequestHint() async throws {
+    func test_joinCall_withoutHighScaleHint_clearsRequestHint() async throws {
         let defaultAPI = MockDefaultAPIEndpoints()
         let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
             videoConfig: Self.videoConfig
@@ -280,7 +287,14 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
             defaultAPI.timesCalled(.joinCall) == 1
         }
 
-        await wait(for: 0.5)
+        await fulfillment {
+            webRTCCoordinatorFactory
+                .mockCoordinatorStack
+                .coordinator
+                .stateMachine
+                .currentStage
+                .id == .joining
+        }
         webRTCCoordinatorFactory
             .mockCoordinatorStack
             .sfuStack

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_ConnectingStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_ConnectingStageTests.swift
@@ -378,8 +378,50 @@ final class WebRTCCoordinatorStateMachine_ConnectingStageTests: XCTestCase, @unc
             XCTAssertFalse(input.create)
             XCTAssertFalse(input.ring)
             XCTAssertFalse(input.notify)
-            XCTAssertNil(input.options)
+            XCTAssertEqual(input.options?.team, options.team)
             XCTAssertTrue(target.context.flowError is ClientError)
+        }
+    }
+
+    func test_transition_fromRejoiningWithHighScaleHint_forwardsReceivedOptions() async throws {
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        subject.context.authenticator = mockCoordinatorStack.webRTCAuthenticator
+        let options = CreateCallOptions(
+            team: .unique,
+            highScaleLivestreamPublisherHint: true
+        )
+
+        try await assertTransition(
+            from: .rejoining,
+            expectedTarget: .disconnected,
+            subject: .connecting(
+                subject.context,
+                create: true,
+                options: options,
+                ring: true,
+                notify: true
+            )
+        ) { [mockCoordinatorStack] _ in
+            let callType = (
+                coordinator: WebRTCCoordinator,
+                currentSFU: String?,
+                migratingFromList: [String]?,
+                create: Bool,
+                ring: Bool,
+                notify: Bool,
+                options: CreateCallOptions?
+            ).self
+            let input = try XCTUnwrap(
+                mockCoordinatorStack?.webRTCAuthenticator.recordedInputPayload(
+                    callType,
+                    for: .authenticate
+                )?.first
+            )
+            XCTAssertFalse(input.create)
+            XCTAssertFalse(input.ring)
+            XCTAssertFalse(input.notify)
+            XCTAssertEqual(input.options?.team, options.team)
+            XCTAssertEqual(input.options?.highScaleLivestreamPublisherHint, true)
         }
     }
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -89,7 +89,8 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
             custom: [.unique: .bool(true)],
             settings: CallSettingsRequest(audio: .init(defaultDevice: .earpiece)),
             startsAt: .init(timeIntervalSince1970: 100),
-            team: .unique
+            team: .unique,
+            highScaleLivestreamPublisherHint: true
         )
         let expectedJoinSource = JoinSource.callKit(.init {})
 
@@ -116,6 +117,10 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
             XCTAssertEqual(expectedStage.options?.settings?.audio?.defaultDevice, .earpiece)
             XCTAssertEqual(expectedStage.options?.startsAt, expectedOptions.startsAt)
             XCTAssertEqual(expectedStage.options?.team, expectedOptions.team)
+            XCTAssertEqual(
+                expectedStage.context.highScaleLivestreamPublisherHint,
+                true
+            )
             XCTAssertTrue(expectedStage.ring)
             XCTAssertTrue(expectedStage.notify)
             XCTAssertEqual(expectedStage.context.joinSource, expectedJoinSource)
@@ -125,6 +130,51 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
                 expectedCallSettings
             )
         }
+    }
+
+    func test_connect_rejectedTransition_keepsHighScaleHint() async throws {
+        let canAuthenticate = CurrentValueSubject<Bool, Never>(false)
+        mockWebRTCAuthenticator.onAuthenticate = { @Sendable in
+            _ = try await canAuthenticate
+                .filter { $0 }
+                .nextValue(timeout: defaultTimeout)
+        }
+        let firstHandler = PassthroughSubject<JoinCallResponse, Error>()
+        let secondHandler = PassthroughSubject<JoinCallResponse, Error>()
+        let options = CreateCallOptions(
+            highScaleLivestreamPublisherHint: true
+        )
+
+        try await subject.connect(
+            callSettings: nil,
+            options: options,
+            ring: false,
+            notify: false,
+            source: .inApp,
+            joinResponseHandler: firstHandler
+        )
+        await fulfillment {
+            self.subject.stateMachine.currentStage.id == .connecting
+        }
+
+        try await subject.connect(
+            callSettings: nil,
+            options: nil,
+            ring: false,
+            notify: false,
+            source: .inApp,
+            joinResponseHandler: secondHandler
+        )
+
+        XCTAssertEqual(
+            subject
+                .stateMachine
+                .currentStage
+                .context
+                .highScaleLivestreamPublisherHint,
+            true
+        )
+        canAuthenticate.send(true)
     }
 
     // MARK: - cleanUp


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1623/enhancementimplement-high-tier-sfu-hinting

### 🎯 Goal

Add support for the high-scale livestream publisher join hint across the iOS SDK so clients can explicitly mark publisher joins that should use the backend’s high-scale livestream routing behavior, and expose a Demo app toggle to exercise that end-to-end.

### 📝 Summary

- add `CreateCallOptions.highScaleLivestreamPublisherHint`
- forward the hint into `JoinCallRequest.hintHighScaleLivestreamPublisher`
- persist the hint in `CallController` so recovery joins reuse it
- expose the hint through `CallViewModel.startCall(...)`
- add a Demo app feature flag to enable/disable the hint, defaulting to disabled
- add unit coverage for core SDK propagation, recovery joins, and SwiftUI forwarding

### 🛠 Implementation

On the core SDK side, the high-scale livestream publisher hint is now part of `CreateCallOptions` and is mapped to `JoinCallRequest.hintHighScaleLivestreamPublisher` before the backend `joinCall` request is sent. `CallController` caches the value from the explicit join invocation so recovery joins continue to send the same hint even when reconnection paths no longer carry `CreateCallOptions`.

On the SwiftUI side, `CallViewModel.startCall(...)` now accepts the optional hint and forwards it through the create-and-join path. This keeps the feature explicit at the call site rather than storing it as mutable view model state. `joinAndRingCall(...)` was intentionally left unchanged.

In the Demo app, a new feature flag was added under the existing debug feature-flags menu in a dedicated file. Demo `startCall(...)` call sites now pass the flag explicitly so the end-to-end behavior can be toggled without changing code.

The change is covered with focused tests in the core SDK for request shape and recovery propagation, and in SwiftUI for `startCall(...)` forwarding.


### 🧪 Manual Testing Notes

1. Open the Demo app debug menu.
2. Under `Feature Flags`, toggle `High-Scale Livestream Hint`.
3. Start a call through a Demo `startCall(...)` flow with the flag disabled and confirm the call joins normally.
4. Enable the flag and repeat the same flow.
5. Optionally verify on the backend/request inspection side that the join request includes `hint_high_scale_livestream_publisher = true` when enabled.
6. Confirm reconnect/recovery behavior still works after the initial join.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call join now supports an optional high-scale livestream publisher hint to enable optimized routing for large-scale livestreams.

* **Debug**
  * New debug toggle to enable/disable the high-scale livestream publisher hint from the app’s debug menu.

* **Documentation**
  * CHANGELOG updated to reflect availability of the high-scale livestream publisher hint.

* **Tests**
  * Added tests verifying the hint is propagated through join and recovery join flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->