### PR TITLE
[Fix] Fulfil CallKit answer action only after the call has successful…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for SFU-provided WebRTC degradation preferences for outgoing video and screen-share tracks.[#1153](https://github.com/GetStream/stream-video-swift/pull/1153)
 - Exposed `callJoinInterceptor` on `CallKitAdapter` and `CallKitService` so CallKit-answered calls honor `CallJoinIntercepting`. [#1160](https://github.com/GetStream/stream-video-swift/pull/1160)
 
+### 🐞 Fixed
+- The CallKit system UI no longer shows a running call duration before the user is actually connected. [#1162](https://github.com/GetStream/stream-video-swift/pull/1162)
+
 # [1.47.1](https://github.com/GetStream/stream-video-swift/releases/tag/1.47.1)
 _May 26, 2026_
 

--- a/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/10-call-join-interceptor.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/05-ui-cookbook/10-call-join-interceptor.swift
@@ -97,9 +97,10 @@ private func content() {
             func callReadyToJoin(_ call: Call) async throws { /* Readiness work goes here. */ }
         }
 
-        // Assign the interceptor on the adapter so calls answered through
-        // CallKit honor it too.
+        // Assign the interceptor at startup, where streamVideo is handed to
+        // the adapter, so CallKit-answered calls honor it even on cold launch.
         @Injected(\.callKitAdapter) var callKitAdapter
+        callKitAdapter.streamVideo = streamVideo
         callKitAdapter.callJoinInterceptor = ParticipantReadyCallJoinInterceptor(streamVideo: streamVideo)
     }
 }

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -505,6 +505,23 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         audioStore.dispatch(.callKit(.deactivate(audioSession)))
     }
 
