### PR TITLE
[Fix] Call duration starts from local join when a CallJoinInterceptor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks.[#1153](https://github.com/GetStream/stream-video-swift/pull/1153)
 - Exposed `callJoinInterceptor` on `CallKitAdapter` and `CallKitService` so CallKit-answered calls honor `CallJoinIntercepting`. [#1160](https://github.com/GetStream/stream-video-swift/pull/1160)
 
+### 🐞 Fixed
+- When a `CallJoinIntercepting` delays call entry, `Call.state.duration` now starts from the moment the user joined instead of the backend session start. [#1161](https://github.com/GetStream/stream-video-swift/pull/1161)
+
 # [1.47.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.1)
 _May 26, 2026_
 

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -109,8 +109,9 @@ public class CallState: ObservableObject {
     @Published public internal(set) var isCurrentUserScreensharing: Bool = false
     /// The elapsed duration of the active call session in seconds.
     ///
-    /// The timer begins only after the backend reports a started session and is
-    /// reset when that session ends. Ringing time is not included.
+    /// The timer begins once the backend reports a started session, or from
+    /// the moment the user joined when a join interceptor delayed call entry.
+    /// It is reset when the session ends. Ringing time is not included.
     @Published public internal(set) var duration: TimeInterval = 0
     @Published public internal(set) var statsReport: CallStatsReport?
 
@@ -150,7 +151,20 @@ public class CallState: ObservableObject {
     /// help customize logic, analytics, and UI based on how the call was started.
     var joinSource: JoinSource?
 
-    private var durationCancellable: AnyCancellable?
+    /// When set, `duration` is measured from this local date instead of the
+    /// backend session start.
+    ///
+    /// The join flow sets this once a join interceptor has delayed call entry,
+    /// so the visible duration starts when the user actually joined. It is
+    /// cleared whenever the duration resets (e.g. the session ends).
+    var durationStartOverride: Date? {
+        get { durationTracker.startOverride }
+        set { durationTracker.startOverride = newValue }
+    }
+
+    /// Computes the visible call duration. `duration` and `startedAt`
+    /// republish its output.
+    private let durationTracker = CallDurationTracker()
     private nonisolated let disposableBag = DisposableBag()
 
     /// We mark this one as `nonisolated` to allow us to initialise a state
@@ -163,6 +177,7 @@ public class CallState: ObservableObject {
         _ callSession: StreamVideo.CallSession
     ) {
         self.streamVideoSession = callSession
+        bindDurationTracker()
     }
 
     internal func updateState(from event: VideoEvent) {
@@ -574,45 +589,34 @@ public class CallState: ObservableObject {
         function: StaticString = #function,
         line: UInt = #line
     ) {
-        func reset() {
-            durationCancellable?.cancel()
-            durationCancellable = nil
+        durationTracker.didUpdate(session)
+    }
 
-            duration = 0
-            startedAt = nil
-        }
-
-        guard let session else {
-            if startedAt == nil {
-                reset()
+    /// Republishes the tracker's output on the `duration` and `startedAt`
+    /// published properties. `receive(on:)` guarantees delivery on the main
+    /// queue, which makes the isolation assumption below safe.
+    private nonisolated func bindDurationTracker() {
+        // `sinkTask` is unsuitable here: it reuses one task identifier per
+        // subscription, so frequent emissions (the 1-second duration timer)
+        // cancel each other's pending assignments and values get dropped.
+        // `receive(on:)` + `sink` delivers every value, in order, on the main
+        // queue, which also makes the isolation assumption below safe.
+        durationTracker
+            .durationPublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                MainActor.assumeIsolated { self?.duration = value }
             }
-            return
-        }
+            .store(in: disposableBag)
 
-        if session.endedAt != nil {
-            reset()
-        } else if session.liveEndedAt != nil {
-            reset()
-        } else if let newStartedAt = session.startedAt ?? session.liveStartedAt {
-            guard newStartedAt != startedAt else {
-                return
+        durationTracker
+            .startedAtPublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                MainActor.assumeIsolated { self?.startedAt = value }
             }
-
-            let now = Date()
-            let newDuration = now.timeIntervalSince(newStartedAt).rounded()
-
-            durationCancellable?.cancel()
-            durationCancellable = nil
-            durationCancellable = DefaultTimer
-                .publish(every: 1.0)
-                .receive(on: DispatchQueue.main)
-                .map { _ in Date().timeIntervalSince(newStartedAt) }
-                .assign(to: \.duration, onWeak: self)
-
-            self.duration = newDuration
-            self.startedAt = newStartedAt
-        } else if startedAt == nil {
-            reset()
-        }
+            .store(in: disposableBag)
     }
 }

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -177,7 +177,9 @@ public class CallState: ObservableObject {
         _ callSession: StreamVideo.CallSession
     ) {
         self.streamVideoSession = callSession
-        bindDurationTracker()
+        Task(disposableBag: disposableBag) { @MainActor [weak self] in
+            self?.bindDurationTracker()
+        }
     }
 
     internal func updateState(from event: VideoEvent) {
@@ -593,30 +595,32 @@ public class CallState: ObservableObject {
     }
 
     /// Republishes the tracker's output on the `duration` and `startedAt`
-    /// published properties. `receive(on:)` guarantees delivery on the main
-    /// queue, which makes the isolation assumption below safe.
-    private nonisolated func bindDurationTracker() {
-        // `sinkTask` is unsuitable here: it reuses one task identifier per
-        // subscription, so frequent emissions (the 1-second duration timer)
-        // cancel each other's pending assignments and values get dropped.
-        // `receive(on:)` + `sink` delivers every value, in order, on the main
-        // queue, which also makes the isolation assumption below safe.
+    /// published properties.
+    ///
+    /// Binding is dispatched once from the nonisolated init onto the main
+    /// actor. The tracker's `CurrentValueSubject`s replay their latest
+    /// value on subscription, so emissions that happen before the bind
+    /// lands are not lost.
+    ///
+    /// `sinkTask` is unsuitable here: it reuses one task identifier per
+    /// subscription, so frequent emissions (the 1-second duration timer)
+    /// cancel each other's pending assignments and values get dropped.
+    /// `receive(on:)` + weak assignment delivers every value, in order, on
+    /// the main queue.
+    @MainActor
+    private func bindDurationTracker() {
         durationTracker
             .durationPublisher
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] value in
-                MainActor.assumeIsolated { self?.duration = value }
-            }
+            .assign(to: \.duration, onWeak: self)
             .store(in: disposableBag)
 
         durationTracker
             .startedAtPublisher
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] value in
-                MainActor.assumeIsolated { self?.startedAt = value }
-            }
+            .assign(to: \.startedAt, onWeak: self)
             .store(in: disposableBag)
     }
 }

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -177,6 +177,12 @@ extension Call.StateMachine.Stage {
             try Task.checkCancellation()
 
             await Task(disposableBag: disposableBag) { @MainActor [weak streamVideo] in
+                // When an interceptor delayed entry, anchor the visible call
+                // duration to the local joined moment instead of the backend
+                // session start.
+                if input.joinInterceptor != nil {
+                    call.state.durationStartOverride = Date()
+                }
                 streamVideo?.state.activeCall = call
             }.value
 

--- a/Sources/StreamVideo/Utils/CallDurationTracker.swift
+++ b/Sources/StreamVideo/Utils/CallDurationTracker.swift
@@ -1,0 +1,115 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// Tracks the elapsed duration of a call session.
+///
+/// The tracker observes backend session payloads and runs a 1-second timer
+/// while a session is active. The timer anchors on the backend session start
+/// or, when set, on a local start date. The local anchor is used when a join
+/// interceptor delays call entry, so the visible duration starts only once
+/// the user has actually joined.
+///
+/// - Important: The tracker does not guarantee delivery on any specific
+///   thread. Subscribers that feed UI state should hop to the main queue.
+final class CallDurationTracker: @unchecked Sendable {
+
+    /// Publishes the elapsed duration of the active session in seconds.
+    ///
+    /// Emits `0` while no session is running and updates every second once
+    /// the duration timer has been anchored.
+    var durationPublisher: AnyPublisher<TimeInterval, Never> {
+        durationSubject.eraseToAnyPublisher()
+    }
+
+    /// Publishes the backend-reported session start date.
+    ///
+    /// This always reflects the backend value, even when the duration is
+    /// anchored to a local override.
+    var startedAtPublisher: AnyPublisher<Date?, Never> {
+        startedAtSubject.eraseToAnyPublisher()
+    }
+
+    /// When set, the duration is measured from this local date instead of
+    /// the backend session start.
+    ///
+    /// The join flow sets this once a join interceptor has delayed call
+    /// entry. It is cleared whenever the duration resets (e.g. the session
+    /// ends).
+    var startOverride: Date? {
+        didSet {
+            guard startOverride != oldValue else {
+                return
+            }
+            configure(for: session)
+        }
+    }
+
+    private let durationSubject = CurrentValueSubject<TimeInterval, Never>(0)
+    private let startedAtSubject = CurrentValueSubject<Date?, Never>(nil)
+    private var session: CallSessionResponse?
+    /// The date the running timer is currently anchored to. Used to avoid
+    /// restarting the timer on repeated session updates.
+    private var anchor: Date?
+    private var timerCancellable: AnyCancellable?
+
+    init() {}
+
+    /// Updates the tracker with the latest backend session payload.
+    func didUpdate(_ session: CallSessionResponse?) {
+        self.session = session
+        configure(for: session)
+    }
+
+    // MARK: - Private Helpers
+
+    private func configure(for session: CallSessionResponse?) {
+        if session?.endedAt != nil || session?.liveEndedAt != nil {
+            reset()
+            return
+        }
+
+        let sessionStartedAt = session?.startedAt ?? session?.liveStartedAt
+
+        if let sessionStartedAt, sessionStartedAt != startedAtSubject.value {
+            startedAtSubject.send(sessionStartedAt)
+        }
+
+        if let anchor = startOverride ?? sessionStartedAt {
+            startTimer(from: anchor)
+        } else if startedAtSubject.value == nil {
+            reset()
+        }
+    }
+
+    /// Starts the duration timer anchored to the provided date. Repeated
+    /// calls with the same anchor keep the running timer untouched.
+    private func startTimer(from anchor: Date) {
+        guard anchor != self.anchor else {
+            return
+        }
+        self.anchor = anchor
+
+        timerCancellable?.cancel()
+        timerCancellable = DefaultTimer
+            .publish(every: 1.0)
+            .map { _ in Date().timeIntervalSince(anchor) }
+            .sink { [weak self] in self?.durationSubject.send($0) }
+
+        durationSubject.send(Date().timeIntervalSince(anchor).rounded())
+    }
+
+    /// Stops the duration timer and clears every duration related anchor.
+    private func reset() {
+        timerCancellable?.cancel()
+        timerCancellable = nil
+
+        anchor = nil
+        startOverride = nil
+        durationSubject.send(0)
+        startedAtSubject.send(nil)
+    }
+}

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -234,7 +234,7 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(subject.duration, 0)
     }
 
-    func test_update_fromCallResponse_withStartedAt_usesActualCallStart() {
+    func test_update_fromCallResponse_withStartedAt_usesActualCallStart() async {
         let subject = CallState(.dummy())
         let startedAt = Date(timeIntervalSinceNow: -95)
 
@@ -247,15 +247,13 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
             )
         )
 
+        await fulfilmentInMainActor {
+            abs(subject.duration - Date().timeIntervalSince(startedAt)) <= 1
+        }
         XCTAssertEqual(subject.startedAt, startedAt)
-        XCTAssertEqual(
-            subject.duration,
-            Date().timeIntervalSince(startedAt),
-            accuracy: 1
-        )
     }
 
-    func test_update_fromCallResponse_withOnlyLiveStartedAt_usesLiveStartedAt() {
+    func test_update_fromCallResponse_withOnlyLiveStartedAt_usesLiveStartedAt() async {
         let subject = CallState(.dummy())
         let liveStartedAt = Date(timeIntervalSinceNow: -42)
 
@@ -267,15 +265,13 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
             )
         )
 
+        await fulfilmentInMainActor {
+            abs(subject.duration - Date().timeIntervalSince(liveStartedAt)) <= 1
+        }
         XCTAssertEqual(subject.startedAt, liveStartedAt)
-        XCTAssertEqual(
-            subject.duration,
-            Date().timeIntervalSince(liveStartedAt),
-            accuracy: 1
-        )
     }
 
