### PR TITLE
[Fix]Audio-room permission revoke toggle hang

### DIFF
--- a/Sources/StreamVideo/CallSettings/CallSettingsManager.swift
+++ b/Sources/StreamVideo/CallSettings/CallSettingsManager.swift
@@ -28,11 +28,16 @@ extension CallSettingsManager {
             return
         }
         await self.state.setUpdatingState(state)
-        try await action(state)
-        await MainActor.run {
-            onUpdate(state)
+        do {
+            try await action(state)
+            await MainActor.run {
+                onUpdate(state)
+            }
+            await self.state.setUpdatingState(nil)
+        } catch {
+            await self.state.setUpdatingState(nil)
+            throw error
         }
-        await self.state.setUpdatingState(nil)
     }
 }
 

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -190,7 +190,7 @@ class CallController: @unchecked Sendable {
         function: StaticString = #function,
         line: UInt = #line
     ) async throws {
-        await webRTCCoordinator.changeAudioState(
+        try await webRTCCoordinator.changeAudioState(
             isEnabled: isEnabled,
             file: file,
             function: function,
@@ -201,7 +201,7 @@ class CallController: @unchecked Sendable {
     /// Changes the video state for the current user.
     /// - Parameter isEnabled: whether video should be enabled.
     func changeVideoState(isEnabled: Bool) async throws {
-        await webRTCCoordinator.changeVideoState(isEnabled: isEnabled)
+        try await webRTCCoordinator.changeVideoState(isEnabled: isEnabled)
     }
 
     /// Changes the availability of sound during the call.

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -169,9 +169,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
         file: StaticString = #file,
         function: StaticString = #function,
         line: UInt = #line
-    ) async {
-        await stateAdapter
-            .enqueueCallSettings(
+    ) async throws {
+        try await stateAdapter
+            .updateCallSettings(
                 functionName: function,
                 fileName: file,
                 lineNumber: line
@@ -188,9 +188,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
     /// Changes the video state (enabled/disabled) for the call.
     ///
     /// - Parameter isEnabled: Whether the video should be enabled.
-    func changeVideoState(isEnabled: Bool) async {
-        await stateAdapter
-            .enqueueCallSettings { $0.withUpdatedVideoState(isEnabled) }
+    func changeVideoState(isEnabled: Bool) async throws {
+        try await stateAdapter
+            .updateCallSettings { $0.withUpdatedVideoState(isEnabled) }
     }
 
     /// Changes the audio output state (e.g., speaker or headphones).

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -579,63 +579,36 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
                 return
             }
 
-            let currentCallSettings = await callSettings
-            let newCallSettings = operation(currentCallSettings)
-            let updatedCallSettings = await permissionsAdapter
-                .willSet(callSettings: newCallSettings)
-
-            guard
-                updatedCallSettings != currentCallSettings
-            else {
-                return
-            }
-
-            /// Prevents local media from being enabled when the user has already
-            /// lost the relevant permissions. This keeps actor state aligned with
-            /// server-side capabilities for audio-room moderation flows.
-            let ownCapabilities = await self.ownCapabilities
-            guard
-                ownCapabilities.allows(callSettings: updatedCallSettings)
-            else {
-                log.warning(
-                    "Unable to update callSettings:\(updatedCallSettings) due to missing capabilities:\(ownCapabilities)",
-                    subsystems: .webRTC,
-                    functionName: functionName,
-                    fileName: fileName,
-                    lineNumber: lineNumber
-                )
-                return
-            }
-
-            await set(callSettings: updatedCallSettings)
-            log.debug(
-                "CallSettings updated \(currentCallSettings) -> \(updatedCallSettings)",
-                subsystems: .webRTC,
+            try await self.processCallSettingsUpdate(
                 functionName: functionName,
                 fileName: fileName,
-                lineNumber: lineNumber
+                lineNumber: lineNumber,
+                throwsOnMissingCapabilities: false,
+                operation
             )
+        }
+    }
 
+    func updateCallSettings(
+        functionName: StaticString = #function,
+        fileName: StaticString = #fileID,
+        lineNumber: UInt = #line,
+        _ operation: @Sendable @escaping (CallSettings) -> CallSettings
+    ) async throws {
+        try await callSettingsProcessingQueue.addSynchronousTaskOperation {
+            [weak self] in
             guard
-                let publisher = await self.publisher
+                let self
             else {
                 return
             }
 
-            try await publisher.didUpdateCallSettings(updatedCallSettings)
-
-            if updatedCallSettings.cameraPosition != currentCallSettings.cameraPosition {
-                try await publisher.didUpdateCameraPosition(
-                    updatedCallSettings.cameraPosition == .back ? .back : .front
-                )
-            }
-
-            log.debug(
-                "Publisher callSettings updated: \(updatedCallSettings).",
-                subsystems: .webRTC,
+            try await self.processCallSettingsUpdate(
                 functionName: functionName,
                 fileName: fileName,
-                lineNumber: lineNumber
+                lineNumber: lineNumber,
+                throwsOnMissingCapabilities: true,
+                operation
             )
         }
     }
@@ -684,6 +657,73 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
                 log.error(error, subsystems: .webRTC)
             }
         }
+    }
+
+    private func processCallSettingsUpdate(
+        functionName: StaticString,
+        fileName: StaticString,
+        lineNumber: UInt,
+        throwsOnMissingCapabilities: Bool,
+        _ operation: @Sendable @escaping (CallSettings) -> CallSettings
+    ) async throws {
+        let currentCallSettings = callSettings
+        let newCallSettings = operation(currentCallSettings)
+        let updatedCallSettings = await permissionsAdapter
+            .willSet(callSettings: newCallSettings)
+
+        guard
+            updatedCallSettings != currentCallSettings
+        else {
+            return
+        }
+
+        let ownCapabilities = ownCapabilities
+        guard
+            ownCapabilities.allows(callSettings: updatedCallSettings)
+        else {
+            log.warning(
+                "Unable to update callSettings:\(updatedCallSettings) due to missing capabilities:\(ownCapabilities)",
+                subsystems: .webRTC,
+                functionName: functionName,
+                fileName: fileName,
+                lineNumber: lineNumber
+            )
+            if throwsOnMissingCapabilities {
+                throw ClientError.MissingPermissions()
+            }
+            return
+        }
+
+        set(callSettings: updatedCallSettings)
+        log.debug(
+            "CallSettings updated \(currentCallSettings) -> \(updatedCallSettings)",
+            subsystems: .webRTC,
+            functionName: functionName,
+            fileName: fileName,
+            lineNumber: lineNumber
+        )
+
+        guard
+            let publisher
+        else {
+            return
+        }
+
+        try await publisher.didUpdateCallSettings(updatedCallSettings)
+
+        if updatedCallSettings.cameraPosition != currentCallSettings.cameraPosition {
+            try await publisher.didUpdateCameraPosition(
+                updatedCallSettings.cameraPosition == .back ? .back : .front
+            )
+        }
+
+        log.debug(
+            "Publisher callSettings updated: \(updatedCallSettings).",
+            subsystems: .webRTC,
+            functionName: functionName,
+            fileName: fileName,
+            lineNumber: lineNumber
+        )
     }
 
     func trace(_ trace: WebRTCTrace) {

--- a/StreamVideoTests/CallSettings/MicrophoneManager_Tests.swift
+++ b/StreamVideoTests/CallSettings/MicrophoneManager_Tests.swift
@@ -63,6 +63,30 @@ final class MicrophoneManager_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(callController.timesCalled(.changeAudioState), 0)
     }
 
+    func test_initialStatusDisabled_enable_whenControllerThrows_clearsUpdatingState() async throws {
+        let callController = MockCallController()
+        callController.stub(for: .changeAudioState, with: ClientError.MissingPermissions())
+        let subject = MicrophoneManager(
+            callController: callController,
+            initialStatus: .disabled
+        )
+
+        do {
+            try await subject.enable()
+            XCTFail("enable should fail when controller throws")
+        } catch {
+            XCTAssertTrue(error is ClientError.MissingPermissions)
+        }
+        do {
+            try await subject.enable()
+            XCTFail("enable should fail when controller throws")
+        } catch {
+            XCTAssertTrue(error is ClientError.MissingPermissions)
+        }
+
+        XCTAssertEqual(callController.timesCalled(.changeAudioState), 2)
+    }
+
     // MARK: - disable
 
     func test_initialStatusEnabled_disable_statusDoesNotChangeUntilCallSettingsUpdate() async throws {

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -825,7 +825,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.audioOn == false }
-                    .perform { try await $0.call.microphone.toggle() }
+                    .performWithErrorExpectation { try await $0.call.microphone.toggle() }
+                    .assert { $0.value is ClientError.MissingPermissions }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.audioOn == false }
             }
@@ -908,7 +909,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                     .assertEventuallyInMainActor { $0.call.state.callSettings.audioOn == false }
                     .perform { try await $0.call.request(permissions: [.sendAudio]) }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
-                    .perform { try await $0.call.microphone.toggle() }
+                    .performWithErrorExpectation { try await $0.call.microphone.toggle() }
+                    .assert { $0.value is ClientError.MissingPermissions }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.audioOn == false }
             }
