### PR TITLE
[WebRTC]Upgrade to 145.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- An audio issue that can cause the local AVAudioEngine to fail to initialise.[#]
 
 # [1.47.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.0)
 _May 22, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
-- An audio issue that can cause the local AVAudioEngine to fail to initialise.[#]
+- An audio issue that can cause the local AVAudioEngine to fail to initialise.[#1148](https://github.com/GetStream/stream-video-swift/pull/1148)
 
 # [1.47.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.0)
 _May 22, 2026_

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
-        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.6.0")
+        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.8.0")
     ],
     targets: [
         .target(

--- a/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
+++ b/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
@@ -9,5 +9,5 @@ extension SystemEnvironment {
   /// A Stream Video version.
   public static let version: String = "1.48.0-SNAPSHOT"
   /// The WebRTC version.
-  public static let webRTCVersion: String = "145.6.0"
+  public static let webRTCVersion: String = "145.8.0"
 }

--- a/StreamVideo-XCFramework.podspec
+++ b/StreamVideo-XCFramework.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
 
   spec.prepare_command = <<-CMD
     mkdir -p Frameworks/
-    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/145.6.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
+    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/145.8.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
     unzip -o Frameworks/StreamWebRTC.zip -d Frameworks/
     rm Frameworks/StreamWebRTC.zip
   CMD

--- a/StreamVideo.podspec
+++ b/StreamVideo.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |spec|
 
   spec.prepare_command = <<-CMD
     mkdir -p Frameworks/
-    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/145.6.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
+    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/145.8.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
     unzip -o Frameworks/StreamWebRTC.zip -d Frameworks/
     rm Frameworks/StreamWebRTC.zip
   CMD

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3317,7 +3317,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-video-swift-webrtc.git";
 			requirement = {
 				kind = exactVersion;
-				version = 145.6.0;
+				version = 145.8.0;
 			};
 		};
 		40F445C32A9E1D91004BE3DA /* XCRemoteSwiftPackageReference "stream-chat-swift-test-helpers" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1725/bugaudio-issue

### 🎯 Goal

Fix an AudioEngine/WebRTC regression where joining a call muted can break both sending and receiving audio.

The issue happens when muted speech detection enables recording-always-prepared mode before WebRTC registers its audio transport. In that order, WebRTC rejects the transport registration with `Failed to set audio transport since media was active`, then repeatedly logs `Invalid audio transport`.

### 📝 Summary

- Updates the WebRTC dependency to include the AudioEngine transport registration fix.
- Covers the regression with an iOS WebRTC test that reproduces the real join-muted flow.
- Prevents muted-speech detection / prepared recording from leaving WebRTC without a valid audio transport.

### 🛠 Implementation

The fix is in the WebRTC fork. When `AudioEngineDevice::RegisterAudioCallback` needs to temporarily stop an already active audio buffer, it now also clears persistent recording state before registering the audio transport.

This allows `AudioDeviceBuffer::RegisterAudioCallback` to succeed, after which the previous AudioEngine state is restored.

The iOS SDK pulls in the fixed WebRTC artifact/version.

### 🎨 Showcase

N/A

|  Before  |  After  |
| -------- | ------- |
| Joining muted could produce `Failed to set audio transport since media was active` and repeated `Invalid audio transport`; audio send/receive failed. | Joining muted no longer drops WebRTC audio transport; audio send/receive works. |

### 🧪 Manual Testing Notes

Before the fix:

1. Join a call directly from the app UI with microphone muted.
2. Confirm muted speech detection / prepared recording is enabled.
3. Observe WebRTC logs:
   - `RegisterAudioCallback while active. Restarting audio buffer.`
   - `Failed to set audio transport since media was active`
   - repeated `Invalid audio transport`
4. Confirm audio send and receive do not work reliably.

After the fix:

1. Join a call directly from the app UI with microphone muted.
2. Confirm the call connects and audio transport registration succeeds.
3. Verify the logs no longer contain `Failed to set audio transport since media was active` or repeated `Invalid audio transport`.
4. Unmute and confirm local audio is sent.
5. Confirm remote audio is received.

Regression comparison:

- Also verify the CallKit ringing/answer flow still works.
- Specifically test answering a CallKit call while muted and unmuting after join.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an audio initialization failure.

* **Chores**
  * Updated stream-video-swift-webrtc dependency to version 145.8.0 across package managers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-swift/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->