### PR TITLE
[Enhancement]Add degradation preference handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
-- Added support for SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks.
+- Added support for SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks.[#1153](https://github.com/GetStream/stream-video-swift/pull/1153)
 
 # [1.47.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.1)
 _May 26, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Added support for SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks.
 
 # [1.47.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.1)
 _May 26, 2026_

--- a/Sources/StreamVideo/Models/PublishOptions.swift
+++ b/Sources/StreamVideo/Models/PublishOptions.swift
@@ -111,6 +111,11 @@ struct PublishOptions: Sendable, Hashable {
         /// be provided by the source or it should be derived by using
         /// `PeerConnectionFactory.codecCapabilities(videoCodec)?.fmtp`
         var fmtp: String
+        /// Preferred WebRTC degradation behavior for constrained bandwidth.
+        ///
+        /// When the SFU omits this value, the SDK keeps its previous behavior
+        /// by defaulting to `.maintainFramerate`.
+        var degradationPreference: Stream_Video_Sfu_Models_DegradationPreference
 
         /// Initializes video options from a server model.
         ///
@@ -129,6 +134,9 @@ struct PublishOptions: Sendable, Hashable {
                 height: Int(publishOption.videoDimension.height)
             )
             fmtp = publishOption.codec.fmtp
+            degradationPreference = publishOption.degradationPreference == .unspecified
+                ? .maintainFramerate
+                : publishOption.degradationPreference
         }
 
         /// Initializes video options with specific parameters.
@@ -141,6 +149,8 @@ struct PublishOptions: Sendable, Hashable {
         ///   - bitrate: Bitrate for the video stream. Defaults to `.maxBitrate`.
         ///   - frameRate: Frame rate for the video stream. Defaults to `30`.
         ///   - dimensions: Dimensions of the video stream. Defaults to `.full`.
+        ///   - degradationPreference: Preferred behavior under constrained
+        ///   bandwidth. Defaults to `.maintainFramerate` for backwards compatibility.
         init(
             id: Int = 0,
             codec: VideoCodec,
@@ -151,7 +161,8 @@ struct PublishOptions: Sendable, Hashable {
             ),
             bitrate: Int = .maxBitrate,
             frameRate: Int = .defaultFrameRate,
-            dimensions: CGSize = .full
+            dimensions: CGSize = .full,
+            degradationPreference: Stream_Video_Sfu_Models_DegradationPreference = .maintainFramerate
         ) {
             self.id = id
             self.codec = codec
@@ -160,6 +171,7 @@ struct PublishOptions: Sendable, Hashable {
             self.bitrate = bitrate
             self.frameRate = frameRate
             self.dimensions = dimensions
+            self.degradationPreference = degradationPreference
         }
 
         /// Combines properties into a hash value for use in hash-based collections.

--- a/Sources/StreamVideo/WebRTC/v2/Extensions/Protobuf/Stream_Video_Sfu_Models_PublishOption+Convenience.swift
+++ b/Sources/StreamVideo/WebRTC/v2/Extensions/Protobuf/Stream_Video_Sfu_Models_PublishOption+Convenience.swift
@@ -62,5 +62,6 @@ extension Stream_Video_Sfu_Models_PublishOption {
         videoDimension.height = UInt32(source.dimensions.height)
         maxSpatialLayers = Int32(source.capturingLayers.spatialLayers)
         maxTemporalLayers = Int32(source.capturingLayers.temporalLayers)
+        degradationPreference = source.degradationPreference
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/Extensions/RTCRtpTransceiverInit+Convenience.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/Extensions/RTCRtpTransceiverInit+Convenience.swift
@@ -5,6 +5,50 @@
 import Foundation
 import StreamWebRTC
 
+extension Stream_Video_Sfu_Models_DegradationPreference {
+
+    /// WebRTC sender parameter value for this SFU degradation preference.
+    ///
+    /// `.unspecified` and unknown values return `nil` so live SFU updates can
+    /// leave the sender's current WebRTC behavior unchanged.
+    var rtcDegradationPreference: NSNumber? {
+        switch self {
+        case .balanced:
+            return NSNumber(value: RTCDegradationPreference.balanced.rawValue)
+        case .maintainFramerate:
+            return NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        case .maintainResolution:
+            return NSNumber(value: RTCDegradationPreference.maintainResolution.rawValue)
+        case .maintainFramerateAndResolution:
+            return NSNumber(value: RTCDegradationPreference.maintainFramerateAndResolution.rawValue)
+        case .unspecified, .UNRECOGNIZED:
+            return nil
+        }
+    }
+}
+
+extension RTCRtpParameters {
+
+    /// Updates the degradation preference when the SFU provides an explicit value.
+    ///
+    /// - Parameter preference: The SFU-provided preference to apply.
+    /// - Returns: `true` when the parameter changed.
+    @discardableResult
+    func setDegradationPreference(
+        _ preference: Stream_Video_Sfu_Models_DegradationPreference
+    ) -> Bool {
+        guard
+            let rtcDegradationPreference = preference.rtcDegradationPreference,
+            degradationPreference != rtcDegradationPreference
+        else {
+            return false
+        }
+
+        degradationPreference = rtcDegradationPreference
+        return true
+    }
+}
+
 extension RTCRtpTransceiverInit {
 
     /// Creates a temporary `RTCRtpTransceiverInit` instance for a specific track type.

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter.swift
@@ -294,7 +294,44 @@ final class LocalScreenShareMediaAdapter: LocalMediaAdapting, @unchecked Sendabl
     func changePublishQuality(
         with layerSettings: [Stream_Video_Sfu_Event_VideoSender]
     ) {
-        /* No-op */
+        processingQueue.addTaskOperation { [weak self] in
+            guard let self else { return }
+
+            for videoSender in layerSettings {
+                let key = PublishOptions.VideoPublishOptions(
+                    id: Int(videoSender.publishOptionID),
+                    codec: VideoCodec(videoSender.codec)
+                )
+                guard
+                    let transceiver = transceiverStorage.get(for: key)?.transceiver
+                else {
+                    log.debug(
+                        """
+                        We didn't apply publish quality change because transceiver
+                        not found for publishOptionID:\(videoSender.publishOptionID) and codec:\(VideoCodec(videoSender.codec)).
+                        Available transceivers: \(transceiverStorage.map { "publishOptionID:\($0.key.id), codec:\($0.key.codec)" })
+                        """,
+                        subsystems: .webRTC
+                    )
+                    continue
+                }
+
+                let params = transceiver.sender.parameters
+                guard params.setDegradationPreference(videoSender.degradationPreference) else {
+                    log.info(
+                        "Update publish quality, degradation preference unchanged",
+                        subsystems: .webRTC
+                    )
+                    continue
+                }
+
+                log.info(
+                    "Update publish quality degradation preference for publishOptionID:\(videoSender.publishOptionID) codec:\(VideoCodec(videoSender.codec))",
+                    subsystems: .webRTC
+                )
+                transceiver.sender.parameters = params
+            }
+        }
     }
 
     /// Retrieves information about the active screen sharing tracks.
@@ -438,6 +475,11 @@ final class LocalScreenShareMediaAdapter: LocalMediaAdapting, @unchecked Sendabl
         else {
             log.warning("Unable to create transceiver for options:\(options).", subsystems: .webRTC)
             return
+        }
+
+        let params = transceiver.sender.parameters
+        if params.setDegradationPreference(options.degradationPreference) {
+            transceiver.sender.parameters = params
         }
         transceiverStorage.set(transceiver, track: track, for: options)
     }

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter.swift
@@ -418,10 +418,16 @@ final class LocalVideoMediaAdapter: LocalMediaAdapting, @unchecked Sendable {
                 let params = transceiver
                     .sender
                     .parameters
+                if params.setDegradationPreference(videoSender.degradationPreference) {
+                    hasChanges = true
+                }
 
                 guard
                     !params.encodings.isEmpty
                 else {
+                    if hasChanges {
+                        transceiver.sender.parameters = params
+                    }
                     log.warning("Update publish quality, No suitable video encoding quality found", subsystems: .webRTC)
                     return
                 }
@@ -796,6 +802,11 @@ final class LocalVideoMediaAdapter: LocalMediaAdapting, @unchecked Sendable {
         else {
             log.warning("Unable to create transceiver for options:\(options).", subsystems: .webRTC)
             return
+        }
+
+        let params = transceiver.sender.parameters
+        if params.setDegradationPreference(options.degradationPreference) {
+            transceiver.sender.parameters = params
         }
         transceiverStorage.set(transceiver, track: track, for: options)
     }

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -8,6 +8,7 @@ import XCTest
 
 final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable {
 
+    private lazy var streamVideo: MockStreamVideo! = .init()
     private lazy var callKitService: MockCallKitService! = .init()
     private lazy var subject: CallKitPushNotificationAdapter! = .init()
 
@@ -15,10 +16,12 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
 
     override func setUp() {
         super.setUp()
+        _ = streamVideo
         InjectedValues[\.callKitService] = callKitService
     }
 
     override func tearDown() {
+        streamVideo = nil
         callKitService = nil
         subject = nil
         super.tearDown()

--- a/StreamVideoTests/Models/PublishOptions_Tests.swift
+++ b/StreamVideoTests/Models/PublishOptions_Tests.swift
@@ -29,6 +29,33 @@ final class VideoPublishOptionsTests: XCTestCase, @unchecked Sendable {
         assertTrackLayers(.video, for: .av1, spatialLayers: 1)
     }
 
+    // MARK: - degradationPreference
+
+    func test_init_withExplicitDegradationPreference_assignsPreference() {
+        var publishOption = Stream_Video_Sfu_Models_PublishOption(
+            trackType: .video,
+            codec: .dummy(name: "h264"),
+            bitrate: 1000
+        )
+        publishOption.degradationPreference = .balanced
+
+        let result = PublishOptions.VideoPublishOptions(publishOption)
+
+        XCTAssertEqual(result.degradationPreference, .balanced)
+    }
+
+    func test_init_withUnspecifiedDegradationPreference_defaultsToMaintainFramerate() {
+        let publishOption = Stream_Video_Sfu_Models_PublishOption(
+            trackType: .video,
+            codec: .dummy(name: "h264"),
+            bitrate: 1000
+        )
+
+        let result = PublishOptions.VideoPublishOptions(publishOption)
+
+        XCTAssertEqual(result.degradationPreference, .maintainFramerate)
+    }
+
     // MARK: - Private Helpers
 
     private func assertTrackLayers(

--- a/StreamVideoTests/Utilities/Dummy/PublishOptions+Dummy.swift
+++ b/StreamVideoTests/Utilities/Dummy/PublishOptions+Dummy.swift
@@ -44,7 +44,8 @@ extension PublishOptions.VideoPublishOptions {
         ),
         bitrate: Int = .maxBitrate,
         frameRate: Int = .defaultFrameRate,
-        dimensions: CGSize = .full
+        dimensions: CGSize = .full,
+        degradationPreference: Stream_Video_Sfu_Models_DegradationPreference = .maintainFramerate
     ) -> PublishOptions.VideoPublishOptions {
         .init(
             id: id,
@@ -53,7 +54,8 @@ extension PublishOptions.VideoPublishOptions {
             capturingLayers: capturingLayers,
             bitrate: bitrate,
             frameRate: frameRate,
-            dimensions: dimensions
+            dimensions: dimensions,
+            degradationPreference: degradationPreference
         )
     }
 }

--- a/StreamVideoTests/Utilities/Dummy/Stream_Video_Sfu_Event_ChangePublishQuality+Dummy.swift
+++ b/StreamVideoTests/Utilities/Dummy/Stream_Video_Sfu_Event_ChangePublishQuality+Dummy.swift
@@ -36,7 +36,8 @@ extension Stream_Video_Sfu_Event_VideoSender {
         codec: VideoCodec,
         trackType: Stream_Video_Sfu_Models_TrackType = .unspecified,
         layers: [Stream_Video_Sfu_Event_VideoLayerSetting] = [],
-        publishOptionID: Int = 0
+        publishOptionID: Int = 0,
+        degradationPreference: Stream_Video_Sfu_Models_DegradationPreference = .unspecified
     ) -> Stream_Video_Sfu_Event_VideoSender {
         var result = Stream_Video_Sfu_Event_VideoSender()
         result.codec = .init()
@@ -44,6 +45,7 @@ extension Stream_Video_Sfu_Event_VideoSender {
         result.layers = layers
         result.trackType = trackType
         result.publishOptionID = Int32(publishOptionID)
+        result.degradationPreference = degradationPreference
         return result
     }
 }

--- a/StreamVideoTests/Utilities/Dummy/Stream_Video_Sfu_Event_VideoSender+Dummy.swift
+++ b/StreamVideoTests/Utilities/Dummy/Stream_Video_Sfu_Event_VideoSender+Dummy.swift
@@ -9,13 +9,15 @@ extension Stream_Video_Sfu_Event_VideoSender {
         codec: Stream_Video_Sfu_Models_Codec = .dummy(),
         layers: [Stream_Video_Sfu_Event_VideoLayerSetting],
         trackType: Stream_Video_Sfu_Models_TrackType,
-        publishOptionID: Int = 0
+        publishOptionID: Int = 0,
+        degradationPreference: Stream_Video_Sfu_Models_DegradationPreference = .unspecified
     ) -> Stream_Video_Sfu_Event_VideoSender {
         var result = Stream_Video_Sfu_Event_VideoSender()
         result.codec = codec
         result.layers = layers
         result.trackType = trackType
         result.publishOptionID = Int32(publishOptionID)
+        result.degradationPreference = degradationPreference
         return result
     }
 }

--- a/StreamVideoTests/WebRTC/v2/Extensions/Protobuf/StreamVideoSfuModelsPublishOption_ConvenienceTests.swift
+++ b/StreamVideoTests/WebRTC/v2/Extensions/Protobuf/StreamVideoSfuModelsPublishOption_ConvenienceTests.swift
@@ -28,7 +28,8 @@ final class StreamVideoSfuModelsPublishOption_ConvenienceTests: XCTestCase, @unc
             capturingLayers: .init(spatialLayers: 3, temporalLayers: 2),
             bitrate: 1_000_000,
             frameRate: 30,
-            dimensions: CGSize(width: 1920, height: 1080)
+            dimensions: CGSize(width: 1920, height: 1080),
+            degradationPreference: .maintainResolution
         )
 
         let publishOption = Stream_Video_Sfu_Models_PublishOption(videoOptions, trackType: .video)
@@ -41,6 +42,7 @@ final class StreamVideoSfuModelsPublishOption_ConvenienceTests: XCTestCase, @unc
         XCTAssertEqual(publishOption.videoDimension.height, 1080)
         XCTAssertEqual(publishOption.maxSpatialLayers, 3)
         XCTAssertEqual(publishOption.maxTemporalLayers, 2)
+        XCTAssertEqual(publishOption.degradationPreference, .maintainResolution)
     }
 
     func test_initWithScreenSharePublishOptions() {

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/Extensions/RTCRtpTransceiverInit_ConvenienceTests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/Extensions/RTCRtpTransceiverInit_ConvenienceTests.swift
@@ -63,6 +63,70 @@ final class RTCRtpTransceiverInit_ConvenienceTests: XCTestCase, @unchecked Senda
         XCTAssertEqual(transceiverInit.sendEncodings.count, 0)
     }
 
+    // MARK: - degradationPreference
+
+    func test_rtcDegradationPreference_mapsKnownValues() {
+        XCTAssertEqual(
+            Stream_Video_Sfu_Models_DegradationPreference.balanced.rtcDegradationPreference,
+            NSNumber(value: RTCDegradationPreference.balanced.rawValue)
+        )
+        XCTAssertEqual(
+            Stream_Video_Sfu_Models_DegradationPreference.maintainFramerate.rtcDegradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        )
+        XCTAssertEqual(
+            Stream_Video_Sfu_Models_DegradationPreference.maintainResolution.rtcDegradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainResolution.rawValue)
+        )
+        XCTAssertEqual(
+            Stream_Video_Sfu_Models_DegradationPreference.maintainFramerateAndResolution.rtcDegradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainFramerateAndResolution.rawValue)
+        )
+    }
+
+    func test_rtcDegradationPreference_withUnspecifiedAndUnrecognized_returnsNil() {
+        XCTAssertNil(Stream_Video_Sfu_Models_DegradationPreference.unspecified.rtcDegradationPreference)
+        XCTAssertNil(Stream_Video_Sfu_Models_DegradationPreference.UNRECOGNIZED(99).rtcDegradationPreference)
+    }
+
+    func test_setDegradationPreference_withChangedPreference_updatesValue() {
+        let parameters = RTCRtpParameters()
+
+        let didChange = parameters.setDegradationPreference(.maintainResolution)
+
+        XCTAssertTrue(didChange)
+        XCTAssertEqual(
+            parameters.degradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainResolution.rawValue)
+        )
+    }
+
+    func test_setDegradationPreference_withUnspecifiedPreference_keepsValue() {
+        let parameters = RTCRtpParameters()
+        parameters.degradationPreference = NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+
+        let didChange = parameters.setDegradationPreference(.unspecified)
+
+        XCTAssertFalse(didChange)
+        XCTAssertEqual(
+            parameters.degradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        )
+    }
+
+    func test_setDegradationPreference_withSamePreference_keepsValue() {
+        let parameters = RTCRtpParameters()
+        parameters.degradationPreference = NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+
+        let didChange = parameters.setDegradationPreference(.maintainFramerate)
+
+        XCTAssertFalse(didChange)
+        XCTAssertEqual(
+            parameters.degradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        )
+    }
+
     // MARK: - init(trackType:direction:streamIds:videoOptions:)
 
     func test_initWithVideoPublishOptions_forNonSVCCodec_withThreeSpatialLayers() {

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalScreenShareMediaAdapter_Tests.swift
@@ -552,6 +552,110 @@ final class LocalScreenShareMediaAdapter_Tests: XCTestCase, @unchecked Sendable 
         }
     }
 
