### PR TITLE
[Fix]Cancel WebRTC stage work before transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - An audio issue that can cause the local AVAudioEngine to fail to initialise.[#1148](https://github.com/GetStream/stream-video-swift/pull/1148)
+- Prevent calls from advancing from stale WebRTC join work after the connection flow has moved on. [#1150](https://github.com/GetStream/stream-video-swift/pull/1150)
 
 # [1.47.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.0)
 _May 22, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -75,6 +75,13 @@ extension WebRTCCoordinator.StateMachine.Stage {
             }
         }
 
+        /// Cancels in-flight join, rejoin, or migration work before leaving
+        /// `.joining`.
+        override func willTransitionAway() {
+            super.willTransitionAway()
+            disposableBag.removeAll()
+        }
+
         /// Executes the joining process.
         /// - Parameter isFastReconnecting: A flag indicating if this is a fast
         ///   reconnection.

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+PeerConnectionPreparing.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+PeerConnectionPreparing.swift
@@ -100,13 +100,21 @@ extension WebRTCCoordinator.StateMachine.Stage {
             }
         }
 
+        /// Cancels the pending peer-connection readiness wait before leaving
+        /// `.peerConnectionPreparing`.
+        override func willTransitionAway() {
+            super.willTransitionAway()
+            disposableBag.removeAll()
+        }
+
         // MARK: - Private Helpers
 
         /// Waits for publisher peer-connection readiness, reports join telemetry, then
         /// transitions to `.joined`.
         ///
         /// The stage tolerates readiness timeouts by logging warnings and
-        /// continuing join completion.
+        /// continuing join completion. Cancellation stops the stage without
+        /// reporting join completion.
         private func execute() async {
             guard
                 context.coordinator != nil
@@ -115,14 +123,24 @@ extension WebRTCCoordinator.StateMachine.Stage {
                 return
             }
 
-            await perform(for: configuration)
+            do {
+                try await perform(for: configuration)
 
-            await reportTelemetryAndCompletion()
+                try Task.checkCancellation()
 
-            transitionOrDisconnect(.joined(context))
+                await reportTelemetryAndCompletion()
+
+                try Task.checkCancellation()
+
+                transitionOrDisconnect(.joined(context))
+            } catch is CancellationError {
+                return
+            } catch {
+                transitionDisconnectOrError(error)
+            }
         }
 
