### PR TITLE
Iliaspavlidakis/ios 1718 fixtracing event names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ buildServer.json
 !.codex/environments/environment.toml
 !.codex/scripts/
 !.codex/scripts/*.sh
+.codegraph
+.cursor

--- a/Sources/StreamVideo/WebRTC/v2/SFU/Extensions/SFUAdapter+Events.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/Extensions/SFUAdapter+Events.swift
@@ -9,7 +9,7 @@ extension SFUAdapter {
     /// Indicates that an SFUAdapter was created for a given host.
     struct CreateEvent: SFUAdapterEvent, Equatable {
         var hostname: String
-        var traceTag: String { "create" }
+        var traceTag: String { "sfu.create" }
         var traceData: AnyEncodable? { .init(["url": hostname]) }
     }
 

--- a/Sources/StreamVideo/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter.swift
@@ -71,10 +71,9 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     /// The peer connection coordinator for the publishing peer connection.
     ///
     /// Assigning a different coordinator instance rebinds tracing for the
-    /// publisher role and emits a synthetic `create` trace for that new
-    /// peer connection. Reassigning the same instance is ignored so reconnect
-    /// flows do not emit duplicate synthetic `create` traces. Setting this to
-    /// `nil` removes the current publisher subscription.
+    /// publisher role. Reassigning the same instance is ignored so reconnect
+    /// bookkeeping does not attach duplicate event subscriptions. Setting this
+    /// to `nil` removes the current publisher subscription.
     var publisher: RTCPeerConnectionCoordinator? {
         didSet { didUpdate(publisher: publisher, oldValue: oldValue) }
     }
@@ -82,10 +81,9 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     /// The peer connection coordinator for the subscribing peer connection.
     ///
     /// Assigning a different coordinator instance rebinds tracing for the
-    /// subscriber role and emits a synthetic `create` trace for that new
-    /// peer connection. Reassigning the same instance is ignored so reconnect
-    /// flows do not emit duplicate synthetic `create` traces. Setting this to
-    /// `nil` removes the current subscriber subscription.
+    /// subscriber role. Reassigning the same instance is ignored so reconnect
+    /// bookkeeping does not attach duplicate event subscriptions. Setting this
+    /// to `nil` removes the current subscriber subscription.
     var subscriber: RTCPeerConnectionCoordinator? {
         didSet { didUpdate(subscriber: subscriber, oldValue: oldValue) }
     }
@@ -282,8 +280,8 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     /// Rebinds publisher tracing when the coordinator instance changes.
     ///
     /// Reassigning the same coordinator instance is ignored so reconnect
-    /// bookkeeping does not emit duplicate synthetic `create` traces. Setting
-    /// the coordinator to `nil` removes the active publisher subscription.
+    /// bookkeeping does not attach duplicate event subscriptions. Setting the
+    /// coordinator to `nil` removes the active publisher subscription.
     private func didUpdate(
         publisher: RTCPeerConnectionCoordinator?,
         oldValue: RTCPeerConnectionCoordinator?
@@ -310,8 +308,8 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     /// Rebinds subscriber tracing when the coordinator instance changes.
     ///
     /// Reassigning the same coordinator instance is ignored so reconnect
-    /// bookkeeping does not emit duplicate synthetic `create` traces. Setting
-    /// the coordinator to `nil` removes the active subscriber subscription.
+    /// bookkeeping does not attach duplicate event subscriptions. Setting the
+    /// coordinator to `nil` removes the active subscriber subscription.
     private func didUpdate(
         subscriber: RTCPeerConnectionCoordinator?,
         oldValue: RTCPeerConnectionCoordinator?

--- a/Sources/StreamVideo/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter.swift
@@ -66,7 +66,7 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     ///
     /// Updating this property will reset trace and stats collection, flush previous
     /// data, and re-attach Combine publishers to new event streams.
-    var sfuAdapter: SFUAdapter? { didSet { didUpdate(sfuAdapter) } }
+    var sfuAdapter: SFUAdapter? { didSet { didUpdate(sfuAdapter, oldValue: oldValue) } }
 
     /// The peer connection coordinator for the publishing peer connection.
     ///
@@ -239,8 +239,8 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
     ///
     /// Attaches new Combine subscriptions to event streams, flushes previous buckets,
     /// and emits an SFU "created" event as the first trace for the new adapter.
-    private func didUpdate(_ sfuAdapter: SFUAdapter?) {
-        guard let sfuAdapter else {
+    private func didUpdate(_ sfuAdapter: SFUAdapter?, oldValue: SFUAdapter?) {
+        guard let sfuAdapter, sfuAdapter !== oldValue else {
             return
         }
 
@@ -305,16 +305,6 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
             .log(.debug, subsystems: .webRTC) { "Trace tag:\($0.tag) create for id:\($0.id) at timestamp:\($0.timestamp)." }
             .sink { [weak self] in self?.peerConnectionBucket.append($0) }
             .store(in: disposableBag, key: DisposableKey.publisher.rawValue)
-
-        peerConnectionBucket.append(
-            .init(
-                peerType: .publisher,
-                event: StreamRTCPeerConnection.CreatedEvent(
-                    configuration: peerConnection.configuration,
-                    hostname: sfuAdapter?.host ?? ""
-                )
-            )
-        )
     }
 
     /// Rebinds subscriber tracing when the coordinator instance changes.
@@ -343,15 +333,5 @@ final class WebRTCTracesAdapter: WebRTCTracing, @unchecked Sendable {
             .log(.debug, subsystems: .webRTC) { "Trace tag:\($0.tag) create for id:\($0.id) at timestamp:\($0.timestamp)." }
             .sink { [weak self] in self?.peerConnectionBucket.append($0) }
             .store(in: disposableBag, key: DisposableKey.subscriber.rawValue)
-
-        peerConnectionBucket.append(
-            .init(
-                peerType: .subscriber,
-                event: StreamRTCPeerConnection.CreatedEvent(
-                    configuration: peerConnection.configuration,
-                    hostname: sfuAdapter?.host ?? ""
-                )
-            )
-        )
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -343,6 +343,16 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
             audioDeviceModule: peerConnectionFactory.audioDeviceModule
         )
 
+        trace(
+            .init(
+                peerType: .publisher,
+                event: StreamRTCPeerConnection.CreatedEvent(
+                    configuration: connectOptions.rtcConfiguration,
+                    hostname: sfuAdapter.host
+                )
+            )
+        )
+
         let subscriber = rtcPeerConnectionCoordinatorFactory.buildCoordinator(
             sessionId: sessionID,
             peerType: .subscriber,
@@ -361,6 +371,16 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
             screenShareSessionProvider: screenShareSessionProvider,
             clientCapabilities: clientCapabilities,
             audioDeviceModule: peerConnectionFactory.audioDeviceModule
+        )
+
+        trace(
+            .init(
+                peerType: .subscriber,
+                event: StreamRTCPeerConnection.CreatedEvent(
+                    configuration: connectOptions.rtcConfiguration,
+                    hostname: sfuAdapter.host
+                )
+            )
         )
 
         publisher

--- a/StreamVideoTests/WebRTC/SFU/Extensions/SFUAdapterEvent_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/Extensions/SFUAdapterEvent_Tests.swift
@@ -9,7 +9,7 @@ final class SFUAdapterEvent_Tests: XCTestCase, @unchecked Sendable {
 
     func test_CreateEvent() {
         let event = SFUAdapter.CreateEvent(hostname: "example.com")
-        XCTAssertEqual(event.traceTag, "create")
+        XCTAssertEqual(event.traceTag, "sfu.create")
         XCTAssertEqual(event.traceData?.value as? [String: String], ["url": "example.com"])
     }
 

--- a/StreamVideoTests/WebRTC/v2/Stats/Models/WebRTCTrace_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/Stats/Models/WebRTCTrace_Tests.swift
@@ -37,7 +37,7 @@ final class WebRTCTrace_Tests: XCTestCase, @unchecked Sendable {
         let trace = WebRTCTrace(event: event)
 
         XCTAssertEqual(trace.id, "sfu")
-        XCTAssertEqual(trace.tag, "create")
+        XCTAssertEqual(trace.tag, "sfu.create")
         XCTAssertEqual((trace.data?.value as? [String: String])?["url"], event.hostname)
     }
 

--- a/StreamVideoTests/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/Stats/Traces/WebRTCTracesAdapter_Tests.swift
@@ -87,40 +87,73 @@ final class WebRTCTracesAdapter_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(idx1 < idx3 && idx2 < idx3)
     }
 
-    func test_publisher_whenSameCoordinatorIsReassigned_doesNotEmitDuplicateCreateTrace_() throws {
+    func test_sfuAdapter_whenSameInstanceIsReassigned_doesNotEmitDuplicateCreateTrace_() throws {
+        let sfuStack = MockSFUStack()
+
+        subject.sfuAdapter = sfuStack.adapter
+
+        XCTAssertEqual(sfuCreateTraces(in: subject.flushTraces()).count, 1)
+
+        subject.sfuAdapter = sfuStack.adapter
+
+        XCTAssertTrue(sfuCreateTraces(in: subject.flushTraces()).isEmpty)
+    }
+
+    func test_sfuAdapter_whenInstanceChanges_emitsCreateTraceForReplacement_() throws {
+        let first = MockSFUStack()
+        let second = MockSFUStack()
+
+        subject.sfuAdapter = first.adapter
+        _ = subject.flushTraces()
+
+        subject.sfuAdapter = second.adapter
+
+        let createTraces = sfuCreateTraces(in: subject.flushTraces())
+        XCTAssertEqual(createTraces.count, 1)
+        XCTAssertEqual(
+            (createTraces.first?.data?.value as? [String: String])?["url"],
+            second.adapter.host
+        )
+    }
+
+    func test_publisher_whenSameCoordinatorIsReassigned_doesNotAttachDuplicateSubscriptions_() throws {
         let coordinator = try makeCoordinator(peerType: .publisher)
 
         subject.publisher = coordinator
-
-        XCTAssertEqual(createTraces(for: "publisher", in: subject.flushTraces()).count, 1)
+        coordinator.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
+        XCTAssertEqual(closeTraces(for: "publisher", in: subject.flushTraces()).count, 1)
 
         subject.publisher = coordinator
+        coordinator.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
 
-        XCTAssertTrue(createTraces(for: "publisher", in: subject.flushTraces()).isEmpty)
+        XCTAssertEqual(closeTraces(for: "publisher", in: subject.flushTraces()).count, 1)
     }
 
-    func test_subscriber_whenSameCoordinatorIsReassigned_doesNotEmitDuplicateCreateTrace_() throws {
+    func test_subscriber_whenSameCoordinatorIsReassigned_doesNotAttachDuplicateSubscriptions_() throws {
         let coordinator = try makeCoordinator(peerType: .subscriber)
 
         subject.subscriber = coordinator
-
-        XCTAssertEqual(createTraces(for: "subscriber", in: subject.flushTraces()).count, 1)
+        coordinator.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
+        XCTAssertEqual(closeTraces(for: "subscriber", in: subject.flushTraces()).count, 1)
 
         subject.subscriber = coordinator
+        coordinator.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
 
-        XCTAssertTrue(createTraces(for: "subscriber", in: subject.flushTraces()).isEmpty)
+        XCTAssertEqual(closeTraces(for: "subscriber", in: subject.flushTraces()).count, 1)
     }
 
-    func test_publisher_whenCoordinatorChanges_emitsCreateTraceForReplacement_() throws {
+    func test_publisher_whenCoordinatorChanges_rebindsToReplacementEvents_() throws {
         let first = try makeCoordinator(peerType: .publisher)
         let second = try makeCoordinator(peerType: .publisher)
 
         subject.publisher = first
+        first.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
         _ = subject.flushTraces()
 
         subject.publisher = second
+        second.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
 
-        XCTAssertEqual(createTraces(for: "publisher", in: subject.flushTraces()).count, 1)
+        XCTAssertEqual(closeTraces(for: "publisher", in: subject.flushTraces()).count, 1)
     }
 
     func test_subscriber_whenCleared_stopsObservingEventsFromPreviousCoordinator_() throws {
@@ -153,10 +186,14 @@ final class WebRTCTracesAdapter_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
-    private func createTraces(
+    private func sfuCreateTraces(in traces: [WebRTCTrace]) -> [WebRTCTrace] {
+        traces.filter { $0.id == "sfu" && $0.tag == "sfu.create" }
+    }
+
+    private func closeTraces(
         for id: String,
         in traces: [WebRTCTrace]
     ) -> [WebRTCTrace] {
-        traces.filter { $0.id == id && $0.tag == "create" }
+        traces.filter { $0.id == id && $0.tag == "close" }
     }
 }

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -540,6 +540,31 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    func test_configurePeerConnections_shouldTracePeerConnectionCreateEvents() async throws {
+        let mockStatsAdapter = MockWebRTCStatsAdapter()
+        await subject.set(statsAdapter: mockStatsAdapter)
+        let sfuStack = MockSFUStack()
+        await subject.set(sfuAdapter: sfuStack.adapter)
+        await subject.enqueueOwnCapabilities { [.sendAudio, .sendVideo] }
+
+        try await subject.configurePeerConnections()
+
+        let traces = mockStatsAdapter.recordedInputPayload(WebRTCTrace.self, for: .trace) ?? []
+        let createTraces = traces.filter { $0.tag == "create" }
+        XCTAssertEqual(createTraces.count, 2)
+        XCTAssertEqual(
+            Set(createTraces.compactMap(\.id)),
+            Set(["publisher", "subscriber"])
+        )
+        createTraces.forEach { trace in
+            let payload = trace.data?.value as? [String: AnyEncodable]
+            XCTAssertEqual(
+                payload?["url"]?.value as? String,
+                sfuStack.adapter.host
+            )
+        }
+    }
+
     func test_configurePeerConnections_withSFU_completesSetUp() async throws {
         let sfuStack = MockSFUStack()
         await subject.set(sfuAdapter: sfuStack.adapter)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1718/fixtracing-event-names

### 🎯 Goal

WebRTC trace payloads were confusing SFU adapter creation with peer-connection
creation because both used the `create` tag. Peer-connection `create` traces were
also emitted from coordinator reassignment in `WebRTCTracesAdapter`, which could
produce duplicates during reconnect bookkeeping.

This change aligns trace tags with their source and records peer-connection
`create` traces at the point where peer connections are actually configured.

### 📝 Summary

- Renamed SFU adapter creation trace tag from `create` to `sfu.create`.
- Moved publisher/subscriber `create` trace emission to
  `WebRTCStateAdapter.configurePeerConnections()`.
- Stopped emitting synthetic peer-connection `create` traces from
  `WebRTCTracesAdapter` on coordinator assignment.
- Ignored reassignment of the same `SFUAdapter` instance to avoid duplicate
  `sfu.create` traces.
- Updated unit tests, inline docs, and the changelog.

### 🛠 Implementation

- `SFUAdapter.CreateEvent.traceTag` now returns `sfu.create`.
- `WebRTCTracesAdapter` still rebinds publisher/subscriber event
  subscriptions when coordinator instances change, but no longer appends
  synthetic `CreatedEvent` traces.
- `WebRTCStateAdapter.configurePeerConnections()` traces publisher and
  subscriber `CreatedEvent` immediately after each coordinator is built.
- `WebRTCTracesAdapter.didUpdate(_:oldValue:)` for `sfuAdapter` returns early
  when the new adapter is identical to the previous instance.


### 🧪 Manual Testing Notes

1. Join a call with tracing enabled.
2. Inspect delivered stats/trace payloads (or debug logs for flushed traces).
3. Confirm:
   - SFU creation appears as `sfu.create` with id `sfu`.
   - Publisher/subscriber creation appears as `create` with ids `publisher` /
     `subscriber`.
   - Reconnect bookkeeping does not produce duplicate `create` or
     `sfu.create` traces for unchanged adapter/coordinator instances.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal event tracing for peer connection and SFU adapter operations.
  * Enhanced trace subscription handling to prevent duplicate trace event emissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-swift/pull/1145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->