-    func test_update_fromCallResponse_withEndedSession_resetsDuration() {
+    func test_update_fromCallResponse_withEndedSession_resetsDuration() async {
         let subject = CallState(.dummy())
         let startedAt = Date(timeIntervalSinceNow: -30)
 
@@ -286,6 +282,7 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
                 )
             )
         )
+        await fulfilmentInMainActor { subject.startedAt == startedAt }
 
         subject.update(
             from: CallResponse.dummy(
@@ -296,8 +293,71 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
             )
         )
 
-        XCTAssertNil(subject.startedAt)
-        XCTAssertEqual(subject.duration, 0)
+        await fulfilmentInMainActor {
+            subject.startedAt == nil && subject.duration == 0
+        }
+    }
+
+    // MARK: - durationStartOverride
+
+    func test_durationStartOverride_whenSet_anchorsDurationToOverride() async {
+        let subject = CallState(.dummy())
+        let startedAt = Date(timeIntervalSinceNow: -95)
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(startedAt: startedAt)
+            )
+        )
+
+        let override = Date(timeIntervalSinceNow: -5)
+        subject.durationStartOverride = override
+
+        await fulfilmentInMainActor {
+            abs(subject.duration - Date().timeIntervalSince(override)) <= 1
+        }
+        XCTAssertEqual(subject.startedAt, startedAt)
+    }
+
+    func test_durationStartOverride_sessionUpdates_doNotReanchorDuration() async {
+        let subject = CallState(.dummy())
+        let override = Date(timeIntervalSinceNow: -5)
+        subject.durationStartOverride = override
+
+        let startedAt = Date(timeIntervalSinceNow: -95)
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(startedAt: startedAt)
+            )
+        )
+
+        await fulfilmentInMainActor { subject.startedAt == startedAt }
+        XCTAssertEqual(
+            subject.duration,
+            Date().timeIntervalSince(override),
+            accuracy: 1
+        )
+    }
+
+    func test_durationStartOverride_withEndedSession_resetsDurationAndOverride() async {
+        let subject = CallState(.dummy())
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(startedAt: Date(timeIntervalSinceNow: -30))
+            )
+        )
+        subject.durationStartOverride = Date(timeIntervalSinceNow: -5)
+        await fulfilmentInMainActor { subject.duration > 0 }
+
+        subject.update(
+            from: CallResponse.dummy(
+                session: .dummy(endedAt: Date())
+            )
+        )
+
+        await fulfilmentInMainActor {
+            subject.startedAt == nil && subject.duration == 0
+        }
+        XCTAssertNil(subject.durationStartOverride)
     }
 
     // MARK: - Private helpers

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -346,6 +346,58 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         }
     }
 