-        private func perform(for configuration: Configuration) async {
+        private func perform(for configuration: Configuration) async throws {
             guard
                 let coordinator = context.coordinator,
                 let publisher = await coordinator.stateAdapter.publisher,
@@ -133,15 +151,16 @@ extension WebRTCCoordinator.StateMachine.Stage {
 
             switch configuration {
             case .publisherOnly:
-                await waitForPeerConnectionToBePrepared(
+                try await waitForPeerConnectionToBePrepared(
                     publisher,
                     subsystem: .peerConnectionPublisher,
                     timeout: timeout
                 )
             case .publisherAndSubscriber:
-                await withTaskGroup(of: Void.self) { [timeout] group in
+                try await withThrowingTaskGroup(of: Void.self) { [timeout] group in
                     group.addTask { [weak self] in
-                        await self?.waitForPeerConnectionToBePrepared(
+                        guard let self else { return }
+                        try await self.waitForPeerConnectionToBePrepared(
                             publisher,
                             subsystem: .peerConnectionPublisher,
                             timeout: timeout
@@ -149,14 +168,15 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     }
 
                     group.addTask { [weak self] in
-                        await self?.waitForPeerConnectionToBePrepared(
+                        guard let self else { return }
+                        try await self.waitForPeerConnectionToBePrepared(
                             subscriber,
                             subsystem: .peerConnectionSubscriber,
                             timeout: timeout
                         )
                     }
 
-                    await group.waitForAll()
+                    try await group.waitForAll()
                 }
             }
         }
@@ -189,10 +209,12 @@ extension WebRTCCoordinator.StateMachine.Stage {
             _ peerConnection: RTCPeerConnectionCoordinator,
             subsystem: LogSubsystem,
             timeout: TimeInterval
-        ) async {
+        ) async throws {
             guard await canWaitForPeerConnection(peerConnection) else {
                 return
             }
+
+            try Task.checkCancellation()
 
             do {
                 _ = try await peerConnection
@@ -200,6 +222,8 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     .log(.debug, subsystems: subsystem) { "PeerConnection transitioned to \($0)" }
                     .filter { $0 == .connected }
                     .nextValue(timeout: timeout)
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 log.warning(
                     "PeerConnection wasn't ready in \(timeout) seconds. We continue joining and the connections should be ready after completing.",

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -61,6 +61,48 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         }
     }
 
+    // MARK: - willTransitionAway
+
+    func test_willTransitionAway_whenJoinResponseIsPending_cancelsPendingJoinTask(
+    ) async throws {
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        subject.context.reconnectAttempts = 11
+
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
+        mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
+
+        let unexpectedTransition = expectation(
+            description: "Joining stage should not transition after cancellation."
+        )
+        unexpectedTransition.isInverted = true
+        subject.transition = { _ in unexpectedTransition.fulfill() }
+
+        _ = subject.transition(from: .fastReconnected(subject.context))
+
+        await fulfillment("Join request was not sent before cancellation.") {
+            let webSocketEngine = self.mockCoordinatorStack.sfuStack.webSocket.mockEngine
+            guard
+                let requests = webSocketEngine.recordedInputPayload(
+                    Stream_Video_Sfu_Event_SfuRequest.self,
+                    for: .sendMessage
+                )
+            else {
+                return false
+            }
+            return !requests.isEmpty
+        }
+
+        subject.willTransitionAway()
+        mockCoordinatorStack.sfuStack.receiveEvent(
+            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse()))
+        )
+
+        await fulfillment(of: [unexpectedTransition], timeout: 0.2)
+    }
+
     // MARK: - transition from connected with isRejoiningFromSessionID == nil
 
     func test_transition_fromConnectedWithoutCoordinator_updatesReconnectionStrategy() async throws {

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_PeerConnectionPreparingStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_PeerConnectionPreparingStageTests.swift
@@ -56,6 +56,99 @@ final class WebRTCCoordinatorStateMachine_PeerConnectionPreparingStageTests:
         }
     }
 
+    func test_willTransitionAway_tracesStage() async {
+        let statsAdapter = MockWebRTCStatsAdapter()
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(statsAdapter: statsAdapter)
+
+        subject.willTransitionAway()
+
+        await fulfillment {
+            statsAdapter
+                .recordedInputPayload(WebRTCTrace.self, for: .trace)?
+                .contains { $0.tag == "call.stage.transition" } == true
+        }
+    }
+
+    func test_willTransitionAway_whenPublisherReadinessIsPending_cancelsPendingReadinessTask(
+    ) async throws {
+        let expectedJoinCallResponse = JoinCallResponse.dummy(
+            call: .dummy(cid: "expected-call-id")
+        )
+        let completionSubject = PassthroughSubject<JoinCallResponse, Error>()
+        let readinessWaitStarted = expectation(
+            description: "Publisher readiness wait should start."
+        )
+        readinessWaitStarted.assertForOverFulfill = false
+        let unexpectedTransition = expectation(
+            description: "Readiness stage should not transition after cancellation."
+        )
+        unexpectedTransition.isInverted = true
+        let unexpectedCompletion = expectation(
+            description: "Join response should not be delivered after cancellation."
+        )
+        unexpectedCompletion.isInverted = true
+        let completionCancellable = completionSubject.sink(
+            receiveCompletion: { _ in unexpectedCompletion.fulfill() },
+            receiveValue: { _ in unexpectedCompletion.fulfill() }
+        )
+        defer { completionCancellable.cancel() }
+
+        let publisherConnectionState = CurrentValueSubject<
+            RTCPeerConnectionState,
+            Never
+        >(.new)
+        let publisherCoordinator = try XCTUnwrap(
+            MockRTCPeerConnectionCoordinator(
+                peerType: .publisher,
+                sfuAdapter: mockCoordinatorStack.sfuStack.adapter
+            )
+        )
+        publisherCoordinator.stub(
+            for: \.connectionStatePublisher,
+            with: publisherConnectionState
+                .handleEvents(
+                    receiveSubscription: { _ in readinessWaitStarted.fulfill() }
+                )
+                .eraseToAnyPublisher()
+        )
+        mockCoordinatorStack
+            .rtcPeerConnectionCoordinatorFactory
+            .stubbedBuildCoordinatorResult[.publisher] = publisherCoordinator
+
+        let context = WebRTCCoordinator.StateMachine.Stage.Context(
+            coordinator: mockCoordinatorStack.coordinator,
+            initialJoinCallResponse: expectedJoinCallResponse,
+            joinResponseHandler: completionSubject
+        )
+        subject = .peerConnectionPreparing(context, telemetryReporter: .init())
+
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
+        try await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .configurePeerConnections()
+        subject.transition = { _ in unexpectedTransition.fulfill() }
+
+        _ = subject.transition(from: .joining(subject.context))
+
+        await fulfillment(of: [readinessWaitStarted], timeout: defaultTimeout)
+
+        subject.willTransitionAway()
+        publisherConnectionState.send(.connected)
+
+        await fulfillment(
+            of: [unexpectedTransition, unexpectedCompletion],
+            timeout: 0.2
+        )
+    }
+
     func test_transition_whenPublisherConnectionDoesNotBecomeReadyWithinTimeout_reportsTelemetryAndTransitionsToJoined(
     ) async throws {
         let expectedJoinCallResponse = JoinCallResponse.dummy(


### PR DESCRIPTION
### 🎯 Goal

We observed a crash that was caused on the AudioIORemote thread and on SendVideoChannel, inside WebRTC. The source of those issues was that after call has been left and its PeerConnections were closed, our flows continued in the background. That was causing audio and video frames to get captured and attempted to sent, which was causing the crash on WebRTC.

This revision now prevents stale WebRTC join and peer-connection readiness tasks from completing after the state machine has already moved to another stage.

### 📝 Summary

- Cancel in-flight `JoiningStage` work when transitioning away.
- Cancel pending `PeerConnectionPreparingStage` readiness waits when transitioning away.
- Preserve WebRTC stage transition tracing for `PeerConnectionPreparingStage`.
- Add DocC comments and focused unit tests for transition-away cleanup behavior.

### 🛠 Implementation

`JoiningStage` and `PeerConnectionPreparingStage` now clear their `DisposableBag` in `willTransitionAway()`, cancelling any stage-owned async work before another stage owns the call lifecycle.

`PeerConnectionPreparingStage` now treats `CancellationError` differently from peer-connection readiness timeouts: timeouts still allow the join to continue, while cancellation exits without reporting join completion or transitioning to `.joined`.


### 🧪 Manual Testing Notes

- Join a call
- While joining leave
- Quickly repeat the steps on the same call
- No crash should be observed
- At some point after joining the call (without leaving) audio should be working as expecte

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)