+    // MARK: - changePublishQuality
+
+    func test_publish_withDefaultDegradationPreference_senderWasUpdated() async throws {
+        let screenShareOptions = PublishOptions.VideoPublishOptions.dummy(codec: .h264)
+        publishOptions = [screenShareOptions]
+        let transceiver = try makeTransceiver(of: .screenshare, videoOptions: screenShareOptions)
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+        screenShareSessionProvider.activeSession = .init(
+            localTrack: subject.primaryTrack,
+            screenSharingType: .inApp,
+            capturer: MockStreamVideoCapturer(),
+            includeAudio: true
+        )
+
+        try await subject.publish()
+
+        await fulfillment {
+            transceiver.sender.parameters.degradationPreference ==
+                NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        }
+    }
+
+    func test_publish_withExplicitDegradationPreference_senderWasUpdated() async throws {
+        let screenShareOptions = PublishOptions.VideoPublishOptions.dummy(
+            codec: .h264,
+            degradationPreference: .balanced
+        )
+        publishOptions = [screenShareOptions]
+        let transceiver = try makeTransceiver(of: .screenshare, videoOptions: screenShareOptions)
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+        screenShareSessionProvider.activeSession = .init(
+            localTrack: subject.primaryTrack,
+            screenSharingType: .inApp,
+            capturer: MockStreamVideoCapturer(),
+            includeAudio: true
+        )
+
+        try await subject.publish()
+
+        await fulfillment {
+            transceiver.sender.parameters.degradationPreference ==
+                NSNumber(value: RTCDegradationPreference.balanced.rawValue)
+        }
+    }
+
+    func test_changePublishQuality_withDegradationPreference_senderWasUpdated() async throws {
+        let transceiver = try makeTransceiver(of: .screenshare, videoOptions: .dummy(codec: .h264))
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+        screenShareSessionProvider.activeSession = .init(
+            localTrack: subject.primaryTrack,
+            screenSharingType: .inApp,
+            capturer: MockStreamVideoCapturer(),
+            includeAudio: true
+        )
+        try await subject.publish()
+        await fulfillment { self.mockPeerConnection.timesCalled(.addTransceiver) == 1 }
+
+        subject.changePublishQuality(
+            with: [
+                .dummy(
+                    codec: .dummy(name: "h264"),
+                    layers: [],
+                    trackType: .screenShare,
+                    degradationPreference: .maintainResolution
+                )
+            ]
+        )
+
+        await fulfillment {
+            transceiver.sender.parameters.degradationPreference ==
+                NSNumber(value: RTCDegradationPreference.maintainResolution.rawValue)
+        }
+    }
+
+    func test_changePublishQuality_withUnspecifiedDegradationPreference_keepsSenderPreference() async throws {
+        let transceiver = try makeTransceiver(of: .screenshare, videoOptions: .dummy(codec: .h264))
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+        screenShareSessionProvider.activeSession = .init(
+            localTrack: subject.primaryTrack,
+            screenSharingType: .inApp,
+            capturer: MockStreamVideoCapturer(),
+            includeAudio: true
+        )
+        try await subject.publish()
+        await fulfillment { self.mockPeerConnection.timesCalled(.addTransceiver) == 1 }
+
+        subject.changePublishQuality(
+            with: [
+                .dummy(
+                    codec: .dummy(name: "h264"),
+                    layers: [],
+                    trackType: .screenShare,
+                    degradationPreference: .unspecified
+                )
+            ]
+        )
+
+        await wait(for: 1)
+        XCTAssertEqual(
+            transceiver.sender.parameters.degradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        )
+    }
+
     // MARK: - Private
 
     private func makeTransceiver(

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/MediaAdapters/LocalMediaAdapters/LocalVideoMediaAdapter_Tests.swift
@@ -892,6 +892,116 @@ final class LocalVideoMediaAdapter_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    func test_publish_withDefaultDegradationPreference_senderWasUpdated() async throws {
+        let videoOptions = PublishOptions.VideoPublishOptions.dummy(codec: .h264)
+        publishOptions = [videoOptions]
+        let transceiver = try makeTransceiver(of: .video, videoOptions: videoOptions)
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+
+        try await subject.setUp(
+            with: .init(videoOn: true, cameraPosition: .back),
+            ownCapabilities: [.sendVideo]
+        )
+        try await subject.didUpdateCallSettings(.init(videoOn: true))
+
+        await fulfillment {
+            transceiver.sender.parameters.degradationPreference ==
+                NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        }
+    }
+
+    func test_publish_withExplicitDegradationPreference_senderWasUpdated() async throws {
+        let videoOptions = PublishOptions.VideoPublishOptions.dummy(
+            codec: .h264,
+            degradationPreference: .balanced
+        )
+        publishOptions = [videoOptions]
+        let transceiver = try makeTransceiver(of: .video, videoOptions: videoOptions)
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+
+        try await subject.setUp(
+            with: .init(videoOn: true, cameraPosition: .back),
+            ownCapabilities: [.sendVideo]
+        )
+        try await subject.didUpdateCallSettings(.init(videoOn: true))
+
+        await fulfillment {
+            transceiver.sender.parameters.degradationPreference ==
+                NSNumber(value: RTCDegradationPreference.balanced.rawValue)
+        }
+    }
+
+    func test_changePublishQuality_withDegradationPreference_senderWasUpdated() async throws {
+        let transceiver = try makeTransceiver(of: .video, videoOptions: .dummy(codec: .h264))
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+        try await subject.setUp(
+            with: .init(videoOn: true, cameraPosition: .back),
+            ownCapabilities: [.sendVideo]
+        )
+        try await subject.didUpdateCallSettings(.init(videoOn: true))
+        await fulfillment { self.mockPeerConnection.timesCalled(.addTransceiver) == 1 }
+
+        subject.changePublishQuality(
+            with: [
+                .dummy(
+                    codec: .dummy(name: "h264"),
+                    layers: [
+                        .dummy(
+                            name: "q",
+                            isActive: true,
+                            maxFramerate: 30,
+                            maxBitrate: 120,
+                            scaleResolutionDownBy: 2
+                        )
+                    ],
+                    trackType: .video,
+                    degradationPreference: .maintainResolution
+                )
+            ]
+        )
+
+        await fulfillment {
+            transceiver.sender.parameters.degradationPreference ==
+                NSNumber(value: RTCDegradationPreference.maintainResolution.rawValue)
+        }
+    }
+
+    func test_changePublishQuality_withUnspecifiedDegradationPreference_keepsSenderPreference() async throws {
+        let transceiver = try makeTransceiver(of: .video, videoOptions: .dummy(codec: .h264))
+        mockPeerConnection.stub(for: .addTransceiver, with: transceiver)
+        try await subject.setUp(
+            with: .init(videoOn: true, cameraPosition: .back),
+            ownCapabilities: [.sendVideo]
+        )
+        try await subject.didUpdateCallSettings(.init(videoOn: true))
+        await fulfillment { self.mockPeerConnection.timesCalled(.addTransceiver) == 1 }
+
+        subject.changePublishQuality(
+            with: [
+                .dummy(
+                    codec: .dummy(name: "h264"),
+                    layers: [
+                        .dummy(
+                            name: "q",
+                            isActive: true,
+                            maxFramerate: 30,
+                            maxBitrate: 120,
+                            scaleResolutionDownBy: 2
+                        )
+                    ],
+                    trackType: .video,
+                    degradationPreference: .unspecified
+                )
+            ]
+        )
+
+        await wait(for: 1)
+        XCTAssertEqual(
+            transceiver.sender.parameters.degradationPreference,
+            NSNumber(value: RTCDegradationPreference.maintainFramerate.rawValue)
+        )
+    }
+
     // MARK: - Private
 
     private func assertTrackEvent(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1723/featuredegradation-preference-implementation

### 🎯 Goal

Support SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks, while preserving existing `maintainFramerate` behavior when the SFU omits the value.

### 📝 Summary

- Added degradation preference to video publish options with backward-compatible defaulting.
- Mapped SFU degradation preference values to StreamWebRTC sender parameters.
- Applied preferences when creating video/screen-share transceivers and when handling `changePublishQuality`.
- Added focused tests for model mapping, protobuf conversion, sender parameter updates, and no-op cases.
- Updated the changelog with an Upcoming Changed entry.

### 🛠 Implementation

The SDK now carries `degradationPreference` through `PublishOptions.VideoPublishOptions` and writes it back when converting to SFU publish options. A WebRTC mapping helper converts explicit SFU values to `RTCDegradationPreference` raw values, while `.unspecified` and unknown values leave live sender parameters unchanged.

Initial transceiver setup applies the preference from publish options. Runtime `changePublishQuality` events update the existing sender parameters only when the SFU provides an explicit value that differs from the current WebRTC parameter.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks to improve publish-quality handling.

* **Tests**
  * Added comprehensive tests covering degradation preference initialization, mapping to WebRTC values, and runtime updates during video and screen-share publishing.

* **Documentation**
  * Updated changelog to document degradation preference support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-swift/pull/1153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->