### PR TITLE
[Fix]Cascading active call teardown on leaving replacement calls

### DIFF
--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+LeavingStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+LeavingStage.swift
@@ -26,6 +26,13 @@ extension Call.StateMachine.Stage {
     final class LeavingStage: Call.StateMachine.Stage, @unchecked Sendable {
         private let reason: String?
         private let disposableBag = DisposableBag()
+        /// When a replacement call leaves before it becomes `activeCall`, the
+        /// previous active call may still be stored in `StreamVideo.State`.
+        ///
+        /// Clearing `activeCall` in that situation reuses
+        /// `StreamVideo.State.didUpdateActiveCall`, which leaves the stale
+        /// active call for us. This keeps the replacement flow consistent with
+        /// the normal active-call handoff without affecting unrelated leaves.
         private var shouldCascadeActiveCallTeardown = false
 
         init(
@@ -81,6 +88,10 @@ extension Call.StateMachine.Stage {
                 if call.streamVideo.state.ringingCall?.cId == call.cId {
                     call.streamVideo.state.ringingCall = nil
                 }
+                /// Replacement flows can leave while `activeCall` still points
+                /// to the call being replaced. Resetting `activeCall` here
+                /// triggers the existing `oldValue.leave()` cascade and tears
+                /// down that stale active call as well.
                 if let activeCall = call.streamVideo.state.activeCall,
                    activeCall.cId == call.cId || shouldCascadeActiveCallTeardown {
                     call.streamVideo.state.activeCall = nil

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+LeavingStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+LeavingStage.swift
@@ -26,6 +26,7 @@ extension Call.StateMachine.Stage {
     final class LeavingStage: Call.StateMachine.Stage, @unchecked Sendable {
         private let reason: String?
         private let disposableBag = DisposableBag()
+        private var shouldCascadeActiveCallTeardown = false
 
         init(
             _ context: Context,
@@ -42,6 +43,11 @@ extension Call.StateMachine.Stage {
             case .leaving:
                 return nil
             default:
+                shouldCascadeActiveCallTeardown = [
+                    .accepting,
+                    .accepted,
+                    .joining
+                ].contains(previousStage.id)
                 execute()
                 return self
             }
@@ -75,7 +81,8 @@ extension Call.StateMachine.Stage {
                 if call.streamVideo.state.ringingCall?.cId == call.cId {
                     call.streamVideo.state.ringingCall = nil
                 }
-                if call.streamVideo.state.activeCall?.cId == call.cId {
+                if let activeCall = call.streamVideo.state.activeCall,
+                   activeCall.cId == call.cId || shouldCascadeActiveCallTeardown {
                     call.streamVideo.state.activeCall = nil
                 }
 

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_LeavingStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_LeavingStageTests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+@preconcurrency import XCTest
+
+@MainActor
+final class CallStateMachineStageLeavingStage_Tests:
+    StreamVideoTestCase,
+    @unchecked Sendable {
+
+    private lazy var callController: MockCallController! = .init()
+    private lazy var call: MockCall! = .init(.dummy(callController: callController))
+    private lazy var subject: Call.StateMachine.Stage! = .leaving(
+        .init(
+            call: call,
+            input: .leaving(
+                .init(
+                    reason: nil,
+                    disposableBag: DisposableBag(),
+                    callController: callController,
+                    closedCaptionsAdapter: ClosedCaptionsAdapter(call),
+                    callCache: InjectedValues[\.callCache],
+                    resetOutgoingRingingController: {},
+                    resetAudioFilter: {}
+                )
+            )
+        ),
+        reason: nil
+    )
+    private var transitionedToStage: Call.StateMachine.Stage?
+
+    override func tearDown() async throws {
+        callController = nil
+        call = nil
+        subject = nil
+        transitionedToStage = nil
+        try await super.tearDown()
+    }
+
+    func test_transition_fromAccepting_clearsPreviousActiveCall() async {
+        let previousActiveCall = MockCall(.dummy(callId: "previous-active-call"))
+        streamVideo.state.activeCall = previousActiveCall
+        subject.transition = { self.transitionedToStage = $0 }
+
+        _ = subject.transition(from: .init(id: .accepting, context: .init(call: call)))
+
+        await fulfilmentInMainActor {
+            self.transitionedToStage?.id == .idle
+                && self.streamVideo.state.activeCall == nil
+        }
+
+        XCTAssertEqual(previousActiveCall.timesCalled(.leave), 1)
+    }
+
+    func test_transition_fromJoined_keepsUnrelatedActiveCall() async {
+        let previousActiveCall = MockCall(.dummy(callId: "previous-active-call"))
+        streamVideo.state.activeCall = previousActiveCall
+        subject.transition = { self.transitionedToStage = $0 }
+
+        _ = subject.transition(from: .init(id: .joined, context: .init(call: call)))
+
+        await fulfilmentInMainActor {
+            self.transitionedToStage?.id == .idle
+        }
+
+        XCTAssertTrue(streamVideo.state.activeCall === previousActiveCall)
+        XCTAssertEqual(previousActiveCall.timesCalled(.leave), 0)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1638/bugghost-call

### 🎯 Goal

Ensure that when a newly accepted incoming call is hung up before it fully replaces the
current active call, the previous active call is also torn down instead of remaining alive and transmitting media in the background.

### 📝 Summary

- Update `Call.LeavingStage` to cascade `activeCall` cleanup when a call leaves from
  replacement-transition states.
- Cover the replacement flow starting from `.accepting`, `.accepted`, and `.joining`.
- Add unit tests to verify:
  - leaving from a replacement-transition state clears the previous active call
  - leaving from `.joined` does not tear down an unrelated active call

### 🛠 Implementation

The fix is implemented in the shared call state machine instead of a CallKit-specific path.

Previously, `Call.LeavingStage` only cleared `streamVideo.state.activeCall` when the call
being left was itself the active call. That breaks the scenario where call B is in the
accept/replace flow, the user hangs up call B before it becomes the active call, and call A
is still the active call. In that case, call A remained alive because `activeCall` was never
cleared.

The updated logic marks leave transitions coming from `.accepting`, `.accepted`, and
`.joining` as replacement-related. When such a call leaves, `LeavingStage` clears
`streamVideo.state.activeCall` even if it still points to a different call. That triggers
the existing `StreamVideo.State.didUpdateActiveCall` behavior, which calls `leave()` on the old active call and fully tears it down.

This keeps normal leave behavior unchanged for unrelated in-call flows.

### 🎨 Showcase

N/A

|  Before  |  After  |
| -------- | ------- |
| Incoming call B can be hung up while call A remains alive in the background | Hanging up incoming/replacement call B also tears down stale active call A |

### 🧪 Manual Testing Notes

1. Start call A.
2. Receive and accept incoming call B.
3. Hang up call B immediately during the replacement flow.
4. Verify the app returns to idle/home state.
5. Verify call A is also left and local media is no longer transmitting.
6. Verify no stale active-call state remains in the UI.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where previous active calls were not properly cleaned up during certain transition scenarios, preventing stale call references from persisting.

* **Tests**
  * Added test coverage for call state transitions to verify proper cleanup across different call scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->