### PR TITLE
[Enhancement] Integrate CallJoinInterceptor in the CallKit flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Added support for SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks.[#1153](https://github.com/GetStream/stream-video-swift/pull/1153)
+- Exposed `callJoinInterceptor` on `CallKitAdapter` and `CallKitService` so CallKit-answered calls honor `CallJoinIntercepting`. [#1160](https://github.com/GetStream/stream-video-swift/pull/1160)
 
 # [1.47.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.1)
 _May 26, 2026_

--- a/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
+++ b/DemoApp/Sources/Components/DemoCallJoinInterceptor/DemoCallJoinInterceptor.swift
@@ -62,6 +62,7 @@ final class DemoCallJoinInterceptor: CallJoinIntercepting {
         }
 
         _ = try? await hasOtherReadyParticipants
+            .receive(on: DispatchQueue.main)
             .filter { $0 }
             .nextValue()
     }
@@ -77,6 +78,7 @@ final class DemoCallJoinInterceptor: CallJoinIntercepting {
 
         customEventCancellable = ringingCall
             .eventPublisher(for: CustomVideoEvent.self)
+            .receive(on: DispatchQueue.main)
             .compactMap { [customEventKey] in $0.custom[customEventKey]?.stringValue }
             .filter { [currentUserID] in $0 != currentUserID }
             .log(LogLevel.debug) { "Call presence event was received for userID:\($0)" }

--- a/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
+++ b/DemoApp/Sources/Views/CallView/CallingView/DemoCallingViewModifier.swift
@@ -56,6 +56,7 @@ struct DemoCallingViewModifier: ViewModifier {
             }
             .onAppear {
                 guard !isAnonymous else { return }
+                callKitAdapter.callJoinInterceptor = AppEnvironment.callJoinInterceptor.value
                 callKitAdapter.participantAutoLeavePolicy =
                     AppEnvironment.autoLeavePolicy.policy
                 callKitAdapter.registerForIncomingCalls()

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/10-call-join-interceptor.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/10-call-join-interceptor.swift
@@ -84,4 +84,22 @@ private func content() {
         let callViewModel = CallViewModel()
         callViewModel.callJoinInterceptor = ParticipantReadyCallJoinInterceptor(streamVideo: streamVideo)
     }
+
+    container {
+        @MainActor
+        final class ParticipantReadyCallJoinInterceptor: CallJoinIntercepting {
+            private let streamVideo: StreamVideo
+
+            init(streamVideo: StreamVideo) {
+                self.streamVideo = streamVideo
+            }
+
+            func callReadyToJoin(_ call: Call) async throws { /* Readiness work goes here. */ }
+        }
+
+        // Assign the interceptor on the adapter so calls answered through
+        // CallKit honor it too.
+        @Injected(\.callKitAdapter) var callKitAdapter
+        callKitAdapter.callJoinInterceptor = ParticipantReadyCallJoinInterceptor(streamVideo: streamVideo)
+    }
 }

--- a/Sources/StreamVideo/CallKit/CallKitAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitAdapter.swift
@@ -57,6 +57,17 @@ open class CallKitAdapter {
         didSet { didUpdate(streamVideo) }
     }
 
+    /// Optional interceptor invoked after the call join response has been
+    /// applied locally but before the SDK treats the call as fully entered.
+    ///
+    /// Assign this when your app needs to perform readiness work during the
+    /// join flow, such as waiting for another participant or validating an
+    /// external precondition. Throw from the interceptor to fail the join.
+    public var callJoinInterceptor: CallJoinIntercepting? {
+        get { callKitService.callJoinInterceptor }
+        set { callKitService.callJoinInterceptor = newValue }
+    }
+
     /// Initializes the `CallKitAdapter`.
     public init() {}
 

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -571,7 +571,14 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 // over and the temporary CallKit bridge can stand down.
                 eventPipelineSubject.send(.joined)
             } catch {
-                callToJoinEntry.call.leave()
+                // Interceptor vetoes and join timeouts already leave the call
+                // (with their specific reasons) inside the join flow. Issuing
+                // another leave here would race that one and could drop the
+                // original leave reason, so only leave for failures the join
+                // flow has not already handled.
+                if !(error is CallJoinInterceptionError), !(error is TimeOutError) {
+                    callToJoinEntry.call.leave()
+                }
                 // The answer action has already been fulfilled at this point,
                 // so CallKit must be told explicitly that the call failed
                 // (e.g. when a join interceptor vetoed the join). Otherwise

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -138,6 +138,14 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         }
     }
 
+    /// Optional interceptor invoked after the call join response has been
+    /// applied locally but before the SDK treats the call as fully entered.
+    ///
+    /// Assign this when your app needs to perform readiness work during the
+    /// join flow, such as waiting for another participant or validating an
+    /// external precondition. Throw from the interceptor to fail the join.
+    public var callJoinInterceptor: CallJoinIntercepting?
+
     var callSettings: CallSettings?
 
     /// The call controller used for managing calls.
