### PR TITLE
[Enhancement] Add CallKit handoff for in-app call flows

### DIFF
--- a/Sources/StreamVideo/CallKit/CallKitAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitAdapter.swift
@@ -11,6 +11,9 @@ open class CallKitAdapter {
 
     @Injected(\.callKitPushNotificationAdapter) private var callKitPushNotificationAdapter
     @Injected(\.callKitService) private var callKitService
+    /// Observes calls started or accepted from in-app UI and mirrors them to
+    /// CallKit after the SDK has already created the regular `Call` object.
+    @Injected(\.callKitExternalAdapter) private var callKitExternalAdapter
     @Injected(\.currentDevice) private var currentDevice
 
     private var loggedInStateCancellable: AnyCancellable?
@@ -86,6 +89,10 @@ open class CallKitAdapter {
         }
 
         callKitService.streamVideo = streamVideo
+        // Keep the external bridge on the same authenticated client as the
+        // main CallKit service. The bridge only observes SDK state and asks the
+        // service to create CallKit transactions for in-app call flows.
+        callKitExternalAdapter.streamVideo = streamVideo
 
         guard streamVideo != nil else {
             unregisterForIncomingCalls()

--- a/Sources/StreamVideo/CallKit/CallKitExternalAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitExternalAdapter.swift
@@ -1,0 +1,160 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// Mirrors SDK-owned call state into CallKit when the user starts or accepts
+/// a call from the app UI instead of from CallKit's system UI.
+///
+/// `CallKitService` already owns calls that originate from VoIP pushes because
+/// those calls enter the SDK through `CXProvider.reportNewIncomingCall`. In-app
+/// flows are different: the SDK first sees a regular `Call` state transition
+/// (`ringingCall` or `activeCall`) and CallKit has to be told afterwards that
+/// the same call is now system-managed. This adapter observes the two pieces of
+/// SDK state that describe that transition and asks `CallKitService` to perform
+/// the matching CallKit handoff.
+///
+/// The adapter is intentionally internal. Public apps configure CallKit through
+/// `CallKitAdapter`; this type is a small bridge used by that adapter once a
+/// `StreamVideo` instance is available.
+final class CallKitExternalAdapter: @unchecked Sendable {
+
+    /// Snapshot of the two SDK-level call references that matter to external
+    /// CallKit handoff.
+    ///
+    /// A ringing outgoing call means CallKit should receive a
+    /// `CXStartCallAction`. A ringing call that later becomes the active call
+    /// means CallKit should be told that the outgoing call connected. For
+    /// incoming calls, the accepting stage asks `CallKitService` directly
+    /// because it already has a CallKit UUID from the incoming ring report.
+    private struct State: Equatable {
+        /// Call currently owned by the SDK as an established call.
+        var activeCall: Call?
+        /// Call currently ringing in the SDK, either incoming or outgoing.
+        var ringingCall: Call?
+
+        /// Compares call identity only.
+        ///
+        /// `Call` instances publish a lot of mutable state. The handoff logic
+        /// only cares when the active or ringing call identity changes, so
+        /// comparing `cId` avoids re-running CallKit transactions for unrelated
+        /// participant, settings, or statistics updates.
+        static func == (
+            lhs: CallKitExternalAdapter.State,
+            rhs: CallKitExternalAdapter.State
+        ) -> Bool {
+            lhs.activeCall?.cId == rhs.activeCall?.cId
+                && lhs.ringingCall?.cId == rhs.ringingCall?.cId
+        }
+    }
+
+    @Injected(\.callKitService) private var callKitService
+    @Injected(\.currentDevice) private var currentDevice
+
+    /// Stream client whose call state should be mirrored to CallKit.
+    ///
+    /// `CallKitAdapter` updates this whenever the app logs in or logs out. A
+    /// new value tears down the old Combine subscriptions before installing new
+    /// ones so handoff decisions always belong to the current authenticated
+    /// user.
+    var streamVideo: StreamVideo? {
+        didSet { didUpdate(streamVideo) }
+    }
+
+    private let disposableBag = DisposableBag()
+    private var state: State = .init()
+
+    // MARK: - Private Helpers
+
+    /// Rebuilds observation for the current `StreamVideo` client.
+    ///
+    /// The adapter is disabled on simulator for parity with the rest of the
+    /// CallKit stack. On devices, it observes both active and ringing call
+    /// publishers together so transitions are evaluated from a consistent
+    /// pair of values. State handling ultimately hops to the main actor because
+    /// `CallState` is main-actor isolated and the handoff checks read values
+    /// such as `createdBy`.
+    private func didUpdate(_ streamVideo: StreamVideo?) {
+        disposableBag.removeAll()
+
+        guard
+            let streamVideo,
+            currentDevice.deviceType != .simulator
+        else {
+            return
+        }
+
+        let activeCallPublisher = streamVideo
+            .state
+            .$activeCall
+        let ringingCallPublisher = streamVideo
+            .state
+            .$ringingCall
+
+        Publishers
+            .CombineLatest(activeCallPublisher, ringingCallPublisher)
+            .map { State(activeCall: $0, ringingCall: $1) }
+            .removeDuplicates()
+            .log(.debug, subsystems: .callKit) {
+                "State updated { activeCallCiD:\($0.activeCall?.cId ?? "-"), ringingCallCiD:\($0.ringingCall?.cId ?? "-") }"
+            }
+            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in await self?.didUpdate($0) }
+            .store(in: disposableBag)
+    }
+
+    /// Applies one SDK state snapshot to the CallKit bridge.
+    ///
+    /// Outgoing call handoff happens in two phases:
+    /// 1. The local user creates/rings a call, which publishes a new
+    ///    `ringingCall`. That is the earliest point where CallKit can be asked
+    ///    to start an outgoing system call.
+    /// 2. The same call becomes `activeCall` and the previous ringing value is
+    ///    cleared. That is the point where CallKit can be told the outgoing call
+    ///    connected.
+    ///
+    /// Both checks verify that the call was created by the current user. This
+    /// prevents the external outgoing bridge from handling incoming calls, which
+    /// already have their own CallKit lifecycle through VoIP push reporting.
+    @MainActor
+    private func didUpdate(_ newState: State) async {
+        if
+            let newActiveCall = newState.activeCall,
+            state.ringingCall?.cId == newActiveCall.cId,
+            newState.ringingCall == nil,
+            newActiveCall.state.createdBy?.id == streamVideo?.user.id {
+            await log.throwing(subsystems: .callKit) {
+                await callKitService.reportExternalConnectedOutgoingCall(
+                    newActiveCall
+                )
+            }
+        } else if
+            let newRingingCall = newState.ringingCall,
+            state.ringingCall == nil,
+            state.activeCall == nil,
+            newRingingCall.state.createdBy?.id == streamVideo?.user.id {
+            await log.throwing(subsystems: .callKit) {
+                try await callKitService.reportExternalOutgoingCall(
+                    newRingingCall
+                )
+            }
+        }
+
+        self.state = newState
+    }
+}
+
+extension CallKitExternalAdapter: InjectionKey {
+    /// Provides the current external CallKit bridge.
+    nonisolated(unsafe) static var currentValue: CallKitExternalAdapter = .init()
+}
+
+extension InjectedValues {
+    /// Accessor for the internal adapter that mirrors in-app call flows to
+    /// CallKit.
+    var callKitExternalAdapter: CallKitExternalAdapter {
+        get { Self[CallKitExternalAdapter.self] }
+        set { Self[CallKitExternalAdapter.self] = newValue }
+    }
+}

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -26,20 +26,42 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
     /// Represents a call that is being managed by the service.
     final class CallEntry: Equatable, @unchecked Sendable {
+        /// SDK call object that owns backend and WebRTC lifecycle work.
         var call: Call
+        /// Stable CallKit UUID used for every transaction for this call.
         var callUUID: UUID
+        /// User that created an incoming ringing call, if fetched from backend.
         var createdBy: User?
+        /// Whether CallKit has promoted the call to the active system call.
         var isActive: Bool = false
+        /// Whether the local CallKit ringing timer expired before answer.
         var ringingTimedOut: Bool = false
+        /// Whether backend or another device ended this CallKit entry first.
         var isEndedElsewhere: Bool = false
+        /// Backend rejection or leave reason to apply when CallKit ends it.
         var leaveReason: String?
+        /// Last CallKit presentation metadata associated with this entry.
+        ///
+        /// Incoming calls build this update before calling
+        /// `reportNewIncomingCall`. Outgoing calls build it before requesting
+        /// `CXStartCallAction`. Keeping it with the entry lets follow-up
+        /// CallKit reporting use the same handle, display name, and video
+        /// metadata if a later action needs to refresh the system UI.
+        var callUpdate: CXCallUpdate
 
+        /// Creates a bridge entry between one SDK call and one CallKit UUID.
+        ///
+        /// `callUUID` must stay stable for the whole CallKit lifecycle. CallKit
+        /// treats every action (`start`, `answer`, `mute`, `end`) as belonging
+        /// to that UUID, while the SDK continues to identify the call by `cId`.
         init(
             call: Call,
-            callUUID: UUID = .init()
+            callUUID: UUID = .init(),
+            callUpdate: CXCallUpdate
         ) {
             self.call = call
             self.callUUID = callUUID
+            self.callUpdate = callUpdate
         }
 
         static func == (
@@ -499,10 +521,64 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
     open func provider(
         _ provider: CXProvider,
+        perform action: CXStartCallAction
+    ) {
+        // CallKit only sends this action after the SDK has requested a start
+        // transaction. If the UUID is missing, the transaction no longer maps
+        // to an SDK call and must fail so the system does not show a stale call.
+        guard
+            let callEntry = callEntry(for: action.callUUID)
+        else {
+            action.fail()
+            return
+        }
+
+        if action.callUUID != active {
+            // This is the first start action for the outgoing call. Marking the
+            // UUID active makes later CallKit actions, especially end and mute,
+            // use the "active call" branch rather than the ringing reject path.
+            active = action.callUUID
+            callEntry.isActive = true
+            Task(disposableBag: disposableBag) { @MainActor [weak self] in
+                guard let self else { return }
+                // The app still owns the SDK join flow, but WebRTC must know
+                // the call has been handed to CallKit before audio is
+                // configured. This prevents WebRTC from activating the audio
+                // session independently while CallKit owns it.
+                callEntry.call.state.joinSource = .callKit(.init {})
+
+                // `startedConnectingAt` moves the system call from "dialing"
+                // to "connecting". The SDK reports "connected" separately once
+                // the same call becomes `StreamVideo.State.activeCall`.
+                callProvider.reportOutgoingCall(
+                    with: action.callUUID,
+                    startedConnectingAt: Date()
+                )
+                action.fulfill()
+            }
+        } else if action.callUUID == active {
+            // Defensive branch for repeated start actions for an already active
+            // UUID. The normal connected transition is reported by
+            // `reportExternalConnectedOutgoingCall(_:)`, but fulfilling here
+            // keeps CallKit from leaving a valid duplicate action pending.
+            Task(disposableBag: disposableBag) { @MainActor [weak self] in
+                guard let self else { return }
+                callProvider.reportOutgoingCall(
+                    with: action.callUUID,
+                    connectedAt: Date()
+                )
+                action.fulfill()
+            }
+        } else {
+            action.fail()
+        }
+    }
+
+    open func provider(
+        _ provider: CXProvider,
         perform action: CXAnswerCallAction
     ) {
         guard
-            action.callUUID != active,
             let callToJoinEntry = callEntry(for: action.callUUID)
         else {
             return action.fail()
@@ -510,64 +586,76 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
 
         ringingTimerCancellable?.cancel()
         ringingTimerCancellable = nil
-        active = action.callUUID
-        callToJoinEntry.call.didPerform(.performAnswerCall)
 
-        Task(disposableBag: disposableBag) { @MainActor [weak self] in
-            guard let self else {
-                return
-            }
-            log
-                .debug(
+        if action.callUUID == active {
+            // The in-app incoming-call screen has already promoted this UUID
+            // before requesting `CXAnswerCallAction`. In that case the SDK
+            // accepting stage continues with the backend accept, so this
+            // delegate path only confirms the CallKit UI transition.
+            action.fulfill()
+            log.debug(
+                "VoIP incoming call with callId:\(callToJoinEntry.call.callId) callType:\(callToJoinEntry.call.callType) callerId:\(callToJoinEntry.createdBy?.id) was answered from inApp call screen.",
+                subsystems: .callKit
+            )
+        } else {
+            active = action.callUUID
+            callToJoinEntry.call.didPerform(.performAnswerCall)
+
+            Task(disposableBag: disposableBag) { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+                log.debug(
                     "Answering VoIP incoming call with callId:\(callToJoinEntry.call.callId) callType:\(callToJoinEntry.call.callType) callerId:\(callToJoinEntry.createdBy?.id)."
                 )
 
-            do {
-                // Mark the CallKit accept before the async join work starts so
-                // the UI can keep the call in a transitional state while the
-                // app is waking up.
-                eventPipelineSubject.send(.accept)
-                try await callToJoinEntry.call.accept()
-                // We need to fulfil here the action to allow CallKit to release
-                // the audioSession to the app, for activation.
-                action.fulfill()
-            } catch {
-                log.error(error, subsystems: .callKit)
-                action.fail()
-            }
-
-            do {
-                // Publish the concrete call as soon as the join flow starts so
-                // CallViewModel can present the joining screen even when the
-                // app was launched from CallKit in the background.
-                eventPipelineSubject.send(.joining(callToJoinEntry.call))
-                // Pass a CallKit completion hook through the join flow so the
-                // WebRTC layer can release CallKit's audio session ownership as
-                // soon as it has configured the audio device module.
-                callToJoinEntry.call.state.joinSource = .callKit(.init {
-                    // Allow CallKit to hand audio session activation back to
-                    // the app before we continue configuring audio locally.
+                do {
+                    // Mark the CallKit accept before the async join work starts so
+                    // the UI can keep the call in a transitional state while the
+                    // app is waking up.
+                    eventPipelineSubject.send(.accept)
+                    try await callToJoinEntry.call.accept()
+                    // We need to fulfil here the action to allow CallKit to release
+                    // the audioSession to the app, for activation.
                     action.fulfill()
-                })
+                } catch {
+                    log.error(error, subsystems: .callKit)
+                    action.fail()
+                }
 
-                // Before reach here we should fulfil the action to allow
-                // CallKit to release the audioSession, so that the SDK
-                // can configure and activate it and complete successfully the
-                // peerConnection configuration.
-                try await callToJoinEntry.call.join(
-                    callSettings: callSettings,
-                    policy: .peerConnectionReadinessAware
-                )
-                // Once the call is joined, the regular call state can take
-                // over and the temporary CallKit bridge can stand down.
-                eventPipelineSubject.send(.joined)
-            } catch {
-                callToJoinEntry.call.leave()
-                set(nil, for: action.callUUID)
-                log.error(error, subsystems: .callKit)
-                // Reset the bridge if the CallKit-driven join flow aborts
-                // before the call becomes active.
-                eventPipelineSubject.send(.idle)
+                do {
+                    // Publish the concrete call as soon as the join flow starts so
+                    // CallViewModel can present the joining screen even when the
+                    // app was launched from CallKit in the background.
+                    eventPipelineSubject.send(.joining(callToJoinEntry.call))
+                    // Pass a CallKit completion hook through the join flow so the
+                    // WebRTC layer can release CallKit's audio session ownership as
+                    // soon as it has configured the audio device module.
+                    callToJoinEntry.call.state.joinSource = .callKit(.init {
+                        // Allow CallKit to hand audio session activation back to
+                        // the app before we continue configuring audio locally.
+                        action.fulfill()
+                    })
+
+                    // Before reach here we should fulfil the action to allow
+                    // CallKit to release the audioSession, so that the SDK
+                    // can configure and activate it and complete successfully the
+                    // peerConnection configuration.
+                    try await callToJoinEntry.call.join(
+                        callSettings: callSettings,
+                        policy: .peerConnectionReadinessAware
+                    )
+                    // Once the call is joined, the regular call state can take
+                    // over and the temporary CallKit bridge can stand down.
+                    eventPipelineSubject.send(.joined)
+                } catch {
+                    callToJoinEntry.call.leave()
+                    set(nil, for: action.callUUID)
+                    log.error(error, subsystems: .callKit)
+                    // Reset the bridge if the CallKit-driven join flow aborts
+                    // before the call becomes active.
+                    eventPipelineSubject.send(.idle)
+                }
             }
         }
     }
@@ -912,18 +1000,31 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         callerId: String,
         hasVideo: Bool
     ) -> (UUID, CXCallUpdate) {
-        let update = CXCallUpdate()
         let idComponents = cid.components(separatedBy: ":")
         let uuid = uuidFactory.get()
+        let update = buildCXUpdate(
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: hasVideo
+        )
         if
             idComponents.count >= 2,
             let call = streamVideo?.call(
                 callType: idComponents[0],
                 callId: idComponents[1]
             ) {
-            set(.init(call: call, callUUID: uuid), for: uuid)
+            set(.init(call: call, callUUID: uuid, callUpdate: update), for: uuid)
         }
 
+        return (uuid, update)
+    }
+
+    private func buildCXUpdate(
+        localizedCallerName: String,
+        callerId: String,
+        hasVideo: Bool
+    ) -> CXCallUpdate {
+        let update = CXCallUpdate()
         update.localizedCallerName = localizedCallerName
         update.remoteHandle = CXHandle(type: .generic, value: callerId)
         update.hasVideo = hasVideo
@@ -939,8 +1040,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             update.supportsHolding = false
             update.supportsUngrouping = false
         }
-
-        return (uuid, update)
+        return update
     }
 
     // MARK: - Storage Access
@@ -1049,5 +1149,98 @@ extension InjectedValues {
     public var callKitService: CallKitService {
         get { Self[CallKitService.self] }
         set { Self[CallKitService.self] = newValue }
+    }
+}
+
+extension CallKitService {
+
+    /// Promotes an existing incoming CallKit call after in-app accept.
+    ///
+    /// Incoming calls are normally registered with CallKit when the VoIP push
+    /// arrives, so by the time the app's custom incoming-call screen appears
+    /// this service already has a `CallEntry` and a CallKit UUID. When the user
+    /// taps the in-app accept button, the SDK still has to tell CallKit that the
+    /// system call is no longer ringing. The supported CallKit transition for
+    /// that is a `CXAnswerCallAction`.
+    ///
+    /// The method sets `active` before requesting the transaction so the
+    /// delegate can distinguish this in-app handoff from a CallKit UI answer.
+    /// It also marks the call as `.callKit` sourced so the later WebRTC join
+    /// uses CallKit's audio session ownership.
+    @MainActor
+    func reportExternalIncomingCallConnecting(_ call: Call) async throws {
+        guard let callEntry = callEntry(for: call.cId) else {
+            return
+        }
+
+        callEntry.isActive = true
+        active = callEntry.callUUID
+        call.state.joinSource = .callKit(.init {})
+
+        try await requestTransaction(
+            CXAnswerCallAction(call: callEntry.callUUID)
+        )
+    }
+
+    /// Registers an SDK-created outgoing ringing call with CallKit.
+    ///
+    /// The app starts the call from its own UI, so there is no CallKit UUID yet.
+    /// This method creates one, stores the SDK call beside the CallKit metadata,
+    /// and requests a `CXStartCallAction`. CallKit then calls
+    /// `provider(_:perform:)`, where the service reports the system call as
+    /// connecting.
+    ///
+    /// The provider is touched before the transaction is requested. Without a
+    /// live `CXProvider`, CallKit can reject `CXStartCallAction` with
+    /// `unknownCallProvider`.
+    @MainActor
+    func reportExternalOutgoingCall(_ call: Call) async throws {
+        guard callEntry(for: call.cId) == nil else {
+            return
+        }
+
+        _ = callProvider
+        call.state.joinSource = .callKit(.init {})
+        let update = buildCXUpdate(
+            localizedCallerName: call.state.createdBy?.name ?? "Unknown",
+            callerId: call.state.createdBy?.id ?? "unknown",
+            hasVideo: call.state.callSettings.videoOn
+        )
+
+        let uuid = uuidFactory.get()
+        set(.init(call: call, callUUID: uuid, callUpdate: update), for: uuid)
+
+        let memberIds = call
+            .state
+            .members.map(\.id)
+            .filter { streamVideo?.user.id != $0 }.joined(separator: ",")
+
+        try await requestTransaction(
+            CXStartCallAction(
+                call: uuid,
+                handle: CXHandle(type: .generic, value: memberIds)
+            )
+        )
+    }
+
+    /// Reports that an externally started outgoing CallKit call connected.
+    ///
+    /// The SDK emits this once the same outgoing call becomes
+    /// `StreamVideo.State.activeCall`. At that point the call is no longer just
+    /// ringing locally; WebRTC has joined and CallKit can move the system UI to
+    /// the connected in-call state.
+    @MainActor
+    func reportExternalConnectedOutgoingCall(_ call: Call) async {
+        guard
+            let callEntry = callEntry(for: call.cId),
+            active == callEntry.callUUID
+        else {
+            return
+        }
+
+        callProvider.reportOutgoingCall(
+            with: callEntry.callUUID,
+            connectedAt: Date()
+        )
     }
 }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+AcceptingStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+AcceptingStage.swift
@@ -24,6 +24,15 @@ extension Call.StateMachine.Stage {
 
     /// Represents the accepting stage in the call state machine.
     final class AcceptingStage: Call.StateMachine.Stage, @unchecked Sendable {
+        /// CallKit bridge used to promote an already reported incoming system
+        /// call when the user accepts from the app's own incoming-call screen.
+        ///
+        /// If CallKit does not know the call, the bridge is a no-op and the
+        /// normal backend accept continues. If CallKit does know the call, this
+        /// asks CallKit to perform `CXAnswerCallAction` before the backend
+        /// accept so the system UI and audio session move to the in-call state.
+        @Injected(\.callKitService) private var callKitService
+
         private let disposableBag = DisposableBag()
 
         /// Creates a new accepting stage with the provided context.
@@ -73,6 +82,14 @@ extension Call.StateMachine.Stage {
                 }
 
                 do {
+                    try Task.checkCancellation()
+
+                    // Keep CallKit in sync before the backend accept. This
+                    // covers foreground incoming calls that were already
+                    // reported to CallKit but accepted from the app UI instead
+                    // of the native CallKit answer affordance.
+                    try await callKitService.reportExternalIncomingCallConnecting(call)
+
                     try Task.checkCancellation()
 
                     let response = try await call.coordinatorClient.acceptCall(

--- a/Sources/StreamVideo/Utils/Logger/Logger+ThrowingExecution.swift
+++ b/Sources/StreamVideo/Utils/Logger/Logger+ThrowingExecution.swift
@@ -29,4 +29,33 @@ extension Logger {
             )
         }
     }
+
+    /// Executes an async throwing operation and logs failures with call-site
+    /// metadata.
+    ///
+    /// This is useful for fire-and-forget bridge work such as best-effort
+    /// CallKit reporting. The caller wants failures to appear in logs with the
+    /// original file, function, and line, but it should not fail the surrounding
+    /// Combine or state-observation pipeline.
+    func throwing(
+        _ message: @autoclosure () -> String = "",
+        subsystems: LogSubsystem,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line,
+        _ operation: @Sendable () async throws -> Void
+    ) async {
+        do {
+            try await operation()
+        } catch {
+            self.error(
+                message(),
+                subsystems: subsystems,
+                error: error,
+                functionName: function,
+                fileName: file,
+                lineNumber: line
+            )
+        }
+    }
 }

--- a/Sources/StreamVideo/Utils/Swift6Migration/Sendable+Extensions.swift
+++ b/Sources/StreamVideo/Utils/Swift6Migration/Sendable+Extensions.swift
@@ -20,6 +20,7 @@ extension AVCaptureDevice: @retroactive @unchecked Sendable {}
 extension AVCapturePhotoOutput: @retroactive @unchecked Sendable {}
 extension AVCaptureVideoDataOutput: @retroactive @unchecked Sendable {}
 extension CMSampleBuffer: @retroactive @unchecked Sendable {}
+extension CXStartCallAction: @retroactive @unchecked Sendable {}
 extension CXAnswerCallAction: @retroactive @unchecked Sendable {}
 extension CXSetHeldCallAction: @retroactive @unchecked Sendable {}
 extension CXSetMutedCallAction: @retroactive @unchecked Sendable {}
@@ -46,6 +47,7 @@ extension AVCapturePhotoOutput: @unchecked Sendable {}
 extension AVCaptureVideoDataOutput: @unchecked Sendable {}
 extension CMSampleBuffer: @unchecked Sendable {}
 extension CXAnswerCallAction: @unchecked Sendable {}
+extension CXStartCallAction: @unchecked Sendable {}
 extension CXSetHeldCallAction: @unchecked Sendable {}
 extension CXSetMutedCallAction: @unchecked Sendable {}
 extension KeyPath: @unchecked Sendable {}

--- a/StreamVideoTests/CallKit/CallKitAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitAdapterTests.swift
@@ -9,6 +9,7 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
 
     private lazy var callKitPushNotificationAdapter: MockCallKitPushNotificationAdapter! = .init()
     private lazy var callKitService: MockCallKitService! = .init()
+    private lazy var callKitExternalAdapter: CallKitExternalAdapter! = .init()
     private lazy var subject: CallKitAdapter! = .init()
 
     @MainActor
@@ -17,12 +18,14 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
         _ = MockStreamVideo()
         InjectedValues[\.callKitPushNotificationAdapter] = callKitPushNotificationAdapter
         InjectedValues[\.callKitService] = callKitService
+        InjectedValues[\.callKitExternalAdapter] = callKitExternalAdapter
         CurrentDevice.currentValue.didUpdate(.phone)
     }
 
     override func tearDown() {
         callKitPushNotificationAdapter = nil
         callKitService = nil
+        callKitExternalAdapter = nil
         subject = nil
         super.tearDown()
     }
@@ -58,6 +61,7 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
 
         // Then
         XCTAssertTrue(callKitService.streamVideo === streamVideo)
+        XCTAssertTrue(callKitExternalAdapter.streamVideo === streamVideo)
         XCTAssertTrue(callKitPushNotificationAdapter.registerWasCalled)
     }
 
@@ -67,6 +71,7 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
 
         // Then
         XCTAssertNil(callKitService.streamVideo)
+        XCTAssertNil(callKitExternalAdapter.streamVideo)
         XCTAssertTrue(callKitPushNotificationAdapter.unregisterWasCalled)
     }
 

--- a/StreamVideoTests/CallKit/CallKitExternalAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitExternalAdapterTests.swift
@@ -1,0 +1,158 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import CallKit
+import Foundation
+@testable import StreamVideo
+import XCTest
+
+final class CallKitExternalAdapterTests: XCTestCase, @unchecked Sendable {
+
+    private var callKitService: CallKitService!
+    private var callController: MockCXCallController!
+    private var callProvider: MockCXProvider!
+    private var uuidFactory: MockUUIDFactory!
+    private var user: User!
+    private var streamVideo: MockStreamVideo! = .init()
+    private var subject: CallKitExternalAdapter!
+
+    @MainActor
+    override func setUp() async throws {
+        try await super.setUp()
+        CurrentDevice.currentValue.didUpdate(.phone)
+        callKitService = .init()
+        callController = .init()
+        callProvider = .init()
+        uuidFactory = .init()
+        user = .init(id: "current-user")
+        streamVideo = .init(user: user)
+        subject = .init()
+        InjectedValues[\.callKitService] = callKitService
+        InjectedValues[\.uuidFactory] = uuidFactory
+        callKitService.callController = callController
+        callKitService.callProvider = callProvider
+        callKitService.streamVideo = streamVideo
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        CurrentDevice.currentValue.didUpdate(.simulator)
+        subject = nil
+        streamVideo = nil
+        user = nil
+        uuidFactory = nil
+        callProvider = nil
+        callController = nil
+        callKitService = nil
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func test_ringingOutgoingCall_requestsStartCallAction() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = makeOutgoingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = streamVideo
+
+        streamVideo.state.ringingCall = call
+
+        await fulfilmentInMainActor {
+            self.callController.requestWasCalledWith?.0.actions.last is CXStartCallAction
+        }
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXStartCallAction
+        )
+        XCTAssertEqual(action.callUUID, callUUID)
+        XCTAssertEqual(action.handle.value, "remote")
+    }
+
+    @MainActor
+    func test_ringingOutgoingCallBecomesActive_reportsOutgoingCallConnected() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = makeOutgoingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = streamVideo
+
+        streamVideo.state.ringingCall = call
+        await fulfilmentInMainActor {
+            self.callController.requestWasCalledWith?.0.actions.last is CXStartCallAction
+        }
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXStartCallAction
+        )
+        callKitService.provider(callProvider, perform: action)
+        await fulfilmentInMainActor {
+            if case .reportOutgoingCallStartedConnecting = self.callProvider.invocations.last {
+                return true
+            } else {
+                return false
+            }
+        }
+        callProvider.reset()
+
+        streamVideo.state.activeCall = call
+
+        await fulfilmentInMainActor {
+            if case .reportOutgoingCallConnected = self.callProvider.invocations.last {
+                return true
+            } else {
+                return false
+            }
+        }
+        guard case let .reportOutgoingCallConnected(uuid, date) = callProvider.invocations.last else {
+            return XCTFail()
+        }
+        XCTAssertEqual(uuid, callUUID)
+        XCTAssertNotNil(date)
+    }
+
+    @MainActor
+    func test_ringingIncomingCall_doesNotRequestStartCallAction() async {
+        let call = makeIncomingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = streamVideo
+
+        streamVideo.state.ringingCall = call
+
+        await wait(for: 1)
+        XCTAssertNil(callController.requestWasCalledWith)
+    }
+
+    // MARK: - Private Helpers
+
+    @MainActor
+    private func makeOutgoingCall(
+        remoteUserIds: [String]
+    ) -> MockCall {
+        makeCall(createdBy: user, remoteUserIds: remoteUserIds)
+    }
+
+    @MainActor
+    private func makeIncomingCall(
+        remoteUserIds: [String]
+    ) -> MockCall {
+        makeCall(createdBy: .init(id: "caller"), remoteUserIds: remoteUserIds)
+    }
+
+    @MainActor
+    private func makeCall(
+        createdBy: User,
+        remoteUserIds: [String]
+    ) -> MockCall {
+        let call = MockCall(.dummy())
+        let callState = CallState(.dummy())
+        callState.createdBy = createdBy
+        callState.members = [Member(user: user, updatedAt: Date())]
+            + remoteUserIds.map { Member(user: .init(id: $0), updatedAt: Date()) }
+        call.stub(for: \.state, with: callState)
+        return call
+    }
+}
+
+private final class MockUUIDFactory: UUIDProviding {
+    var getResult: UUID?
+
+    func get() -> UUID {
+        getResult ?? .init()
+    }
+}

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -580,6 +580,159 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - external CallKit handoff
+
+    @MainActor
+    func test_reportExternalOutgoingCall_requestsStartCallActionAndStoresCallKitJoinSource() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = makeExternalOutgoingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = mockedStreamVideo
+
+        try await subject.reportExternalOutgoingCall(call)
+
+        await fulfillment {
+            self.callController.requestWasCalledWith?.0.actions.last is CXStartCallAction
+        }
+
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXStartCallAction
+        )
+        XCTAssertEqual(action.callUUID, callUUID)
+        XCTAssertEqual(action.handle.value, "remote")
+
+        guard case .callKit = call.state.joinSource else {
+            return XCTFail("Expected outgoing handoff to mark joinSource as CallKit.")
+        }
+    }
+
+    @MainActor
+    func test_reportExternalOutgoingCall_callAlreadyStored_doesNotRequestSecondStartAction() async throws {
+        let call = makeExternalOutgoingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = mockedStreamVideo
+
+        try await subject.reportExternalOutgoingCall(call)
+        await fulfillment {
+            self.callController.requestWasCalledWith?.0.actions.last is CXStartCallAction
+        }
+
+        callController.reset()
+        try await subject.reportExternalOutgoingCall(call)
+
+        await waitExpectation(timeout: 1)
+        XCTAssertNil(callController.requestWasCalledWith)
+    }
+
+    @MainActor
+    func test_providerStartCall_firstStart_reportsOutgoingCallConnecting() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = makeExternalOutgoingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = mockedStreamVideo
+        try await subject.reportExternalOutgoingCall(call)
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXStartCallAction
+        )
+        callProvider.reset()
+
+        subject.provider(callProvider, perform: action)
+
+        await fulfillment {
+            if case .reportOutgoingCallStartedConnecting = self.callProvider.invocations.last {
+                return true
+            } else {
+                return false
+            }
+        }
+        guard case let .reportOutgoingCallStartedConnecting(uuid, date) = callProvider.invocations.last else {
+            return XCTFail()
+        }
+        XCTAssertEqual(uuid, callUUID)
+        XCTAssertNotNil(date)
+        XCTAssertEqual(subject.callId, call.callId)
+    }
+
+    @MainActor
+    func test_reportExternalConnectedOutgoingCall_activeCall_reportsOutgoingCallConnected() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = makeExternalOutgoingCall(remoteUserIds: ["remote"])
+        subject.streamVideo = mockedStreamVideo
+        try await subject.reportExternalOutgoingCall(call)
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXStartCallAction
+        )
+        subject.provider(callProvider, perform: action)
+        await fulfillment {
+            if case .reportOutgoingCallStartedConnecting = self.callProvider.invocations.last {
+                return true
+            } else {
+                return false
+            }
+        }
+        callProvider.reset()
+
+        await subject.reportExternalConnectedOutgoingCall(call)
+
+        guard case let .reportOutgoingCallConnected(uuid, date) = callProvider.invocations.last else {
+            return XCTFail()
+        }
+        XCTAssertEqual(uuid, callUUID)
+        XCTAssertNotNil(date)
+    }
+
+    @MainActor
+    func test_reportExternalIncomingCallConnecting_existingIncomingCall_requestsAnswerCallAction() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        subject.streamVideo = mockedStreamVideo
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+        await waitExpectation(timeout: 1)
+        callController.reset()
+
+        try await subject.reportExternalIncomingCallConnecting(call)
+
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXAnswerCallAction
+        )
+        XCTAssertEqual(action.callUUID, callUUID)
+        XCTAssertEqual(subject.callId, call.callId)
+        guard case .callKit = call.state.joinSource else {
+            return XCTFail("Expected incoming handoff to mark joinSource as CallKit.")
+        }
+    }
+
+    @MainActor
+    func test_providerAnswerCall_whenIncomingCallWasAcceptedInApp_doesNotAcceptOrJoinAgain() async throws {
+        let callUUID = UUID()
+        uuidFactory.getResult = callUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        subject.streamVideo = mockedStreamVideo
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+        await waitExpectation(timeout: 1)
+        try await subject.reportExternalIncomingCallConnecting(call)
+        let action = try XCTUnwrap(
+            callController.requestWasCalledWith?.0.actions.last as? CXAnswerCallAction
+        )
+
+        subject.provider(callProvider, perform: action)
+
+        await waitExpectation(timeout: 1)
+        XCTAssertEqual(call.timesCalled(.accept), 0)
+        XCTAssertEqual(call.timesCalled(.join), 0)
+    }
+
     // MARK: - accept
 
     @MainActor
