### PR TITLE
[Fix]Missing early peer-connection traces

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/Stats/Reporter/WebRTCStatsReporter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Stats/Reporter/WebRTCStatsReporter.swift
@@ -68,7 +68,16 @@ final class WebRTCStatsReporter: WebRTCStatsReporting, @unchecked Sendable {
 
     // MARK: - Manual trigger
 
+    /// Triggers delivery only when no previous delivery is still in flight.
+    ///
+    /// The provider flushes trace buffers while preparing the delivery input.
+    /// Skipping the provider while another delivery is active prevents traces
+    /// from being flushed into a payload that would be discarded.
     func triggerDelivery() {
+        guard canDeliverStats else {
+            return
+        }
+
         guard
             let input = provider()
         else {
@@ -95,6 +104,10 @@ final class WebRTCStatsReporter: WebRTCStatsReporting, @unchecked Sendable {
         log.debug("Delivery scheduled on hostname:\(sfuAdapter?.hostname) with interval:\(interval) seconds.")
     }
 
+    /// Schedules periodic delivery without draining buffers during overlap.
+    ///
+    /// The timer checks `canDeliverStats` before asking the provider for input
+    /// so an overlapping tick does not flush traces that cannot be sent yet.
     private func scheduleDelivery(with interval: TimeInterval) {
         deliveryCancellable?.cancel()
         deliveryCancellable = nil
@@ -106,6 +119,7 @@ final class WebRTCStatsReporter: WebRTCStatsReporting, @unchecked Sendable {
 
         deliveryCancellable = DefaultTimer
             .publish(every: interval)
+            .filter { [weak self] _ in self?.canDeliverStats == true }
             .compactMap { [weak self] _ in self?.provider() }
             .sink { [weak self] in self?.deliverStats($0) }
     }
@@ -114,7 +128,7 @@ final class WebRTCStatsReporter: WebRTCStatsReporting, @unchecked Sendable {
     ///
     /// - Parameter report: The statistics report to deliver.
     private func deliverStats(_ input: Input) {
-        guard activeDeliveryTask == nil else {
+        guard canDeliverStats else {
             return
         }
 
@@ -157,4 +171,7 @@ final class WebRTCStatsReporter: WebRTCStatsReporting, @unchecked Sendable {
         }
         // swiftlint:enable discourage_task_init
     }
+
+    /// Indicates whether collecting and sending a new delivery payload is safe.
+    private var canDeliverStats: Bool { activeDeliveryTask == nil }
 }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -93,12 +93,16 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     private let rtcPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordinatorProviding
     private let disposableBag = DisposableBag()
     private let peerConnectionsDisposableBag = DisposableBag()
+    /// Holds temporary peer-connection trace subscriptions created before the
+    /// stats adapter is available.
+    private let pendingPeerConnectionTracesDisposableBag = DisposableBag()
 
     private let processingQueue = OperationQueue(maxConcurrentOperationCount: 1)
     private let callSettingsProcessingQueue = OperationQueue(maxConcurrentOperationCount: 1)
     /// Publishes WebRTC stage changes so permission prompts can wait until the
     /// coordinator has fully joined.
     private let stagePublisher: AnyPublisher<WebRTCCoordinator.StateMachine.Stage.ID, Never>
+    /// Stores traces emitted before the stats adapter is ready to consume them.
     private var queuedTraces: ConsumableBucket<WebRTCTrace> = .init()
     private lazy var permissionsAdapter: WebRTCPermissionsAdapter = .init(self, stagePublisher: stagePublisher)
 
@@ -231,10 +235,20 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     /// Sets the own capabilities of the current user.
     private func set(ownCapabilities value: Set<OwnCapability>) { self.ownCapabilities = value }
 
-    /// Sets the WebRTC stats reporter.
+    /// Sets the WebRTC stats reporter and drains traces collected before it was
+    /// available.
+    ///
+    /// Peer connections can emit traceable events while they are being created
+    /// and before `JoinedStage` installs the stats adapter. Those events are
+    /// stored in `queuedTraces`; once a stats adapter is provided, the queued
+    /// traces are transferred to it and the temporary peer-connection observers
+    /// are removed so normal stats-adapter tracing can take over.
     func set(statsAdapter value: WebRTCStatsAdapting?) {
         self.statsAdapter = value
         value?.consume(queuedTraces)
+        if value != nil {
+            pendingPeerConnectionTracesDisposableBag.removeAll()
+        }
     }
 
     /// Sets the SFU (Selective Forwarding Unit) adapter and updates the stats
@@ -383,6 +397,20 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
             )
         )
 
+        if let statsAdapter {
+            statsAdapter.publisher = publisher
+            statsAdapter.subscriber = subscriber
+        } else {
+            observePendingPeerConnectionTraces(
+                for: .publisher,
+                peerConnection: publisher
+            )
+            observePendingPeerConnectionTraces(
+                for: .subscriber,
+                peerConnection: subscriber
+            )
+        }
+
         publisher
             .trackPublisher
             .log(.debug, subsystems: .peerConnectionPublisher)
@@ -428,6 +456,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     func cleanUp() async {
         screenShareSessionProvider.activeSession = nil
         videoCaptureSessionProvider.activeSession = nil
+        pendingPeerConnectionTracesDisposableBag.removeAll()
         peerConnectionsDisposableBag.removeAll()
         disposableBag.removeAll()
         await audioSession.deactivate()
@@ -467,6 +496,7 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         )
 
         peerConnectionsDisposableBag.removeAll()
+        pendingPeerConnectionTracesDisposableBag.removeAll()
         disposableBag.removeAll()
         await audioSession.deactivate()
         await publisher?.prepareForClosing()
@@ -712,6 +742,26 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         } else {
             queuedTraces.append(trace)
         }
+    }
+
+    /// Observes peer-connection events until the stats adapter is installed.
+    ///
+    /// This prevents early publisher/subscriber events, such as `createOffer`
+    /// or ICE state changes, from being lost during join setup. The subscription
+    /// is temporary and is cancelled as soon as a non-nil stats adapter is set.
+    private func observePendingPeerConnectionTraces(
+        for peerType: PeerConnectionType,
+        peerConnection: RTCPeerConnectionCoordinator
+    ) {
+        let queuedTraces = self.queuedTraces
+        peerConnection
+            .eventPublisher
+            .map { WebRTCTrace(peerType: peerType, event: $0) }
+            .log(.debug, subsystems: .webRTC) {
+                "Trace tag:\($0.tag) create for id:\($0.id) at timestamp:\($0.timestamp)."
+            }
+            .sink { queuedTraces.append($0) }
+            .store(in: pendingPeerConnectionTracesDisposableBag)
     }
 
     private func processEnqueuedOperation(

--- a/StreamVideoTests/Mock/MockWebRTCStatsAdapter.swift
+++ b/StreamVideoTests/Mock/MockWebRTCStatsAdapter.swift
@@ -59,6 +59,7 @@ final class MockWebRTCStatsAdapter: Mockable, WebRTCStatsAdapting, @unchecked Se
     }
 
     let latestReportSubject: PassthroughSubject<CallStatsReport, Never> = .init()
+    var consumedTraces: [WebRTCTrace] = []
 
     // MARK: - WebRTCStatsAdapting
 
@@ -117,5 +118,6 @@ final class MockWebRTCStatsAdapter: Mockable, WebRTCStatsAdapting, @unchecked Se
 
     func consume(_ bucket: ConsumableBucket<WebRTCTrace>) {
         stubbedFunctionInput[.consume]?.append(.consume(bucket))
+        consumedTraces.append(contentsOf: bucket.consume(flush: true))
     }
 }