+    func test_execute_withoutRetries_joinInterceptorReturns_durationStartOverrideWasSet() async throws {
+        let joinInterceptor = CallJoinInterceptor_Spy()
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: .init(nil),
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .joined
+        ) { @MainActor in
+            XCTAssertNotNil(self.call.state.durationStartOverride)
+        }
+    }
+
+    func test_execute_withoutRetries_withoutJoinInterceptor_durationStartOverrideRemainsNil() async throws {
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: .init(nil)
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .joined
+        ) { @MainActor in
+            XCTAssertNil(self.call.state.durationStartOverride)
+        }
+    }
+
     func test_execute_withoutRetries_joinInterceptorThrows_tracesFailureAndTransitionsToError() async throws {
         let deliverySubject = CurrentValueSubject<JoinCallResponse?, Error>(nil)
         let deliveryExpectation = expectation(description: "DeliverySubject delivered failure.")

--- a/StreamVideoTests/Utils/CallDurationTracker_Tests.swift
+++ b/StreamVideoTests/Utils/CallDurationTracker_Tests.swift
@@ -1,0 +1,143 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamVideo
+import XCTest
+
+@MainActor
+final class CallDurationTracker_Tests: XCTestCase, @unchecked Sendable {
+
+    private var disposableBag: DisposableBag! = .init()
+    private var duration: TimeInterval! = 0
+    private var startedAt: Date?
+    private var subject: CallDurationTracker! = .init()
+
+    override func setUp() async throws {
+        try await super.setUp()
+        subject
+            .durationPublisher
+            .sink { [weak self] in self?.duration = $0 }
+            .store(in: disposableBag)
+        subject
+            .startedAtPublisher
+            .sink { [weak self] in self?.startedAt = $0 }
+            .store(in: disposableBag)
+    }
+
+    override func tearDown() {
+        disposableBag = nil
+        duration = nil
+        startedAt = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - didUpdate(session:)
+
+    func test_didUpdate_withoutStartedSession_keepsDurationReset() {
+        subject.didUpdate(.dummy())
+
+        XCTAssertNil(startedAt)
+        XCTAssertEqual(duration, 0)
+    }
+
+    func test_didUpdate_withStartedAt_anchorsDurationToSessionStart() {
+        let sessionStartedAt = Date(timeIntervalSinceNow: -95)
+
+        subject.didUpdate(
+            .dummy(
+                liveStartedAt: Date(timeIntervalSinceNow: -120),
+                startedAt: sessionStartedAt
+            )
+        )
+
+        XCTAssertEqual(startedAt, sessionStartedAt)
+        XCTAssertEqual(
+            duration,
+            Date().timeIntervalSince(sessionStartedAt),
+            accuracy: 1
+        )
+    }
+
+    func test_didUpdate_withOnlyLiveStartedAt_anchorsDurationToLiveStart() {
+        let liveStartedAt = Date(timeIntervalSinceNow: -42)
+
+        subject.didUpdate(.dummy(liveStartedAt: liveStartedAt))
+
+        XCTAssertEqual(startedAt, liveStartedAt)
+        XCTAssertEqual(
+            duration,
+            Date().timeIntervalSince(liveStartedAt),
+            accuracy: 1
+        )
+    }
+
+    func test_didUpdate_withEndedSession_resetsDuration() {
+        let sessionStartedAt = Date(timeIntervalSinceNow: -30)
+        subject.didUpdate(.dummy(startedAt: sessionStartedAt))
+
+        subject.didUpdate(.dummy(endedAt: Date(), startedAt: sessionStartedAt))
+
+        XCTAssertNil(startedAt)
+        XCTAssertEqual(duration, 0)
+    }
+
+    // MARK: - startOverride
+
+    func test_startOverride_whenSet_anchorsDurationToOverride() {
+        let sessionStartedAt = Date(timeIntervalSinceNow: -95)
+        subject.didUpdate(.dummy(startedAt: sessionStartedAt))
+
+        let override = Date(timeIntervalSinceNow: -5)
+        subject.startOverride = override
+
+        XCTAssertEqual(
+            duration,
+            Date().timeIntervalSince(override),
+            accuracy: 1
+        )
+        XCTAssertEqual(startedAt, sessionStartedAt)
+    }
+
+    func test_startOverride_sessionUpdates_doNotReanchorDuration() {
+        let override = Date(timeIntervalSinceNow: -5)
+        subject.startOverride = override
+
+        let sessionStartedAt = Date(timeIntervalSinceNow: -95)
+        subject.didUpdate(.dummy(startedAt: sessionStartedAt))
+
+        XCTAssertEqual(
+            duration,
+            Date().timeIntervalSince(override),
+            accuracy: 1
+        )
+        XCTAssertEqual(startedAt, sessionStartedAt)
+    }
+
+    func test_startOverride_withoutStartedSession_anchorsDurationToOverride() {
+        subject.didUpdate(.dummy())
+
+        let override = Date(timeIntervalSinceNow: -5)
+        subject.startOverride = override
+
+        XCTAssertEqual(
+            duration,
+            Date().timeIntervalSince(override),
+            accuracy: 1
+        )
+        XCTAssertNil(startedAt)
+    }
+
+    func test_startOverride_withEndedSession_resetClearsOverride() {
+        subject.didUpdate(.dummy(startedAt: Date(timeIntervalSinceNow: -30)))
+        subject.startOverride = Date(timeIntervalSinceNow: -5)
+
+        subject.didUpdate(.dummy(endedAt: Date()))
+
+        XCTAssertNil(subject.startOverride)
+        XCTAssertNil(startedAt)
+        XCTAssertEqual(duration, 0)
+    }
+}

--- a/StreamVideoTests/Utils/CallDurationTracker_Tests.swift
+++ b/StreamVideoTests/Utils/CallDurationTracker_Tests.swift
@@ -26,12 +26,12 @@ final class CallDurationTracker_Tests: XCTestCase, @unchecked Sendable {
             .store(in: disposableBag)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         disposableBag = nil
         duration = nil
         startedAt = nil
         subject = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - didUpdate(session:)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1758/blinkcall-duration-when-joincallinterceptor-is-involved-its-wrong

### 🥞 Stacked PR 

Depends on #1160

### 🎯 Goal

When a `CallJoinIntercepting` delays call entry, `Call.state.duration` was anchored to the backend session `startedAt`, so users saw elapsed time that included the interceptor's waiting period. The visible duration should start only once the user actually enters the call (reaches the `.joined` state).

### 📝 Summary

- Extracted the duration logic from `CallState` into a new internal `CallDurationTracker` that anchors the duration timer on the backend session start or, when set, on a local start date.
- Added an internal `durationStartOverride` to `CallState` (forwarding to the tracker). The joining stage sets it — only when a join interceptor was involved — right before the call becomes active.
- `CallState.duration` and `CallState.startedAt` remain `@Published` and keep their public semantics; they now republish the tracker's output on the main queue.
- No public API changes. Flows without an interceptor behave exactly as before.

### 🛠 Implementation

- `CallDurationTracker` resolves the timer anchor with explicit precedence (`startOverride ?? session.startedAt ?? session.liveStartedAt`), runs a single timer pipeline, and dedupes repeated session updates via the stored anchor — backend session updates can no longer re-anchor an override. Session end clears the override so a rejoin starts clean.
- `startedAt` keeps reflecting the backend session start even while the duration is anchored locally, preserving its documented meaning.
- The override is set in `JoiningStage.executeJoin` inside the existing MainActor hop that publishes `activeCall`, gated on `input.joinInterceptor != nil` — one condition, surgical.
- `CallState` binds the tracker once in `init`. The binding intentionally uses `receive(on:)` + `sink` (with `MainActor.assumeIsolated`) instead of `sinkTask`: `sinkTask` reuses one task identifier per subscription, so the 1-second timer emissions cancel each other's pending assignments and drop values
- WebRTC reconnects don't re-run the call state machine's joining stage, so the local anchor survives reconnections and the duration doesn't reset.
- CallKit-answered calls are intentionally out of scope and will be handled in a follow-up PR.

### 🧪 Manual Testing Notes

1. In the DemoApp debug menu set **Call Join Interceptor** to **Synchronised**.
2. Ring user B from user A; have B accept in-app while A's interceptor waits for the readiness handshake.
3. Verify B's call duration starts at ~0:00 when the in-call UI appears, not at the time elapsed since the session started.
4. With the interceptor set to **None**, verify durations match the backend session start as before (e.g. joining an ongoing call shows the running call time).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed call duration tracking to start from the user's join moment when using join interceptors, rather than from the backend session start time, ensuring accurate duration display.

* **Tests**
  * Enhanced test coverage for call duration tracking behavior and session lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->