+    /// Handles the user answering an incoming CallKit call.
+    ///
+    /// The answer action stays pending while the SDK accepts the call and
+    /// runs the full join flow (including any `CallJoinIntercepting` delay),
+    /// so the system call UI keeps showing the call as connecting until the
+    /// user is actually connected:
+    /// - On success, the Call state machine's joining stage invokes the
+    ///   `JoinSource.ActionCompletion` hook stored in `call.state.joinSource`
+    ///   and the action is fulfilled. CallKit then activates the audio
+    ///   session and the system UI starts counting the call duration.
+    /// - On failure, the action is failed (exactly once). If the action had
+    ///   already been fulfilled — the join failed after the hook fired — the
+    ///   call is reported to CallKit as `.failed` instead, tearing down the
+    ///   live system call.
+    /// - If the join outlasts CallKit's allowed answer window, the system
+    ///   times the action out and `provider(_:timedOutPerforming:)` aborts
+    ///   the join.
     open func provider(
         _ provider: CXProvider,
         perform action: CXAnswerCallAction
@@ -521,6 +538,27 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         active = action.callUUID
         callToJoinEntry.call.didPerform(.performAnswerCall)
 
+        // Guards the answer action so it is completed exactly once across the
+        // success path (the joinSource hook fulfilling it once the call has
+        // joined) and the failure paths (accept/join errors failing it).
+        // Returns `true` when the provided completion was executed and `false`
+        // when the action had already been completed by another path.
+        let hasCompletedAction = Atomic(wrappedValue: false)
+        @discardableResult @Sendable func completeActionOnce(
+            _ completion: @escaping () -> Void
+        ) -> Bool {
+            var shouldComplete = false
+            hasCompletedAction.mutate { hasCompleted in
+                shouldComplete = !hasCompleted
+                return true
+            }
+            guard shouldComplete else {
+                return false
+            }
+            completion()
+            return true
+        }
+
         Task(disposableBag: disposableBag) { @MainActor [weak self] in
             guard let self else {
                 return
@@ -536,12 +574,9 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 // app is waking up.
                 eventPipelineSubject.send(.accept)
                 try await callToJoinEntry.call.accept()
-                // We need to fulfil here the action to allow CallKit to release
-                // the audioSession to the app, for activation.
-                action.fulfill()
             } catch {
                 log.error(error, subsystems: .callKit)
-                action.fail()
+                completeActionOnce { action.fail() }
             }
 
             do {
@@ -549,19 +584,20 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 // CallViewModel can present the joining screen even when the
                 // app was launched from CallKit in the background.
                 eventPipelineSubject.send(.joining(callToJoinEntry.call))
-                // Pass a CallKit completion hook through the join flow so the
-                // WebRTC layer can release CallKit's audio session ownership as
-                // soon as it has configured the audio device module.
+                // Pass a CallKit completion hook through the join flow. The
+                // Call state machine's joining stage invokes it once the call
+                // has joined successfully (after any join interceptor).
                 callToJoinEntry.call.state.joinSource = .callKit(.init {
-                    // Allow CallKit to hand audio session activation back to
-                    // the app before we continue configuring audio locally.
-                    action.fulfill()
+                    // Fulfil the answer action so CallKit hands audio session
+                    // activation to the app and the system UI starts counting
+                    // the call duration only once the user is connected.
+                    completeActionOnce { action.fulfill() }
                 })
 
-                // Before reach here we should fulfil the action to allow
-                // CallKit to release the audioSession, so that the SDK
-                // can configure and activate it and complete successfully the
-                // peerConnection configuration.
+                // The answer action stays pending while the join is running:
+                // the joinSource hook above fulfils it on success, while the
+                // catch below fails it when the join aborts. Until then the
+                // system UI keeps showing the call as connecting.
                 try await callToJoinEntry.call.join(
                     callSettings: callSettings,
                     policy: .peerConnectionReadinessAware,
@@ -571,6 +607,23 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 // over and the temporary CallKit bridge can stand down.
                 eventPipelineSubject.send(.joined)
             } catch {
+                // On the common path the join fails before the joinSource
+                // hook fulfilled the action, so failing the action is enough
+                // to tear down the system UI and reporting the call ended
+                // would be redundant.
+                let didFail = completeActionOnce { action.fail() }
+                if !didFail {
+                    // The action was already fulfilled: the joining stage
+                    // invoked the hook before `Call.join`'s delivery timeout
+                    // threw, so the system call is live. Reporting the
+                    // failure is the only thing that tears the CallKit UI
+                    // down in that race.
+                    callProvider.reportCall(
+                        with: action.callUUID,
+                        endedAt: nil,
+                        reason: .failed
+                    )
+                }
                 // Interceptor vetoes and join timeouts already leave the call
                 // (with their specific reasons) inside the join flow. Issuing
                 // another leave here would race that one and could drop the
@@ -579,15 +632,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 if !(error is CallJoinInterceptionError), !(error is TimeOutError) {
                     callToJoinEntry.call.leave()
                 }
-                // The answer action has already been fulfilled at this point,
-                // so CallKit must be told explicitly that the call failed
-                // (e.g. when a join interceptor vetoed the join). Otherwise
-                // the system keeps presenting an ongoing call.
-                callProvider.reportCall(
-                    with: action.callUUID,
-                    endedAt: nil,
-                    reason: .failed
-                )
                 set(nil, for: action.callUUID)
                 log.error(error, subsystems: .callKit)
                 // Reset the bridge if the CallKit-driven join flow aborts
@@ -595,6 +639,54 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 eventPipelineSubject.send(.idle)
             }
         }
+    }
+
+    /// Called when the system gave up waiting for `action` to be completed
+    /// before its timeout elapsed.
+    ///
+    /// With the answer action being fulfilled only once the call has joined
+    /// successfully (see `provider(_:perform: CXAnswerCallAction)` for the
+    /// full answer lifecycle), a slow join (network, SFU negotiation or a
+    /// join interceptor delaying entry) can exceed CallKit's allowed window.
+    /// By the time this is invoked the action is already dead system-side
+    /// and CallKit has torn down the pending system call UI on its own, so
+    /// the SDK neither fulfils, fails nor reports the call here.
+    ///
+    /// For the pending answer action of a tracked call the SDK aborts the
+    /// in-flight join by leaving with reason `callkit.join.timeout`, removes
+    /// the call entry and resets the CallKit bridge to idle. The join flow's
+    /// failure handling that runs afterwards is idempotent: its reason-less
+    /// `leave()` is a state-machine no-op, completing the dead action has no
+    /// effect, and the call is not reported as failed again. Timeouts for
+    /// any other action type are only logged.
+    open func provider(
+        _ provider: CXProvider,
+        timedOutPerforming action: CXAction
+    ) {
+        guard
+            let answerAction = action as? CXAnswerCallAction,
+            let callToJoinEntry = callEntry(for: answerAction.callUUID)
+        else {
+            log.warning(
+                "CallKit timed out performing action:\(action).",
+                subsystems: .callKit
+            )
+            return
+        }
+
+        log.warning(
+            """
+            CallKit timed out performing the answer action while joining
+            callId:\(callToJoinEntry.call.callId)
+            callType:\(callToJoinEntry.call.callType)
+            callerId:\(callToJoinEntry.createdBy?.id)
+            """,
+            subsystems: .callKit
+        )
+
+        callToJoinEntry.call.leave(reason: "callkit.join.timeout")
+        set(nil, for: answerAction.callUUID)
+        eventPipelineSubject.send(.idle)
     }
 
     open func provider(

--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -178,6 +178,21 @@ extension Call.StateMachine.Stage {
 
             await Task(disposableBag: disposableBag) { @MainActor [weak streamVideo] in
                 streamVideo?.state.activeCall = call
+
+                // The call is now fully joined (including any interceptor
+                // delay). If the join was initiated from CallKit, invoke the
+                // completion hook so the pending `CXAnswerCallAction` is
+                // fulfilled. This is the audio hand-off point: the WebRTC
+                // layer configured the session earlier with
+                // `shouldSetActive: false`, so once CallKit (now fulfilled)
+                // activates the session and `didActivate` dispatches the
+                // activation into the audio store, the deferred activation
+                // wakes up and audio starts. Failure paths never reach this
+                // point; they complete the action through `CallKitService`'s
+                // join error handling.
+                if case let .callKit(completion) = call.state.joinSource {
+                    completion.complete()
+                }
             }.value
 
             try Task.checkCancellation()

--- a/Sources/StreamVideo/Models/JoinSource.swift
+++ b/Sources/StreamVideo/Models/JoinSource.swift
@@ -11,8 +11,18 @@ import Foundation
 /// This helps distinguish the user's entry point and can be used to customize
 /// behavior or analytics based on how the call was initiated.
 enum JoinSource: Sendable, Equatable {
-    /// Carries the completion hook CallKit expects us to invoke once the SDK is
-    /// ready for CallKit to hand audio session ownership back to the app.
+    /// Carries the completion hook CallKit expects us to invoke once the call
+    /// has been joined successfully.
+    ///
+    /// `CallKitService` stores it on `CallState.joinSource` when the user
+    /// answers an incoming call, before the join flow starts. The Call state
+    /// machine's joining stage invokes it right after the joined call becomes
+    /// the active call (including any join interceptor delay). Completing it
+    /// fulfils the pending `CXAnswerCallAction`, which lets CallKit hand
+    /// audio session ownership to the app and switches the system call UI
+    /// from connecting to a running call duration. It is never invoked on
+    /// join failure paths; those complete the action through
+    /// `CallKitService`'s error handling.
     struct ActionCompletion: @unchecked Sendable {
         fileprivate let identifier: UUID = .init()
         private let completion: () -> Void
@@ -31,6 +41,9 @@ enum JoinSource: Sendable, Equatable {
     case inApp
 
     /// Indicates that the call was joined via CallKit integration.
+    ///
+    /// The associated `ActionCompletion` fulfils the pending answer action
+    /// and is invoked by the joining stage once the call has joined.
     case callKit(ActionCompletion)
 
     /// Compares `JoinSource` values while treating CallKit sources as distinct

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore+CallKitRecoveryMiddleware.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore+CallKitRecoveryMiddleware.swift
@@ -1,0 +1,61 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamWebRTC
+
+extension RTCAudioStore {
+
+    /// Restores microphone capture after CallKit hands the audio session to
+    /// the app.
+    ///
+    /// With CallKit joins the answer action is fulfilled only once the call
+    /// has joined, so the WebRTC layer configures the peer connections (and
+    /// may start ADM recording) while the AVAudioSession is still inactive.
+    /// In that window the recording is initialised but the engine input
+    /// never actually starts. When CallKit later activates the session,
+    /// `CallKitReducer` only forwards the activation and flips `isActive`;
+    /// nothing restarts the stalled recording, leaving the microphone dead
+    /// while the state reports recording. This middleware closes that gap by
+    /// replaying the same recovery `InterruptionsEffect` uses: stop and start
+    /// recording, then re-apply the current microphone mute state.
+    ///
+    /// Playout needs no equivalent treatment: WebRTC restarts its audio unit
+    /// when the activation is forwarded through `audioSessionDidActivate`,
+    /// and the deferred policy application re-issues `setAudioEnabled`,
+    /// which maps to `setPlayout` on the ADM.
+    final class CallKitRecoveryMiddleware: Middleware<RTCAudioStore.Namespace>,
+        @unchecked Sendable {
+
+        /// Dispatches a recording restart when CallKit activates the audio
+        /// session while recording was already on. Activations with recording
+        /// off are left untouched.
+        override func apply(
+            state: RTCAudioStore.StoreState,
+            action: RTCAudioStore.StoreAction,
+            file: StaticString,
+            function: StaticString,
+            line: UInt
+        ) {
+            guard
+                case .callKit(.activate) = action,
+                state.audioDeviceModule != nil,
+                state.isRecording
+            else {
+                return
+            }
+
+            // The follow-up actions are enqueued on the store's serial
+            // processing queue, so they execute after `CallKitReducer` has
+            // forwarded the activation to the WebRTC session. The restart
+            // therefore runs against an active audio session.
+            let actions: [Namespace.Action] = [
+                .setRecording(false),
+                .setRecording(true),
+                .setMicrophoneMuted(state.isMicrophoneMuted)
+            ]
+            dispatcher?.dispatch(actions.map(\.box))
+        }
+    }
+}

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore+Namespace.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore+Namespace.swift
@@ -27,7 +27,8 @@ extension RTCAudioStore {
 
         static func middleware(audioSession: RTCAudioSession) -> [Middleware<RTCAudioStore.Namespace>] {
             [
-                AudioDeviceModuleMiddleware()
+                AudioDeviceModuleMiddleware(),
+                CallKitRecoveryMiddleware()
             ]
         }
 

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -392,12 +392,19 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         )
                     }
 
-                    group.addTask { [weak self] in
+                    group.addTask { [weak self, context] in
                         /// Before we move on configuring the PeerConnections we need to ensure
-                        /// that the audioSession has been:
-                        /// - released from CallKit (if our source was CallKit)
-                        /// - activated and configured correctly
-                        await self?.ensureAudioSessionIsReady()
+                        /// that the audioSession has been activated and configured correctly.
+                        ///
+                        /// When the join was initiated from CallKit, activation only happens
+                        /// after the call has fully joined and the pending answer action has
+                        /// been fulfilled, so waiting here would always time out. We skip the
+                        /// wait and let CallKit's later activation start audio once it arrives.
+                        if case .callKit = context.joinSource {
+                            // No-op: CallKit activates the session post-join.
+                        } else {
+                            await self?.ensureAudioSessionIsReady()
+                        }
 
                         /// Configures all peer connections after the audio session is ready.
                         /// Ensures signaling, media, and routing are correctly established for

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -935,19 +935,19 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
             return true
         }()
 
-        if case let .callKit(completion) = source {
-            // Let CallKit release its audio session ownership once WebRTC has
-            // the audio device module it needs.
-            completion.complete()
-        }
-
         audioSession.activate(
             callSettingsPublisher: $callSettings.removeDuplicates().eraseToAnyPublisher(),
             ownCapabilitiesPublisher: $ownCapabilities.removeDuplicates().eraseToAnyPublisher(),
             delegate: self,
             statsAdapter: statsAdapter,
-            /// If we are joining from CallKit the AudioSession will be activated from it and we
-            /// shouldn't attempt another activation.
+            /// When joining from CallKit we configure the session here but
+            /// never activate it ourselves. The ordering is: the joining
+            /// stage fulfils the pending answer action once the call has
+            /// joined, CallKit then activates the session and `didActivate`
+            /// dispatches `.callKit(.activate)` into the audio store, whose
+            /// `isActive` flip wakes the deferred activation scheduled by
+            /// `CallAudioSession` below. Activating locally as well would
+            /// race CallKit's ownership of the session.
             shouldSetActive: !sourceIsCallKit
         )
     }

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -53,6 +53,10 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     override func tearDown() {
         mockApplicationStateAdapter.dismante()
         mockPermissions.dismantle()
+        // Restore the process-global audio store. Leaving the mock shared
+        // poisons every subsequent real join in the same xctest process
+        // (joins stall waiting on the stale store and time out).
+        mockAudioStore.dismantle()
         subject = nil
         uuidFactory = nil
         callController = nil

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -57,6 +57,11 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         // poisons every subsequent real join in the same xctest process
         // (joins stall waiting on the stale store and time out).
         mockAudioStore.dismantle()
+        // Restore the process-global UUID factory. Tests set a fixed
+        // `getResult` on the mock; leaving it injected makes every SDK
+        // `Task(disposableBag:)`/`sinkTask` share one identifier, so tasks
+        // cancel each other and real joins in the same process time out.
+        InjectedValues[\.uuidFactory] = StreamUUIDFactory()
         subject = nil
         uuidFactory = nil
         callController = nil
@@ -827,43 +832,6 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
                 }
             }
         )
-    }
-
-    @MainActor
-    func test_accept_joinFailsWithInterceptionError_callIsReportedEndedWithoutAdditionalLeave() async throws {
-        let firstCallUUID = UUID()
-        uuidFactory.getResult = firstCallUUID
-        let call = stubCall(response: defaultGetCallResponse)
-        call.stubbedJoinError = CallJoinInterceptionError("interceptor veto")
-        subject.streamVideo = mockedStreamVideo
-
-        subject.reportIncomingCall(
-            cid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: false
-        ) { _ in }
-
-        await waitExpectation(timeout: 1)
-
-        subject.provider(
-            callProvider,
-            perform: CXAnswerCallAction(call: firstCallUUID)
-        )
-
-        await fulfillment {
-            self.callProvider.invocations.contains {
-                switch $0 {
-                case let .reportCall(uuid, _, reason):
-                    return uuid == firstCallUUID && reason == .failed
-                default:
-                    return false
-                }
-            }
-        }
-        // The join flow has already left the call when the interceptor vetoes
-        // the join, so the service must not issue another leave.
-        XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 0)
     }
 
     // MARK: - mute
@@ -1768,7 +1736,7 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     /// fulfilled only when the joinSource `.callKit` hook is invoked.
     @MainActor
     private func assertAnswerActionFulfilledOnlyViaJoinSourceHook(
-        file: StaticString = #filePath,
+        file: StaticString = #file,
         line: UInt = #line
     ) async throws {
         let firstCallUUID = UUID()

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -651,7 +651,76 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     }
 
     @MainActor
-    func test_accept_joinFails_callIsReportedEndedToCallKit() async throws {
+    func test_accept_joinFailsAfterActionWasFulfilled_callIsReportedEndedToCallKit() async throws {
+        let firstCallUUID = UUID()
+        uuidFactory.getResult = firstCallUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        call.waitForJoinToResume = true
+        call.stubbedJoinError = ClientError("join failed")
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        await waitExpectation(timeout: 1)
+
+        let action = RecordingAnswerCallAction(call: firstCallUUID)
+        subject.provider(callProvider, perform: action)
+
+        await fulfillment { call.timesCalled(.join) == 1 }
+
+        // Fulfil the action through the joinSource hook while the join is
+        // still suspended, mirroring the joining stage invoking the hook
+        // right before the join flow throws (e.g. delivery timeout).
+        guard
+            case let .callKit(completion) = try XCTUnwrap(call.state.joinSource)
+        else {
+            return XCTFail("Expected the joinSource to be set to .callKit.")
+        }
+        completion.complete()
+        await fulfillment { action.fulfillWasCalled }
+
+        call.resumeJoin()
+
+        await fulfillment {
+            self.callProvider.invocations.contains {
+                switch $0 {
+                case let .reportCall(uuid, _, reason):
+                    return uuid == firstCallUUID && reason == .failed
+                default:
+                    return false
+                }
+            }
+        }
+        XCTAssertFalse(action.failWasCalled)
+        XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 1)
+    }
+
+    @MainActor
+    func test_accept_actionIsFulfilledOnlyWhenJoinSourceHookIsInvoked() async throws {
+        try await assertAnswerActionFulfilledOnlyViaJoinSourceHook()
+    }
+
+    @MainActor
+    func test_accept_appStateIsBackground_actionIsFulfilledOnlyWhenJoinSourceHookIsInvoked() async throws {
+        mockApplicationStateAdapter.stubbedState = .background
+
+        try await assertAnswerActionFulfilledOnlyViaJoinSourceHook()
+    }
+
+    @MainActor
+    func test_accept_appStateIsForeground_actionIsFulfilledOnlyWhenJoinSourceHookIsInvoked() async throws {
+        mockApplicationStateAdapter.stubbedState = .foreground
+
+        try await assertAnswerActionFulfilledOnlyViaJoinSourceHook()
+    }
+
+    @MainActor
+    func test_accept_joinFails_actionIsFailedAndCallIsNotReportedEnded() async throws {
         let firstCallUUID = UUID()
         uuidFactory.getResult = firstCallUUID
         let call = stubCall(response: defaultGetCallResponse)
@@ -667,22 +736,93 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
 
         await waitExpectation(timeout: 1)
 
-        subject.provider(
-            callProvider,
-            perform: CXAnswerCallAction(call: firstCallUUID)
-        )
+        let action = RecordingAnswerCallAction(call: firstCallUUID)
+        subject.provider(callProvider, perform: action)
 
-        await fulfillment {
-            self.callProvider.invocations.contains {
+        await fulfillment { action.failWasCalled }
+        XCTAssertFalse(action.fulfillWasCalled)
+        XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 1)
+
+        // The cleanup removes the call entry after the report decision, so
+        // once the entry is gone we can assert no report was made.
+        await fulfillment { self.subject.callCount == 0 }
+        XCTAssertFalse(
+            callProvider.invocations.contains {
                 switch $0 {
-                case let .reportCall(uuid, _, reason):
-                    return uuid == firstCallUUID && reason == .failed
+                case .reportCall:
+                    return true
                 default:
                     return false
                 }
             }
+        )
+    }
+
+    // MARK: - timedOutPerforming
+
+    @MainActor
+    func test_timedOutPerformingAnswerAction_whileJoining_joinIsAbortedAndBridgeResets() async throws {
+        let firstCallUUID = UUID()
+        uuidFactory.getResult = firstCallUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        call.waitForJoinToResume = true
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        await waitExpectation(timeout: 1)
+
+        let action = RecordingAnswerCallAction(call: firstCallUUID)
+        subject.provider(callProvider, perform: action)
+        await fulfillment { call.timesCalled(.join) == 1 }
+
+        subject.provider(callProvider, timedOutPerforming: action)
+
+        await fulfillment { call.timesCalled(.leave) == 1 }
+        XCTAssertEqual(
+            call.recordedInputPayload(String.self, for: .leave)?.first,
+            "callkit.join.timeout"
+        )
+        XCTAssertEqual(subject.callCount, 0)
+        await fulfillment {
+            if case .idle = self.subject.eventPipelineSubject.value {
+                return true
+            } else {
+                return false
+            }
         }
-        XCTAssertEqual(call.stubbedFunctionInput[.leave]?.count, 1)
+        // The timeout path never touches the dead action.
+        XCTAssertFalse(action.fulfillWasCalled)
+        XCTAssertFalse(action.failWasCalled)
+
+        // Resume the suspended join: it throws because the timeout's leave
+        // cancelled it, and the catch must not report the call as failed
+        // (the no-op fail on the dead action is tolerated) nor overwrite
+        // the timeout leave reason.
+        call.resumeJoin()
+
+        await fulfillment { action.failWasCalled }
+        XCTAssertFalse(action.fulfillWasCalled)
+        let leaveReasons = try XCTUnwrap(
+            call.recordedInputPayload(String.self, for: .leave)
+        )
+        XCTAssertEqual(leaveReasons.first, "callkit.join.timeout")
+        XCTAssertTrue(leaveReasons.dropFirst().allSatisfy(\.isEmpty))
+        XCTAssertFalse(
+            callProvider.invocations.contains {
+                switch $0 {
+                case .reportCall:
+                    return true
+                default:
+                    return false
+                }
+            }
+        )
     }
 
     @MainActor
@@ -1619,6 +1759,53 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         mockedStreamVideo.stub(for: \.state, with: mockedState)
     }
 
+    /// Answers an incoming call and asserts the deferred-fulfil contract:
+    /// the answer action stays pending while the join is running and is
+    /// fulfilled only when the joinSource `.callKit` hook is invoked.
+    @MainActor
+    private func assertAnswerActionFulfilledOnlyViaJoinSourceHook(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let firstCallUUID = UUID()
+        uuidFactory.getResult = firstCallUUID
+        let call = stubCall(response: defaultGetCallResponse)
+        subject.streamVideo = mockedStreamVideo
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        await waitExpectation(timeout: 1)
+
+        let action = RecordingAnswerCallAction(call: firstCallUUID)
+        subject.provider(callProvider, perform: action)
+
+        await fulfillment(file: file, line: line) { call.timesCalled(.join) == 1 }
+        XCTAssertFalse(action.fulfillWasCalled, file: file, line: line)
+
+        guard
+            case let .callKit(completion) = try XCTUnwrap(
+                call.state.joinSource,
+                file: file,
+                line: line
+            )
+        else {
+            return XCTFail(
+                "Expected the joinSource to be set to .callKit.",
+                file: file,
+                line: line
+            )
+        }
+        completion.complete()
+
+        await fulfillment(file: file, line: line) { action.fulfillWasCalled }
+        XCTAssertFalse(action.failWasCalled, file: file, line: line)
+    }
+
     /// Reports an incoming call and answers it, returning the stubbed call so
     /// tests can assert on the recorded join inputs.
     @MainActor
@@ -1679,6 +1866,23 @@ private class MockUUIDFactory: UUIDProviding {
 
     func get() -> UUID {
         getResult ?? .init()
+    }
+}
+
+/// Records `fulfill`/`fail` invocations because `CXAction.isComplete` doesn't
+/// update for actions that aren't part of a system-delivered transaction.
+private final class RecordingAnswerCallAction: CXAnswerCallAction, @unchecked Sendable {
+    private(set) var fulfillWasCalled = false
+    private(set) var failWasCalled = false
+
+    override func fulfill() {
+        fulfillWasCalled = true
+        super.fulfill()
+    }
+
+    override func fail() {
+        failWasCalled = true
+        super.fail()
     }
 }
 

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -346,6 +346,104 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         }
     }
 
