### PR TITLE
Ingress participants sort priority

### DIFF
--- a/Sources/StreamVideo/Utils/Sorting/Participants.swift
+++ b/Sources/StreamVideo/Utils/Sorting/Participants.swift
@@ -115,4 +115,5 @@ public nonisolated func withParticipantSources(_ sources: [ParticipantSource]) -
 
 /// A comparator that surfaces video-ingest participants (RTMP, SRT, WHIP, RTSP)
 /// ahead of regular WebRTC participants, in that priority order.
-public nonisolated(unsafe) let videoIngressSource: StreamSortComparator<CallParticipant> = withParticipantSources([.rtmp, .srt, .whip, .rtsp])
+public nonisolated(unsafe) let videoIngressSource: StreamSortComparator<CallParticipant> =
+    withParticipantSources([.rtmp, .srt, .whip, .rtsp])

--- a/Sources/StreamVideo/Utils/Sorting/Participants.swift
+++ b/Sources/StreamVideo/Utils/Sorting/Participants.swift
@@ -99,3 +99,20 @@ public nonisolated func participantSource(_ source: ParticipantSource) -> Stream
         return .orderedSame
     }
 }
+
+/// A comparator creator that ranks participants by their source priority.
+/// Sources listed earlier take precedence; participants with unlisted sources
+/// are ranked last.
+public nonisolated func withParticipantSources(_ sources: [ParticipantSource]) -> StreamSortComparator<CallParticipant> {
+    { a, b in
+        let priorityA = sources.firstIndex(of: a.source) ?? Int.max
+        let priorityB = sources.firstIndex(of: b.source) ?? Int.max
+        if priorityA < priorityB { return .orderedAscending }
+        if priorityA > priorityB { return .orderedDescending }
+        return .orderedSame
+    }
+}
+
+/// A comparator that surfaces video-ingest participants (RTMP, SRT, WHIP, RTSP)
+/// ahead of regular WebRTC participants, in that priority order.
+public nonisolated(unsafe) let videoIngressSource: StreamSortComparator<CallParticipant> = withParticipantSources([.rtmp, .srt, .whip, .rtsp])