@@ -1526,6 +1679,21 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         let mockedState = mockedStreamVideo.state
         mockedState.connection = status
         mockedStreamVideo.stub(for: \.state, with: mockedState)
+    }
+
+    @MainActor
+    private func makeExternalOutgoingCall(
+        remoteUserIds: [String],
+        videoOn: Bool = true
+    ) -> MockCall {
+        let call = MockCall(.dummy(callId: callId))
+        let callState = CallState(.dummy())
+        callState.createdBy = user
+        callState.callSettings = .init(audioOn: true, videoOn: videoOn)
+        callState.members = [Member(user: user, updatedAt: Date())]
+            + remoteUserIds.map { Member(user: .init(id: $0), updatedAt: Date()) }
+        call.stub(for: \.state, with: callState)
+        return call
     }
 
     @MainActor

--- a/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
@@ -9,6 +9,8 @@ final class MockCXProvider: CXProvider {
     enum Invocation {
         case reportNewIncomingCall(uuid: UUID, update: CXCallUpdate, completion: (Error?) -> Void)
         case reportCall(uuid: UUID, endedAt: Date?, reason: CXCallEndedReason)
+        case reportOutgoingCallStartedConnecting(uuid: UUID, date: Date?)
+        case reportOutgoingCallConnected(uuid: UUID, date: Date?)
     }
 
     private(set) var invocations: [Invocation] = []
@@ -42,6 +44,30 @@ final class MockCXProvider: CXProvider {
                 uuid: UUID,
                 endedAt: dateEnded,
                 reason: endedReason
+            )
+        )
+    }
+
+    override func reportOutgoingCall(
+        with UUID: UUID,
+        startedConnectingAt dateStartedConnecting: Date?
+    ) {
+        invocations.append(
+            .reportOutgoingCallStartedConnecting(
+                uuid: UUID,
+                date: dateStartedConnecting
+            )
+        )
+    }
+
+    override func reportOutgoingCall(
+        with UUID: UUID,
+        connectedAt dateConnected: Date?
+    ) {
+        invocations.append(
+            .reportOutgoingCallConnected(
+                uuid: UUID,
+                date: dateConnected
             )
         )
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1732/blinkcallkit-controls-when-the-call-answered-from-incoming-callscreen

### 🎯 Goal

Allow calls started or accepted from the app UI to be handed over to CallKit so the system UI, audio session ownership, and CallKit controls stay in sync even when the user did not answer from CallKit's native UI.

### 📝 Summary

- Added an internal `CallKitExternalAdapter` that observes SDK `activeCall` and `ringingCall` state and mirrors eligible in-app call flows to CallKit.
- Added CallKit service hooks for externally handled incoming and outgoing calls.
- Added `CXStartCallAction` handling for outgoing calls started from in-app UI.
- Marked in-app CallKit handoffs with `JoinSource.callKit` so WebRTC respects CallKit audio-session ownership.
- Added focused CallKit tests for external incoming/outgoing handoff behavior.

### 🛠 Implementation

`CallKitAdapter` now wires the active `StreamVideo` client into both the existing CallKit service and the new external adapter.

`CallKitExternalAdapter` watches SDK call state transitions:
- outgoing `ringingCall` created by current user triggers `CXStartCallAction`;
- that same call becoming active reports the outgoing CallKit call as connected;
- incoming calls are ignored by this adapter because they already enter CallKit through incoming call reporting.

`CallKitService` now stores CallKit update metadata with each call entry, handles outgoing start actions, and exposes internal APIs for in-app handoff:
- `reportExternalOutgoingCall(_:)`
- `reportExternalConnectedOutgoingCall(_:)`
- `reportExternalIncomingCallConnecting(_:)`

The accepting stage asks CallKit to promote an already reported incoming call before continuing the backend accept flow, keeping CallKit UI aligned with in-app accept.

### 🧪 Manual Testing Notes

- Start an outgoing ringing call from app UI and verify CallKit shows the outgoing call as connecting, then connected after join.
- Receive an incoming CallKit-ringing call, accept from the app UI, and verify CallKit transitions to in-call instead of staying in ringing state.
- End and mute from CallKit controls and verify SDK call state follows existing CallKit paths.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)