@@ -959,7 +961,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                     .assertEventuallyInMainActor { $0.call.state.callSettings.audioOn == false }
                     .performWithoutValueOverride { $0.call.updateCallSettingsManagers(with: await $0.call.state.callSettings) }
                     .assertEventuallyInMainActor { $0.call.microphone.status == .disabled }
-                    .perform { try await $0.call.microphone.toggle() }
+                    .performWithErrorExpectation { try await $0.call.microphone.toggle() }
+                    .assert { $0.value is ClientError.MissingPermissions }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.audioOn == false }
             }
@@ -997,8 +1000,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendVideo) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.videoOn == false }
-                    .perform { try await $0.call.camera.toggle() }
-                    .delay(0.5)
+                    .performWithErrorExpectation { try await $0.call.camera.toggle() }
+                    .assert { $0.value is ClientError.MissingPermissions }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.videoOn == false }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendVideo) == false }
             }

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -180,6 +180,9 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
     override func changeVideoState(isEnabled: Bool) async throws {
         stubbedFunctionInput[.changeVideoState]?
             .append(.changeVideoState(isEnabled))
+        if let error = stubbedFunction[.changeVideoState] as? Error {
+            throw error
+        }
     }
 
     override func changeAudioState(
@@ -190,6 +193,9 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
     ) async throws {
         stubbedFunctionInput[.changeAudioState]?
             .append(.changeAudioState(isEnabled))
+        if let error = stubbedFunction[.changeAudioState] as? Error {
+            throw error
+        }
     }
 
     override func changeCameraMode(position: CameraPosition) async throws {

--- a/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCCoorindator_Tests.swift
@@ -276,11 +276,41 @@ final class WebRTCCoordinator_Tests: XCTestCase, @unchecked Sendable {
 
     func test_changeAudioState_shouldUpdateAudioState() async throws {
         await subject.stateAdapter.enqueueOwnCapabilities { [.sendAudio, .sendVideo] }
-        await subject.changeAudioState(isEnabled: false)
+        try await subject.changeAudioState(isEnabled: false)
 
         await fulfillment {
             let currentValue = await self.subject.stateAdapter.callSettings.audioOn
             return currentValue == false
+        }
+    }
+
+    func test_changeAudioState_withoutSendAudioCapability_throwsMissingPermissions() async throws {
+        callSettings = .init(audioOn: false)
+        let mockPermissions = MockPermissionsStore()
+        defer { mockPermissions.dismantle() }
+        mockPermissions.stubMicrophonePermission(.granted)
+        await subject.stateAdapter.enqueueOwnCapabilities { [] }
+
+        do {
+            try await subject.changeAudioState(isEnabled: true)
+            XCTFail("changeAudioState should fail without send-audio capability")
+        } catch {
+            XCTAssertTrue(error is ClientError.MissingPermissions)
+        }
+    }
+
+    func test_changeVideoState_withoutSendVideoCapability_throwsMissingPermissions() async throws {
+        callSettings = .init(audioOn: false, videoOn: false)
+        let mockPermissions = MockPermissionsStore()
+        defer { mockPermissions.dismantle() }
+        mockPermissions.stubCameraPermission(.granted)
+        await subject.stateAdapter.enqueueOwnCapabilities { [] }
+
+        do {
+            try await subject.changeVideoState(isEnabled: true)
+            XCTFail("changeVideoState should fail without send-video capability")
+        } catch {
+            XCTAssertTrue(error is ClientError.MissingPermissions)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix a cron check failure where an audio-room integration test could hang after a host revoked a participant's speak permission.

### 📝 Summary

- Make mic/camera enable requests fail fast with `ClientError.MissingPermissions` when own capabilities do not allow publishing.
- Keep fire-and-forget call settings updates unchanged for capability-driven moderation updates.
- Update audio-room integration tests to expect missing-permission failures instead of waiting on rejected toggles.
- Add focused unit coverage for missing-capability media toggles and updating-state cleanup after thrown errors.

### 🛠 Implementation

Added an awaited call-settings update path in `WebRTCStateAdapter` for user-initiated mic/camera changes. This path reuses the existing permissions/capabilities validation, but throws `ClientError.MissingPermissions` when enabling media is rejected by current own capabilities.

`CallSettingsManager` now clears its in-flight updating state when the controller action throws, so a failed enable does not block future attempts.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

#### Audio Room: Revoke Speak Permission

1. Create/join an audio room as host.
2. Join same room as participant with mic off.
3. Participant requests speak permission.
4. Host grants request.
5. Participant enables microphone.
6. Host revokes participant's speak permission.
7. Verify participant microphone turns off.
8. Verify participant cannot enable microphone again.
9. Verify app does not hang/spin, and mic UI stays disabled/off.

#### Audio Room: Request Rejected

1. Create/join an audio room as host.
2. Join same room as participant with mic off.
3. Participant requests speak permission.
4. Host rejects request.
5. Participant taps microphone toggle.
6. Verify microphone remains off.
7. Verify app stays responsive and no loading state gets stuck.

#### Audio Room: No Speak Permission

1. Create/join audio room as participant without speak permission.
2. Tap microphone toggle.
3. Verify microphone remains off.
4. Verify expected permission/error UI appears if product has one.
5. Repeat tap.
6. Verify second attempt also returns quickly and UI does not get stuck.

#### Video Permission Guard

1. Join audio room or call type where participant lacks send-video capability.
2. Tap camera toggle.
3. Verify camera remains off.
4. Verify UI stays responsive and no spinner/loading state remains active.

#### Regression: Happy Path Still Works

1. Join a call/audio room where user has send-audio capability.
2. Toggle microphone on.
3. Verify local mic turns on and remote participant sees/hears audio.
4. Toggle microphone off.
5. Verify local mic turns off and remote participant sees muted state.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)