### PR TITLE
Add protobuf degradation preference property

### DIFF
--- a/Sources/StreamVideo/protobuf/sfu/event/events.pb.swift
+++ b/Sources/StreamVideo/protobuf/sfu/event/events.pb.swift
@@ -1171,6 +1171,8 @@ struct Stream_Video_Sfu_Event_VideoSender {
 
   var publishOptionID: Int32 = 0
 
+  var degradationPreference: Stream_Video_Sfu_Models_DegradationPreference = .unspecified
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -3274,6 +3276,7 @@ extension Stream_Video_Sfu_Event_VideoSender: SwiftProtobuf.Message, SwiftProtob
     3: .same(proto: "layers"),
     4: .standard(proto: "track_type"),
     5: .standard(proto: "publish_option_id"),
+    6: .standard(proto: "degradation_preference"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -3286,6 +3289,7 @@ extension Stream_Video_Sfu_Event_VideoSender: SwiftProtobuf.Message, SwiftProtob
       case 3: try { try decoder.decodeRepeatedMessageField(value: &self.layers) }()
       case 4: try { try decoder.decodeSingularEnumField(value: &self.trackType) }()
       case 5: try { try decoder.decodeSingularInt32Field(value: &self.publishOptionID) }()
+      case 6: try { try decoder.decodeSingularEnumField(value: &self.degradationPreference) }()
       default: break
       }
     }
@@ -3308,6 +3312,9 @@ extension Stream_Video_Sfu_Event_VideoSender: SwiftProtobuf.Message, SwiftProtob
     if self.publishOptionID != 0 {
       try visitor.visitSingularInt32Field(value: self.publishOptionID, fieldNumber: 5)
     }