--- a/Sources/StreamVideo/Utils/Sorting/Presets.swift
+++ b/Sources/StreamVideo/Utils/Sorting/Presets.swift
@@ -40,6 +40,7 @@ public nonisolated(unsafe) let speakerLayoutSortPreset = [
         combineComparators(
             [
                 speaking,
+                videoIngressSource,
                 publishingVideo,
                 publishingAudio
             ]
@@ -58,6 +59,7 @@ public nonisolated(unsafe) let paginatedLayoutSortPreset = [
             [
                 dominantSpeaker,
                 speaking,
+                videoIngressSource,
                 publishingVideo,
                 publishingAudio
             ]
@@ -73,7 +75,7 @@ public nonisolated(unsafe) let livestreamOrAudioRoomSortPreset = [
             [
                 dominantSpeaker,
                 speaking,
-                participantSource(.rtmp),
+                videoIngressSource,
                 publishingVideo,
                 publishingAudio
             ]

--- a/StreamVideoTests/Utils/Sorting_Tests.swift
+++ b/StreamVideoTests/Utils/Sorting_Tests.swift
@@ -818,6 +818,319 @@ final class Sorting_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    // MARK: - withParticipantSources
+
+    func test_withParticipantSources_firstSourceHasHighestPriority() {
+        let subject = withParticipantSources([.rtmp, .srt, .whip])
+
+        assertSort(
+            [
+                .dummy(source: .srt),
+                .dummy(source: .rtmp)
+            ],
+            comparator: subject,
+            expectedTransformer: { [$0[1], $0[0]] } // rtmp (index 0) beats srt (index 1).
+        )
+    }
+
+    func test_withParticipantSources_laterSourceHasLowerPriority() {
+        let subject = withParticipantSources([.rtmp, .srt, .whip])
+
+        assertSort(
+            [
+                .dummy(source: .whip),
+                .dummy(source: .srt)
+            ],
+            comparator: subject,
+            expectedTransformer: { [$0[1], $0[0]] } // srt (index 1) beats whip (index 2).
+        )
+    }
+
+    func test_withParticipantSources_unlistedSourceRanksLast() {
+        let subject = withParticipantSources([.rtmp, .srt])
+
+        assertSort(
+            [
+                .dummy(source: .webRTCUnspecified),
+                .dummy(source: .srt)
+            ],
+            comparator: subject,
+            expectedTransformer: { [$0[1], $0[0]] } // srt (listed) beats webRTCUnspecified (unlisted).
+        )
+    }
+
+    func test_withParticipantSources_bothUnlisted_orderedSame() {
+        let subject = withParticipantSources([.rtmp])
+
+        assertSort(
+            [
+                .dummy(source: .webRTCUnspecified),
+                .dummy(source: .sip)
+            ],
+            comparator: subject,
+            expectedTransformer: { [$0[0], $0[1]] } // Both unlisted — order unchanged.
+        )
+    }
+
+    func test_withParticipantSources_sameSource_orderedSame() {
+        let subject = withParticipantSources([.rtmp, .srt])
+
+        assertSort(
+            [
+                .dummy(source: .srt),
+                .dummy(source: .srt)
+            ],
+            comparator: subject,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    func test_withParticipantSources_emptySourceList_allUnlisted() {
+        let subject = withParticipantSources([])
+
+        assertSort(
+            [
+                .dummy(source: .rtmp),
+                .dummy(source: .srt)
+            ],
+            comparator: subject,
+            expectedTransformer: { [$0[0], $0[1]] } // All unlisted — order unchanged.
+        )
+    }
+
+    // MARK: - videoIngressSource
+
+    func test_videoIngressSource_rtmpBeforeSrt() {
+        assertSort(
+            [
+                .dummy(source: .srt),
+                .dummy(source: .rtmp)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[1], $0[0]] } // rtmp has higher priority than srt.
+        )
+    }
+
+    func test_videoIngressSource_srtBeforeWhip() {
+        assertSort(
+            [
+                .dummy(source: .whip),
+                .dummy(source: .srt)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[1], $0[0]] } // srt has higher priority than whip.
+        )
+    }
+
+    func test_videoIngressSource_whipBeforeRtsp() {
+        assertSort(
+            [
+                .dummy(source: .rtsp),
+                .dummy(source: .whip)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[1], $0[0]] } // whip has higher priority than rtsp.
+        )
+    }
+
+    func test_videoIngressSource_anyIngressBeforeWebRTC() {
+        assertSort(
+            [
+                .dummy(source: .webRTCUnspecified),
+                .dummy(source: .rtsp)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[1], $0[0]] } // rtsp (ingress) ranks above webRTCUnspecified.
+        )
+    }
+
+    func test_videoIngressSource_allFourIngressTypes() {
+        assertSort(
+            [
+                .dummy(source: .rtsp),
+                .dummy(source: .whip),
+                .dummy(source: .srt),
+                .dummy(source: .rtmp)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[3], $0[2], $0[1], $0[0]] } // rtmp, srt, whip, rtsp.
+        )
+    }
+
+    func test_videoIngressSource_sipIsNotIngress() {
+        assertSort(
+            [
+                .dummy(source: .sip),
+                .dummy(source: .rtmp)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[1], $0[0]] } // rtmp (ingress) ranks above sip (not in list).
+        )
+    }
+
+    func test_videoIngressSource_sameSource_orderedSame() {
+        assertSort(
+            [
+                .dummy(source: .rtmp),
+                .dummy(source: .rtmp)
+            ],
+            comparator: videoIngressSource,
+            expectedTransformer: { [$0[0], $0[1]] }
+        )
+    }
+
+    // MARK: - speakerLayoutSortPreset with ingress
+
+    func test_speakerLayoutSortPreset_ingressParticipantBeforeWebRTC_whenInvisible() {
+        let combined = combineComparators(speakerLayoutSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .webRTCUnspecified),
+                .dummy(showTrack: false, source: .rtmp)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] } // RTMP ingress ranks above plain WebRTC.
+        )
+    }
+
+    func test_speakerLayoutSortPreset_speakingStillBeforeIngress_whenInvisible() {
+        let combined = combineComparators(speakerLayoutSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, isSpeaking: false, source: .rtmp),
+                .dummy(showTrack: false, isSpeaking: true, source: .webRTCUnspecified)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] } // Speaking WebRTC participant still beats silent RTMP.
+        )
+    }
+
+    func test_speakerLayoutSortPreset_multipleIngressTypes_whenInvisible() {
+        let combined = combineComparators(speakerLayoutSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .whip),
+                .dummy(showTrack: false, source: .rtmp),
+                .dummy(showTrack: false, source: .webRTCUnspecified)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0], $0[2]] } // rtmp, whip, webRTCUnspecified.
+        )
+    }
+
+    // MARK: - paginatedLayoutSortPreset with ingress
+
+    func test_paginatedLayoutSortPreset_ingressParticipantBeforeWebRTC_whenInvisible() {
+        let combined = combineComparators(paginatedLayoutSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .webRTCUnspecified),
+                .dummy(showTrack: false, source: .srt)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] } // SRT ingress ranks above plain WebRTC.
+        )
+    }
+
+    func test_paginatedLayoutSortPreset_dominantSpeakerBeforeIngress_whenInvisible() {
+        let combined = combineComparators(paginatedLayoutSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, isDominantSpeaker: false, source: .rtmp),
+                .dummy(showTrack: false, isDominantSpeaker: true, source: .webRTCUnspecified)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] } // Dominant speaker beats ingress.
+        )
+    }
+
+    func test_paginatedLayoutSortPreset_ingressBeforeVideoPublisher_whenInvisible() {
+        let combined = combineComparators(paginatedLayoutSortPreset)
+
+        assertSort(
+            [
+                .dummy(hasVideo: true, showTrack: false, source: .webRTCUnspecified),
+                .dummy(hasVideo: false, showTrack: false, source: .rtmp)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] } // RTMP ingress ranks above video-publishing WebRTC.
+        )
+    }
+
+    // MARK: - livestreamOrAudioRoomSortPreset with ingress
+
+    func test_livestreamOrAudioRoomSortPreset_rtmpIngressBeforeWebRTC_whenInvisible() {
+        let combined = combineComparators(livestreamOrAudioRoomSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .webRTCUnspecified),
+                .dummy(showTrack: false, source: .rtmp)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    func test_livestreamOrAudioRoomSortPreset_srtIngressBeforeWebRTC_whenInvisible() {
+        let combined = combineComparators(livestreamOrAudioRoomSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .webRTCUnspecified),
+                .dummy(showTrack: false, source: .srt)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] } // SRT also prioritized (was previously only RTMP).
+        )
+    }
+
+    func test_livestreamOrAudioRoomSortPreset_whipIngressBeforeWebRTC_whenInvisible() {
+        let combined = combineComparators(livestreamOrAudioRoomSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .webRTCUnspecified),
+                .dummy(showTrack: false, source: .whip)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    func test_livestreamOrAudioRoomSortPreset_rtspIngressBeforeWebRTC_whenInvisible() {
+        let combined = combineComparators(livestreamOrAudioRoomSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .webRTCUnspecified),
+                .dummy(showTrack: false, source: .rtsp)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    func test_livestreamOrAudioRoomSortPreset_ingressPriorityOrder_whenInvisible() {
+        let combined = combineComparators(livestreamOrAudioRoomSortPreset)
+
+        assertSort(
+            [
+                .dummy(showTrack: false, source: .rtsp),
+                .dummy(showTrack: false, source: .srt),
+                .dummy(showTrack: false, source: .rtmp),
+                .dummy(showTrack: false, source: .whip)
+            ],
+            comparator: combined,
+            expectedTransformer: { [$0[2], $0[1], $0[3], $0[0]] } // rtmp, srt, whip, rtsp.
+        )
+    }
+
     // MARK: - Private Helpers
 
     private func assertSort(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1708/ingress-participant-prioritization.

### 🎯 Goal

Give ingress participants priority in the sorting.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Participant ordering now prioritizes video ingress sources (RTMP, SRT, WHIP, RTSP) across speaker, paginated, and livestream layouts.
  * New option to define custom source-priority ordering for participant sorting.

* **Tests**
  * Added coverage for source-priority sorting and its interaction with visibility, speaking, and dominant-speaker ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-swift/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->