--- a/StreamVideoTests/WebRTC/SFU/Mocks/MockSignalServer.swift
+++ b/StreamVideoTests/WebRTC/SFU/Mocks/MockSignalServer.swift
@@ -47,6 +47,7 @@ final class MockSignalServer: SFUSignalService, Mockable, @unchecked Sendable {
 
     var updateMuteStatesWasCalledWithRequest: Stream_Video_Sfu_Signal_UpdateMuteStatesRequest?
     var sendStatsWasCalledWithRequest: Stream_Video_Sfu_Signal_SendStatsRequest?
+    var sendStatsDelay: TimeInterval = 0
     private(set) var startNoiseCancellationWasCalledWithRequest: Stream_Video_Sfu_Signal_StartNoiseCancellationRequest?
     private(set) var stopNoiseCancellationWasCalledWithRequest: Stream_Video_Sfu_Signal_StopNoiseCancellationRequest?
     private(set) var setPublisherWasCalledWithRequest: Stream_Video_Sfu_Signal_SetPublisherRequest?
@@ -86,6 +87,9 @@ final class MockSignalServer: SFUSignalService, Mockable, @unchecked Sendable {
         sendStatsRequest: Stream_Video_Sfu_Signal_SendStatsRequest
     ) async throws -> Stream_Video_Sfu_Signal_SendStatsResponse {
         sendStatsWasCalledWithRequest = sendStatsRequest
+        if sendStatsDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(sendStatsDelay * 1_000_000_000))
+        }
         return stubbedFunction[.sendStats] as! Stream_Video_Sfu_Signal_SendStatsResponse
     }
 