+    if self.degradationPreference != .unspecified {
+      try visitor.visitSingularEnumField(value: self.degradationPreference, fieldNumber: 6)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -3316,6 +3323,7 @@ extension Stream_Video_Sfu_Event_VideoSender: SwiftProtobuf.Message, SwiftProtob
     if lhs.layers != rhs.layers {return false}
     if lhs.trackType != rhs.trackType {return false}
     if lhs.publishOptionID != rhs.publishOptionID {return false}
+    if lhs.degradationPreference != rhs.degradationPreference {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/StreamVideo/protobuf/sfu/models/models.pb.swift
+++ b/Sources/StreamVideo/protobuf/sfu/models/models.pb.swift
@@ -904,6 +904,60 @@ extension Stream_Video_Sfu_Models_ClientCapability: CaseIterable {
 
 #endif  // swift(>=4.2)
 
+/// DegradationPreference represents the RTCDegradationPreference from WebRTC.
+/// See https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters#degradationpreference
+enum Stream_Video_Sfu_Models_DegradationPreference: SwiftProtobuf.Enum {
+  typealias RawValue = Int
+  case unspecified // = 0
+  case balanced // = 1
+  case maintainFramerate // = 2
+  case maintainResolution // = 3
+  case maintainFramerateAndResolution // = 4
+  case UNRECOGNIZED(Int)
+
+  init() {
+    self = .unspecified
+  }
+
+  init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unspecified
+    case 1: self = .balanced
+    case 2: self = .maintainFramerate
+    case 3: self = .maintainResolution
+    case 4: self = .maintainFramerateAndResolution
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  var rawValue: Int {
+    switch self {
+    case .unspecified: return 0
+    case .balanced: return 1
+    case .maintainFramerate: return 2
+    case .maintainResolution: return 3
+    case .maintainFramerateAndResolution: return 4
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Stream_Video_Sfu_Models_DegradationPreference: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static let allCases: [Stream_Video_Sfu_Models_DegradationPreference] = [
+    .unspecified,
+    .balanced,
+    .maintainFramerate,
+    .maintainResolution,
+    .maintainFramerateAndResolution,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
 /// CallState is the current state of the call
 /// as seen by an SFU.
 struct Stream_Video_Sfu_Models_CallState {
@@ -1190,6 +1244,9 @@ struct Stream_Video_Sfu_Models_PublishOption {
 
   /// Audio bitrate profiles for different audio quality profiles.
   var audioBitrateProfiles: [Stream_Video_Sfu_Models_AudioBitrate] = []
+
+  /// The degradation preference for video encoding.
+  var degradationPreference: Stream_Video_Sfu_Models_DegradationPreference = .unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1799,6 +1856,7 @@ extension Stream_Video_Sfu_Models_WebsocketReconnectStrategy: @unchecked Sendabl
 extension Stream_Video_Sfu_Models_AndroidThermalState: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_AppleThermalState: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_ClientCapability: @unchecked Sendable {}
+extension Stream_Video_Sfu_Models_DegradationPreference: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_CallState: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_ParticipantCount: @unchecked Sendable {}
 extension Stream_Video_Sfu_Models_Pin: @unchecked Sendable {}
@@ -1999,6 +2057,16 @@ extension Stream_Video_Sfu_Models_ClientCapability: SwiftProtobuf._ProtoNameProv
     0: .same(proto: "CLIENT_CAPABILITY_UNSPECIFIED"),
     1: .same(proto: "CLIENT_CAPABILITY_SUBSCRIBER_VIDEO_PAUSE"),
     2: .same(proto: "CLIENT_CAPABILITY_COORDINATOR_STATS"),
+  ]
+}
+
+extension Stream_Video_Sfu_Models_DegradationPreference: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "DEGRADATION_PREFERENCE_UNSPECIFIED"),
+    1: .same(proto: "DEGRADATION_PREFERENCE_BALANCED"),
+    2: .same(proto: "DEGRADATION_PREFERENCE_MAINTAIN_FRAMERATE"),
+    3: .same(proto: "DEGRADATION_PREFERENCE_MAINTAIN_RESOLUTION"),
+    4: .same(proto: "DEGRADATION_PREFERENCE_MAINTAIN_FRAMERATE_AND_RESOLUTION"),
   ]
 }
 
@@ -2433,6 +2501,7 @@ extension Stream_Video_Sfu_Models_PublishOption: SwiftProtobuf.Message, SwiftPro
     8: .same(proto: "id"),
     9: .standard(proto: "use_single_layer"),
     10: .standard(proto: "audio_bitrate_profiles"),
+    11: .standard(proto: "degradation_preference"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -2451,6 +2520,7 @@ extension Stream_Video_Sfu_Models_PublishOption: SwiftProtobuf.Message, SwiftPro
       case 8: try { try decoder.decodeSingularInt32Field(value: &self.id) }()
       case 9: try { try decoder.decodeSingularBoolField(value: &self.useSingleLayer) }()
       case 10: try { try decoder.decodeRepeatedMessageField(value: &self.audioBitrateProfiles) }()
+      case 11: try { try decoder.decodeSingularEnumField(value: &self.degradationPreference) }()
       default: break
       }
     }
@@ -2491,6 +2561,9 @@ extension Stream_Video_Sfu_Models_PublishOption: SwiftProtobuf.Message, SwiftPro
     if !self.audioBitrateProfiles.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.audioBitrateProfiles, fieldNumber: 10)
     }
+    if self.degradationPreference != .unspecified {
+      try visitor.visitSingularEnumField(value: self.degradationPreference, fieldNumber: 11)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2505,6 +2578,7 @@ extension Stream_Video_Sfu_Models_PublishOption: SwiftProtobuf.Message, SwiftPro
     if lhs.id != rhs.id {return false}
     if lhs.useSingleLayer != rhs.useSingleLayer {return false}
     if lhs.audioBitrateProfiles != rhs.audioBitrateProfiles {return false}
+    if lhs.degradationPreference != rhs.degradationPreference {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
### 🔗 Issue Links

n/a

### 🎯 Goal

Add protobuf degradation preference property.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added degradation preference support to video sender and publish option configurations.
  * Introduced new degradation preference enum with WebRTC-aligned options available for video system use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-swift/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->