+    func test_execute_withoutRetries_joinSourceIsCallKit_completionIsInvokedOnceJoined() async throws {
+        let completionInvoked = expectation(
+            description: "CallKit joinSource completion was invoked."
+        )
+        let joinSource = JoinSource.callKit(.init { completionInvoked.fulfill() })
+        call.state.joinSource = joinSource
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: joinSource,
+                    deliverySubject: .init(nil)
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .joined
+        ) { @MainActor in
+            await self.fulfillment(of: [completionInvoked], timeout: defaultTimeout)
+            XCTAssertEqual(self.streamVideo.state.activeCall?.cId, self.call.cId)
+        }
+    }
+
+    func test_execute_withoutRetries_joinSourceIsCallKitAndJoinFails_completionIsNotInvoked() async throws {
+        let completionInvoked = expectation(
+            description: "CallKit joinSource completion should not be invoked."
+        )
+        completionInvoked.isInverted = true
+        let joinSource = JoinSource.callKit(.init { completionInvoked.fulfill() })
+        call.state.joinSource = joinSource
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: joinSource,
+                    deliverySubject: .init(nil),
+                    retryPolicy: .init(maxRetries: 0, delay: { _ in 0 })
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            expectedTransition: .error
+        ) { @MainActor in
+            await self.fulfillment(of: [completionInvoked], timeout: 1)
+        }
+    }
+
+    func test_execute_withoutRetries_joinSourceIsCallKitAndInterceptorThrows_completionIsNotInvoked() async throws {
+        let completionInvoked = expectation(
+            description: "CallKit joinSource completion should not be invoked."
+        )
+        completionInvoked.isInverted = true
+        let joinSource = JoinSource.callKit(.init { completionInvoked.fulfill() })
+        call.state.joinSource = joinSource
+        let joinInterceptor = CallJoinInterceptor_Spy { _ in
+            throw TestError()
+        }
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: joinSource,
+                    deliverySubject: .init(nil),
+                    joinInterceptor: joinInterceptor
+                )
+            )
+        )
+
+        try await assertJoining(
+            context,
+            joinResponse: JoinCallResponse.dummy(),
+            expectedTransition: .error
+        ) { @MainActor in
+            await self.fulfillment(of: [completionInvoked], timeout: 1)
+            XCTAssertNil(self.streamVideo.state.activeCall)
+        }
+    }
+
     func test_execute_withoutRetries_joinInterceptorThrows_tracesFailureAndTransitionsToError() async throws {
         let deliverySubject = CurrentValueSubject<JoinCallResponse?, Error>(nil)
         let deliveryExpectation = expectation(description: "DeliverySubject delivered failure.")

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore_CallKitRecoveryMiddlewareTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore_CallKitRecoveryMiddlewareTests.swift
@@ -1,0 +1,175 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+@testable import StreamVideo
+import XCTest
+
+final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked Sendable {
+
+    private var receivedActions: Atomic<[RTCAudioStore.StoreAction]>! = .init(wrappedValue: [])
+    private var subject: RTCAudioStore.CallKitRecoveryMiddleware!
+
+    override func setUp() {
+        super.setUp()
+        subject = .init()
+        let receivedActions = receivedActions
+        subject.dispatcher = .init { actions, _, _, _ in
+            receivedActions?.mutate { $0 + actions.map(\.wrappedValue) }
+        }
+    }
+
+    override func tearDown() {
+        subject.dispatcher = nil
+        subject = nil
+        receivedActions = nil
+        super.tearDown()
+    }
+
+    // MARK: - apply
+
+    func test_apply_activateWhileRecording_dispatchesRecordingRestart() {
+        let (module, _) = makeModule(isRecording: true)
+        let state = makeState(
+            isRecording: true,
+            isMicrophoneMuted: true,
+            audioDeviceModule: module
+        )
+
+        subject.apply(
+            state: state,
+            action: .callKit(.activate(AVAudioSession.sharedInstance())),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        let actions = receivedActions.wrappedValue
+        XCTAssertEqual(actions.count, 3)
+        guard
+            actions.count == 3,
+            case .setRecording(false) = actions[0],
+            case .setRecording(true) = actions[1],
+            case .setMicrophoneMuted(true) = actions[2]
+        else {
+            return XCTFail("Unexpected restart actions: \(actions).")
+        }
+    }
+
+    func test_apply_activateWhileNotRecording_doesNotDispatch() {
+        let (module, _) = makeModule(isRecording: false)
+        let state = makeState(
+            isRecording: false,
+            audioDeviceModule: module
+        )
+
+        subject.apply(
+            state: state,
+            action: .callKit(.activate(AVAudioSession.sharedInstance())),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+    }
+
+    func test_apply_activateWhileRecordingWithoutAudioDeviceModule_doesNotDispatch() {
+        let state = makeState(
+            isRecording: true,
+            audioDeviceModule: nil
+        )
+
+        subject.apply(
+            state: state,
+            action: .callKit(.activate(AVAudioSession.sharedInstance())),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+    }
+
+    func test_apply_deactivateWhileRecording_doesNotDispatch() {
+        let (module, _) = makeModule(isRecording: true)
+        let state = makeState(
+            isRecording: true,
+            audioDeviceModule: module
+        )
+
+        subject.apply(
+            state: state,
+            action: .callKit(.deactivate(AVAudioSession.sharedInstance())),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+    }
+
+    func test_apply_nonCallKitActionWhileRecording_doesNotDispatch() {
+        let (module, _) = makeModule(isRecording: true)
+        let state = makeState(
+            isRecording: true,
+            audioDeviceModule: module
+        )
+
+        subject.apply(
+            state: state,
+            action: .setActive(true),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeModule(
+        isRecording: Bool,
+        isMicrophoneMuted: Bool = false
+    ) -> (AudioDeviceModule, MockRTCAudioDeviceModule) {
+        let source = MockRTCAudioDeviceModule()
+        source.stub(for: \.isRecording, with: isRecording)
+        source.stub(for: \.isMicrophoneMuted, with: isMicrophoneMuted)
+
+        let module = AudioDeviceModule(source)
+        return (module, source)
+    }
+
+    private func makeState(
+        isActive: Bool = false,
+        isRecording: Bool = false,
+        isMicrophoneMuted: Bool = false,
+        audioDeviceModule: AudioDeviceModule? = nil
+    ) -> RTCAudioStore.StoreState {
+        .init(
+            isActive: isActive,
+            isInterrupted: false,
+            isRecording: isRecording,
+            isMicrophoneMuted: isMicrophoneMuted,
+            isMutedSpeechDetectionEnabled: false,
+            hasRecordingPermission: false,
+            activeSessionIdentifier: "",
+            audioDeviceModule: audioDeviceModule,
+            currentRoute: .empty,
+            audioSessionConfiguration: .init(
+                category: .soloAmbient,
+                mode: .default,
+                options: [],
+                overrideOutputAudioPort: .none
+            ),
+            webRTCAudioSessionConfiguration: .init(
+                isAudioEnabled: false,
+                useManualAudio: false,
+                prefersNoInterruptionsFromSystemAlerts: false
+            ),
+            stereoConfiguration: .init(playout: .init(preferred: false, enabled: false))
+        )
+    }
+}

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -573,6 +573,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
 
         subject.context.coordinator = mockCoordinatorStack.coordinator
         subject.context.reconnectAttempts = 11
+        subject.context.joinSource = .inApp
         await mockCoordinatorStack
             .coordinator
             .stateAdapter
@@ -582,6 +583,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
             every: 0.3
         )
+        let start = Date()
 
         try await assertTransition(
             from: .connected,
@@ -589,6 +591,49 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             subject: subject
         ) { _ in }
 
+        // Non-CallKit joins go through the readiness wait: with the audio
+        // store inactive the stage must hold for at least the configured
+        // readiness window before configuring the peer connections.
+        XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), 0.1)
+        cancellable.cancel()
+    }
+
+    func test_transition_fromConnected_joinSourceIsCallKit_doesNotWaitForAudioSessionReadiness() async throws {
+        let previousTimeout = WebRTCConfiguration.timeout
+        let mockAudioStore = MockRTCAudioStore()
+        mockAudioStore.makeShared()
+        defer {
+            WebRTCConfiguration.timeout = previousTimeout
+            mockAudioStore.dismantle()
+        }
+        // With a practically infinite readiness window and an inactive audio
+        // store, the stage can only reach `.joined` within the assertion
+        // timeout if the CallKit join skipped the readiness wait entirely.
+        WebRTCConfiguration.timeout.audioSessionConfigurationCompletion = 60
+
+        subject.context.coordinator = mockCoordinatorStack.coordinator
+        subject.context.reconnectAttempts = 11
+        subject.context.joinSource = .callKit(.init {})
+        await mockCoordinatorStack
+            .coordinator
+            .stateAdapter
+            .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
+        mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
+        let cancellable = receiveEvent(
+            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            every: 0.3
+        )
+        let start = Date()
+
+        try await assertTransition(
+            from: .connected,
+            expectedTarget: .joined,
+            subject: subject
+        ) { _ in }
+
+        // Sanity bound: the join must complete well below the readiness
+        // window, proving no stall occurred while the store stayed inactive.
+        XCTAssertLessThan(Date().timeIntervalSince(start), defaultTimeout)
         cancellable.cancel()
     }
 

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -737,10 +737,14 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         }
     }
 
-    func test_configureAudioSession_callKitSource_completesActionCompletion() async throws {
+    func test_configureAudioSession_callKitSource_doesNotCompleteActionCompletion() async throws {
+        // The CallKit answer action is fulfilled by the Call state machine's
+        // joining stage once the call has joined successfully, not while the
+        // audio session is being configured.
         let completionExpectation = expectation(
-            description: "CallKit action completion invoked."
+            description: "CallKit action completion should not be invoked."
         )
+        completionExpectation.isInverted = true
         let sfuStack = MockSFUStack()
         sfuStack.setConnectionState(to: .connected(healthCheckInfo: .init()))
         await subject.set(sfuAdapter: sfuStack.adapter)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1759/blinkfix-answer-call-action-fulfilment-in-callkit.

### 🎯 Goal

The CXAnswerCallAction was fulfilled right after `accept()`, before the call had actually joined. This made the system UI replace "connecting…" with a running call duration prematurely, and handed audio session ownership to the SDK earlier than intended. The answer action is now fulfilled only once the call has successfully joined (join interceptor included).

### 📝 Summary

- Removed the premature `action.fulfill()` after `accept()`; the action is now fulfilled by the Call joining stage via the `JoinSource.ActionCompletion` hook, after the join (and any `CallJoinIntercepting`) has completed and right before the call becomes active.
- Exactly-once completion guard: on join failure the action is failed; if the failure surfaces after the action was already fulfilled (delivery-timeout race), the call is reported to CallKit as `.failed` instead.
- Implemented `provider(_:timedOutPerforming:)`: if CallKit times out the pending answer (slow join / long interceptor), the SDK aborts the join and leaves with reason `callkit.join.timeout`.
- Skipped the audio-session readiness wait for CallKit joins in the WebRTC joining stage (it became circular with the new ordering); peer connections are now configured before session activation — the canonical CallKit+WebRTC pattern.
- Fixed the resulting dead-mic regression with a new `CallKitRecoveryMiddleware`: when `.callKit(.activate)` arrives while recording is already on, the recording path is restarted (same recovery pattern as audio interruptions), so the mic is live without a manual mute toggle.
- Updated DocC across the lifecycle (`CallKitService`, `JoinSource.ActionCompletion`, joining stage, `configureAudioSession`) and added an "Answering calls" section to the CallKit integration docs page.

### 🛠 Implementation

- The joining stage invokes the `.callKit` completion inside the existing MainActor block that publishes `activeCall` — success path only; failure paths complete the action exactly once through an atomic guard in `CallKitService`.
- Audio hand-off ordering: `configureAudioSession(shouldSetActive: false)` → join completes → action fulfilled → CallKit activates the session → `didActivate` dispatches `.callKit(.activate)` into RTCAudioStore → deferred activation applies the audio policy. The recovery middleware reacts to the same action and restarts recording only when it was already on (in-app flows never dispatch it).
- Playout intentionally excluded from the restart: it is already refreshed via `audioSessionDidActivate` and the deferred `setAudioEnabled(true)`; the regression was capture-only.

### 🧪 Manual Testing Notes

All scenarios on a physical device, callee side answering via CallKit unless stated.

**Audio (peer connections now configured before session activation)**
1. Lock the device, receive a ringing call, answer from the lock screen (app cold-launched in background). Verify: remote audio audible promptly, and the local mic is live **without toggling mute** (caller hears you immediately) — regression check for the dead-mic fix.
2. Repeat with a Bluetooth headset connected — verify the route is honored once audio starts.
3. Repeat with the app in the foreground (in-app CallKit banner) — same audio expectations.

**System UI / answer-action lifecycle**
4. Answer with a normal network: system UI shows "connecting…" until the call joins, then the call duration starts (no premature duration).
5. Answer with a poor network (Network Link Conditioner): if the join completes within CallKit's answer window, the call connects normally; no premature duration at any point.
6. Enable the Synchronised Call Join Interceptor in the DemoApp debug menu and make the readiness handshake exceed CallKit's answer window (~5 s): the system ends the call and the SDK leaves with reason `callkit.join.timeout` (verify in logs); the app returns to a clean idle state and can receive the next call.
7. Answer, then hang up immediately while still "connecting…" — verify clean teardown.

**Audio session contention**
8. While on a regular phone (PSTN) call, answer a Stream call: if audio activation is delayed beyond ~10 s the audio watchdog forces a rejoin — verify the call recovers audio or fails cleanly, with no endless rejoin loop.

**CallKit mute sync**
9. After connecting, toggle mute/unmute from the CallKit system UI and from the in-app UI — verify both stay in sync and audio capture follows.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CallKit system UI no longer displaying running call duration before the user connects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->