--- a/StreamVideoTests/WebRTC/v2/Stats/Reporter/WebRTCStatsReporter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/Stats/Reporter/WebRTCStatsReporter_Tests.swift
@@ -80,6 +80,24 @@ final class WebRTCStatsReporter_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(request.deviceState?.thermalState, .critical)
     }
 
+    func test_triggerDelivery_whileDeliveryIsActive_doesNotRequestNewInput() {
+        mockSFUStack.service.sendStatsDelay = 1
+        var providerCallsCount = 0
+        subject = WebRTCStatsReporter(
+            interval: 100,
+            provider: {
+                providerCallsCount += 1
+                return self.input
+            }
+        )
+        subject.sfuAdapter = mockSFUStack.adapter
+
+        subject.triggerDelivery()
+        subject.triggerDelivery()
+
+        XCTAssertEqual(providerCallsCount, 1)
+    }
+
     func test_sfuAdapterNotNil_updateToAnotherSFUAdapter_firstReportCollectionIsCancelledAndOnlyTheSecondOneCompletes(
     ) async throws {
         try XCTSkipIf(true, "https://linear.app/stream/issue/IOS-904/reenable-skipped-tests")

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -337,6 +337,36 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await assertTrueAsync(await subject.statsAdapter === expected)
     }
 
+    func test_setStatsReporter_consumesQueuedPeerConnectionEventTraces() async throws {
+        let sfuStack = MockSFUStack()
+        await subject.set(sfuAdapter: sfuStack.adapter)
+        try await subject.configurePeerConnections()
+        let publisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        publisher.stubEventSubject.send(
+            StreamRTCPeerConnection.CreateOfferEvent(
+                sessionDescription: .init(type: .offer, sdp: "")
+            )
+        )
+        let statsAdapter = MockWebRTCStatsAdapter()
+
+        await subject.set(statsAdapter: statsAdapter)
+
+        XCTAssertTrue(
+            statsAdapter.consumedTraces.contains {
+                $0.id == PeerConnectionType.publisher.rawValue
+                    && $0.tag == "createOffer"
+            }
+        )
+
+        publisher.stubEventSubject.send(StreamRTCPeerConnection.CloseEvent())
+
+        XCTAssertFalse(
+            statsAdapter
+                .recordedInputPayload(WebRTCTrace.self, for: .trace)?
+                .contains { $0.tag == "close" } == true
+        )
+    }
+
     // MARK: - setSFUAdapter
 
     func test_setSFUAdapter_shouldUpdateSFUAdapterAndStatsReporter() async throws {
@@ -563,6 +593,20 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
                 sfuStack.adapter.host
             )
         }
+    }
+
+    func test_configurePeerConnections_withExistingStatsAdapter_updatesStatsAdapterWithPeerConnections() async throws {
+        let mockStatsAdapter = MockWebRTCStatsAdapter()
+        await subject.set(statsAdapter: mockStatsAdapter)
+        let sfuStack = MockSFUStack()
+        await subject.set(sfuAdapter: sfuStack.adapter)
+
+        try await subject.configurePeerConnections()
+
+        let publisher = try await XCTAsyncUnwrap(await subject.publisher)
+        let subscriber = try await XCTAsyncUnwrap(await subject.subscriber)
+        XCTAssertTrue(mockStatsAdapter.publisher === publisher)
+        XCTAssertTrue(mockStatsAdapter.subscriber === subscriber)
     }
 
     func test_configurePeerConnections_withSFU_completesSetUp() async throws {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1730/bugmissing-peerconnection-traces

### 🎯 Goal

Ensure publisher/subscriber peer connection traces emitted during join setup are not lost before the stats adapter is installed.

### 📝 Summary

- Queue early publisher/subscriber peer connection trace events when `statsAdapter` is not ready yet.
- Stop temporary peer connection trace observation once the stats adapter becomes available.
- Prevent overlapping stats deliveries from flushing traces into payloads that will be skipped.

### 🛠 Implementation

`WebRTCStateAdapter` now installs temporary peer connection event observers during `configurePeerConnections()` only when the stats adapter is nil. These observers convert peer connection events into `WebRTCTrace` values and append them to `queuedTraces`.

When `set(statsAdapter:)` receives a non-nil adapter, queued traces are consumed by the stats adapter and the temporary observers are removed, allowing normal `WebRTCTracesAdapter` peer connection tracing to take over.

`WebRTCStatsReporter` now checks whether a delivery is already active before asking the provider for input, so traces are not flushed from buffers into a delivery payload that would be discarded.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping WebRTC stats delivery attempts that could cause trace buffer issues.
  * Improved capture of WebRTC events occurring during early peer connection setup.

* **Tests**
  * Added test coverage for stats delivery overlap prevention.
  * Added test coverage for trace event queueing during connection initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-swift/pull/1152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->