@@ -556,13 +564,23 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 // peerConnection configuration.
                 try await callToJoinEntry.call.join(
                     callSettings: callSettings,
-                    policy: .peerConnectionReadinessAware
+                    policy: .peerConnectionReadinessAware,
+                    joinInterceptor: callJoinInterceptor
                 )
                 // Once the call is joined, the regular call state can take
                 // over and the temporary CallKit bridge can stand down.
                 eventPipelineSubject.send(.joined)
             } catch {
                 callToJoinEntry.call.leave()
+                // The answer action has already been fulfilled at this point,
+                // so CallKit must be told explicitly that the call failed
+                // (e.g. when a join interceptor vetoed the join). Otherwise
+                // the system keeps presenting an ongoing call.
+                callProvider.reportCall(
+                    with: action.callUUID,
+                    endedAt: nil,
+                    reason: .failed
+                )
                 set(nil, for: action.callUUID)
                 log.error(error, subsystems: .callKit)
                 // Reset the bridge if the CallKit-driven join flow aborts

--- a/StreamVideoTests/CallKit/CallKitAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitAdapterTests.swift
@@ -91,6 +91,23 @@ final class CallKitAdapterTests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    // MARK: - callJoinInterceptor
+
+    func test_callJoinInterceptor_whenSet_forwardsValueToCallKitService() throws {
+        let interceptor = StubCallJoinInterceptor()
+
+        subject.callJoinInterceptor = interceptor
+
+        XCTAssertIdentical(
+            try XCTUnwrap(callKitService.callJoinInterceptor) as AnyObject,
+            interceptor
+        )
+        XCTAssertIdentical(
+            try XCTUnwrap(subject.callJoinInterceptor) as AnyObject,
+            interceptor
+        )
+    }
+
     // MARK: - Private Helpers
 
     private func makeStreamVideo() async throws -> StreamVideo {
@@ -118,4 +135,8 @@ private final class MockParticipantAutoLeavePolicy:
     ParticipantAutoLeavePolicy,
     @unchecked Sendable {
     var onPolicyTriggered: (() -> Void)?
+}
+
+private final class StubCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
+    func callReadyToJoin(_ call: Call) async throws { /* No-op */ }
 }

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -631,6 +631,60 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    @MainActor
+    func test_accept_withJoinInterceptor_interceptorIsForwardedToJoin() async throws {
+        let interceptor = StubCallJoinInterceptor()
+        subject.callJoinInterceptor = interceptor
+
+        let call = try await acceptIncomingCall()
+
+        let recorded = try XCTUnwrap(call.recordedJoinInterceptors.first ?? nil)
+        XCTAssertIdentical(recorded as AnyObject, interceptor)
+    }
+
+    @MainActor
+    func test_accept_withoutJoinInterceptor_joinReceivesNilInterceptor() async throws {
+        let call = try await acceptIncomingCall()
+
+        XCTAssertEqual(call.recordedJoinInterceptors.count, 1)
+        XCTAssertNil(call.recordedJoinInterceptors.first ?? nil)
+    }
+
+    @MainActor
+    func test_accept_joinFails_callIsReportedEndedToCallKit() async throws {
+        let firstCallUUID = UUID()
+        uuidFactory.getResult = firstCallUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        call.stubbedJoinError = ClientError("join failed")
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        await waitExpectation(timeout: 1)
+
+        subject.provider(
+            callProvider,
+            perform: CXAnswerCallAction(call: firstCallUUID)
+        )
+
+        await fulfillment {
+            self.callProvider.invocations.contains {
+                switch $0 {
+                case let .reportCall(uuid, _, reason):
+                    return uuid == firstCallUUID && reason == .failed
+                default:
+                    return false
+                }
+            }
+        }
+        XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 1)
+    }
+
     // MARK: - mute
 
     @MainActor
@@ -1528,6 +1582,34 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         mockedStreamVideo.stub(for: \.state, with: mockedState)
     }
 
+    /// Reports an incoming call and answers it, returning the stubbed call so
+    /// tests can assert on the recorded join inputs.
+    @MainActor
+    private func acceptIncomingCall() async throws -> MockCall {
+        let firstCallUUID = UUID()
+        uuidFactory.getResult = firstCallUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        await waitExpectation(timeout: 1)
+
+        subject.provider(
+            callProvider,
+            perform: CXAnswerCallAction(call: firstCallUUID)
+        )
+
+        await fulfillment { call.recordedJoinInterceptors.count == 1 }
+
+        return call
+    }
+
     @MainActor
     @discardableResult
     private func stubCall(
@@ -1571,4 +1653,8 @@ private final class MockParticipantAutoLeavePolicy:
     func trigger() {
         onPolicyTriggered?()
     }
+}
+
+private final class StubCallJoinInterceptor: CallJoinIntercepting, @unchecked Sendable {
+    func callReadyToJoin(_ call: Call) async throws { /* No-op */ }
 }

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -685,6 +685,43 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 1)
     }
 
+    @MainActor
+    func test_accept_joinFailsWithInterceptionError_callIsReportedEndedWithoutAdditionalLeave() async throws {
+        let firstCallUUID = UUID()
+        uuidFactory.getResult = firstCallUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        call.stubbedJoinError = CallJoinInterceptionError("interceptor veto")
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        await waitExpectation(timeout: 1)
+
+        subject.provider(
+            callProvider,
+            perform: CXAnswerCallAction(call: firstCallUUID)
+        )
+
+        await fulfillment {
+            self.callProvider.invocations.contains {
+                switch $0 {
+                case let .reportCall(uuid, _, reason):
+                    return uuid == firstCallUUID && reason == .failed
+                default:
+                    return false
+                }
+            }
+        }
+        // The join flow has already left the call when the interceptor vetoes
+        // the join, so the service must not issue another leave.
+        XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 0)
+    }
+
     // MARK: - mute
 
     @MainActor

--- a/StreamVideoTests/Mock/MockCall.swift
+++ b/StreamVideoTests/Mock/MockCall.swift
@@ -77,6 +77,9 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
     @Atomic var stubbedFunctionInput: [FunctionKey: [FunctionInputKey]] = FunctionKey.allCases
         .reduce(into: [FunctionKey: [FunctionInputKey]]()) { $0[$1] = [] }
     @Atomic var recordedJoinInterceptors: [CallJoinIntercepting?] = []
+    /// When set, `join` throws this error instead of returning the stubbed
+    /// response, allowing tests to drive join-failure paths.
+    var stubbedJoinError: Error?
     var waitForJoinToResume = false
     var onJoinStarted: (@Sendable () -> Void)?
     var onJoinResumed: (@Sendable (MockCall) async -> Void)?
@@ -208,6 +211,10 @@ final class MockCall: Call, Mockable, @unchecked Sendable {
 
         if let onJoinResumed {
             await onJoinResumed(self)
+        }
+
+        if let stubbedJoinError {
+            throw stubbedJoinError
         }
 
         if let stub = stubbedFunction[.join] as? JoinCallResponse {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1757/blinkcallkit-joincallinterceptor-integration

### 📚 Docs

https://github.com/GetStream/docs-content/pull/1361

### 🎯 Goal

Calls answered through CallKit bypass `CallViewModel`'s join path, so an app-provided `CallJoinIntercepting` hook never ran for them. This PR wires the interceptor into the CallKit answer flow so CallKit-answered calls honor the same readiness logic as in-app joins.

### 📝 Summary

- Exposed `callJoinInterceptor` on `CallKitAdapter` (forwarding to `CallKitService`) and passed it to `call.join(policy:joinInterceptor:)` when answering a CallKit call.
- Fixed a bug where a join failure after answering (e.g. an interceptor veto) left the CallKit system UI showing an ongoing call: the service now reports the call as ended with reason `.failed`.
- DemoApp: assigned the interceptor on `callKitAdapter` and made `DemoCallJoinInterceptor` publishers deliver on the main queue.
- Updated the call-join-interceptor documentation page and DocumentationTests with the CallKit attachment snippet.

### 🛠 Implementation

- `CallKitService.callJoinInterceptor` is a plain optional property (same pattern as `callSettings`) read inside the `CXAnswerCallAction` handler and forwarded to the join flow. The interceptor runs inside the call state machine's joining stage, after the answer action has been fulfilled, so a slow interceptor cannot stall the CallKit answer action (it is additionally capped by `CallConfiguration.timeout.joinInterception`).
- In the answer-action failure path, the service calls `callProvider.reportCall(with:endedAt:reason:)` before clearing the call entry, since the answer action has already been fulfilled at that point and CallKit must be told explicitly that the call failed.

### 🧪 Manual Testing Notes

#### Scenario A
1. In the DemoApp debug menu, set **Call Join Interceptor** to **Synchronised**.
2. Ring a user on a device where the app is backgrounded/locked and answer via the CallKit UI.
3. Verify the callee waits for the `participant.ready` handshake before entering the call, then joins normally.
4. Force a join failure (e.g. airplane mode right after answering) and verify the system call UI ends instead of staying active.

#### Scenario B
1. In the DemoApp debug menu, set **Call Join Interceptor** to **Synchronised**.
2. Ring a user (audio-only) on a device where the app is backgrounded/locked and answer via the CallKit UI.
3. Verify the callee waits for the `participant.ready` handshake before entering the call

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CallKit now exposes a configurable call-join interceptor so CallKit-answered calls can be intercepted before final join.

* **Bug Fixes**
  * Improved CallKit join error handling: failed joins are now reported to the system and cleaned up correctly.

* **Documentation**
  * Changelog and examples updated for configuring call-join interceptors.

* **Tests**
  * Added tests and test helpers covering call-join interception and join-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->