### PR TITLE
[Fix] Correct client event retry reporting

### DIFF
--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -148,7 +148,8 @@ extension Call.StateMachine.Stage {
                 ring: input.ring,
                 notify: input.notify,
                 source: input.source,
-                policy: input.policy
+                policy: input.policy,
+                coordinatorJoinAttemptCount: input.currentNumberOfRetries
             )
 
             try Task.checkCancellation()

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -136,6 +136,8 @@ class CallController: @unchecked Sendable {
     ///   - source: Describes the source from which the join action was triggered.
     ///            Use this to indicate if the call was joined from in-app UI or
     ///            via CallKit.
+    ///   - coordinatorJoinAttemptCount: Zero-based retry index of the
+    ///     coordinator join attempt.
     /// - Returns: A newly created `JoinCallResponse`.
     /// - Throws: If authentication, API call, or SFU connection fails.
     @discardableResult
@@ -146,7 +148,8 @@ class CallController: @unchecked Sendable {
         ring: Bool = false,
         notify: Bool = false,
         source: JoinSource,
-        policy: WebRTCJoinPolicy = .default
+        policy: WebRTCJoinPolicy = .default,
+        coordinatorJoinAttemptCount: Int = 0
     ) async throws -> JoinCallResponse {
         /// Each join attempt creates a fresh `PassthroughSubject` so
         /// that a failure from a previous attempt cannot accidentally
@@ -180,7 +183,8 @@ class CallController: @unchecked Sendable {
             notify: notify,
             source: source,
             joinResponseHandler: joinCallResponseSubject,
-            policy: policy
+            policy: policy,
+            coordinatorJoinAttemptCount: coordinatorJoinAttemptCount
         )
 
         do {

--- a/Sources/StreamVideo/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter.swift
+++ b/Sources/StreamVideo/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter.swift
@@ -24,6 +24,7 @@ final class WebRTCPeerConnectionConnectReporter: @unchecked Sendable {
     private let reporter: ClientEventReporting
     private let peerConnection: ClientEventPeerConnection
     private let details: ClientEventStageDetails
+    private let retryCount: Int
     private let disposableBag = DisposableBag()
     private let processingQueue = OperationQueue(maxConcurrentOperationCount: 1)
     private var attempt: ClientEventStageAttempt?
@@ -39,6 +40,7 @@ final class WebRTCPeerConnectionConnectReporter: @unchecked Sendable {
     ///   - reporter: The reporter that delivers the events.
     ///   - wasPreviouslyConnected: Whether the ICE connection had been
     ///     established earlier in the same session (a reconnect).
+    ///   - retryCount: Retry count to attach to the completion event.
     ///   - details: Stage-specific identifiers (sfu id, session ids) included
     ///     on every emitted event.
     init(
@@ -47,11 +49,13 @@ final class WebRTCPeerConnectionConnectReporter: @unchecked Sendable {
         iceStatePublisher: AnyPublisher<RTCIceConnectionState, Never>,
         reporter: ClientEventReporting,
         wasPreviouslyConnected: Bool,
+        retryCount: Int = 0,
         details: ClientEventStageDetails
     ) {
         self.reporter = reporter
         peerConnection = .init(peerConnectionType)
         self.details = details.merging(.init(wasPreviouslyConnected: wasPreviouslyConnected))
+        self.retryCount = retryCount
 
         Publishers.CombineLatest(
             statePublisher.prepend(.new),
@@ -135,7 +139,7 @@ final class WebRTCPeerConnectionConnectReporter: @unchecked Sendable {
         await reporter.completeStage(
             attempt,
             outcome: outcome,
-            retryCount: 0,
+            retryCount: retryCount,
             details: .init(iceState: clientEventICEState),
             failure: failure
         )

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Connecting.swift
@@ -192,7 +192,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                             .clientEventReporter
                             .completeStage(
                                 coordinatorJoinAttempt,
-                                retryCount: Int(context.reconnectAttempts),
+                                retryCount: context.clientEventRetryCount,
                                 details: coordinatorJoinDetails,
                                 failure: .init(error)
                             )
@@ -203,7 +203,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         .completeStage(
                             coordinatorJoinAttempt,
                             outcome: .success,
-                            retryCount: Int(context.reconnectAttempts),
+                            retryCount: context.clientEventRetryCount,
                             details: coordinatorJoinDetails.merging(
                                 .init(
                                     callSessionId: response.call.session?.id
@@ -243,7 +243,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                             .clientEventReporter
                             .completeStage(
                                 coordinatorWSAttempt,
-                                retryCount: Int(context.reconnectAttempts),
+                                retryCount: context.clientEventRetryCount,
                                 details: coordinatorWSDetails,
                                 failure: .init(error)
                             )
@@ -254,7 +254,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                         .completeStage(
                             coordinatorWSAttempt,
                             outcome: .success,
-                            retryCount: Int(context.reconnectAttempts),
+                            retryCount: context.clientEventRetryCount,
                             details: coordinatorWSDetails,
                             failure: nil
                         )

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Joining.swift
@@ -173,7 +173,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     context.reconnectionStrategy = context
                         .reconnectionStrategy
                         .next
-                    transitionDisconnectOrError(error)
+                    transitionErrorOrDisconnect(error)
                 }
             }
         }
@@ -656,6 +656,7 @@ extension WebRTCCoordinator.StateMachine.Stage {
                     iceStatePublisher: peerConnection.iceConnectionStatePublisher,
                     reporter: coordinator.clientEventReporter,
                     wasPreviouslyConnected: wasPreviouslyConnected,
+                    retryCount: context.clientEventRetryCount,
                     details: details
                 )
             }
@@ -717,15 +718,30 @@ extension WebRTCCoordinator.StateMachine.Stage {
         private func completeWebSocketJoin(
             _ error: Error?
         ) async {
+            // Use the client-event retry count instead of `reconnectAttempts`
+            // directly. During initial join, a WSJoin timeout is retried by the
+            // outer Call.join() loop and should report attempt 0, 1, 2, ...
+            // even though WebRTC recovery has not started yet.
             if let error {
                 await webSocketJoinTelemetryReporter.fail(
-                    retryCount: Int(context.reconnectAttempts),
+                    retryCount: context.clientEventRetryCount,
                     error: error
                 )
             } else {
                 await webSocketJoinTelemetryReporter.complete(
-                    retryCount: Int(context.reconnectAttempts)
+                    retryCount: context.clientEventRetryCount
                 )
+            }
+        }
+
+        /// Initial joins are owned by `Call.join()`, which retries only when the
+        /// pending join subject receives a failure. Recovery joins keep using the
+        /// disconnected path so the WebRTC recovery state machine can continue.
+        private func transitionErrorOrDisconnect(_ error: Error) {
+            if context.joinResponseHandler != nil {
+                transitionErrorOrLog(error)
+            } else {
+                transitionDisconnectOrError(error)
             }
         }
 

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -15,6 +15,9 @@ extension WebRTCCoordinator.StateMachine {
             var authenticator: WebRTCAuthenticating = WebRTCAuthenticator()
             var sfuEventObserver: SFUEventAdapter?
             var reconnectAttempts: UInt32 = 0
+            /// Zero-based retry index of the `CoordinatorJoin` attempt that
+            /// created this coordinator flow.
+            var coordinatorJoinAttemptCount: Int = 0
             /// Shared id for events emitted by one coordinator connection flow.
             var coordinatorConnectId: String = UUID().uuidString.lowercased()
             var currentSFU: String = ""
@@ -90,6 +93,24 @@ extension WebRTCCoordinator.StateMachine {
             var healthCheckInterval: TimeInterval = 5
             var webSocketHealthTimeout: TimeInterval = 15
             var lastHealthCheckReceivedAt: Date?
+            /// Retry count attached to client-event stage completions.
+            ///
+            /// The retry source depends on where the flow is in the call
+            /// lifecycle:
+            /// - Before the call has joined, failures are retried by the outer
+            ///   `Call.join()` loop. Those attempts create new `JoinInitiated`,
+            ///   `CoordinatorJoin`, `CoordinatorWS`, and `WSJoin` event pairs,
+            ///   so they use `coordinatorJoinAttemptCount`.
+            /// - After the call has joined, failures are handled by WebRTC
+            ///   recovery. Those attempts reuse the recovery context and use
+            ///   `reconnectAttempts`.
+            ///
+            /// In particular, an initial `WSJoin` timeout is still a failed
+            /// join attempt, not an in-call reconnect, even though the failure
+            /// happens on the SFU websocket.
+            var clientEventRetryCount: Int {
+                max(coordinatorJoinAttemptCount, Int(reconnectAttempts))
+            }
 
             /// Stores the initial join response so the pending ``Call.join()``
             /// completion can be finished once the SFU handshake succeeds.

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Stages/WebRTCCoordinator+Stage.swift
@@ -97,10 +97,11 @@ extension WebRTCCoordinator.StateMachine {
             ///
             /// The retry source depends on where the flow is in the call
             /// lifecycle:
-            /// - Before the call has joined, failures are retried by the outer
-            ///   `Call.join()` loop. Those attempts create new `JoinInitiated`,
-            ///   `CoordinatorJoin`, `CoordinatorWS`, and `WSJoin` event pairs,
-            ///   so they use `coordinatorJoinAttemptCount`.
+            /// - While a `Call.join()` caller is still waiting for completion,
+            ///   failures are retried by that outer join loop. Those attempts
+            ///   create new `JoinInitiated`, `CoordinatorJoin`, `CoordinatorWS`,
+            ///   and `WSJoin` event pairs, so they use
+            ///   `coordinatorJoinAttemptCount`.
             /// - After the call has joined, failures are handled by WebRTC
             ///   recovery. Those attempts reuse the recovery context and use
             ///   `reconnectAttempts`.
@@ -109,7 +110,9 @@ extension WebRTCCoordinator.StateMachine {
             /// join attempt, not an in-call reconnect, even though the failure
             /// happens on the SFU websocket.
             var clientEventRetryCount: Int {
-                max(coordinatorJoinAttemptCount, Int(reconnectAttempts))
+                joinResponseHandler != nil
+                    ? coordinatorJoinAttemptCount
+                    : Int(reconnectAttempts)
             }
 
             /// Stores the initial join response so the pending ``Call.join()``

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -115,6 +115,8 @@ final class WebRTCCoordinator: @unchecked Sendable {
     ///   - source: Source that initiated the join.
     ///   - joinResponseHandler: A subject that receives the join completion
     ///     result once the flow finishes.
+    ///   - coordinatorJoinAttemptCount: Zero-based retry index of the
+    ///     coordinator join attempt.
     func connect(
         create: Bool = true,
         callSettings: CallSettings?,
@@ -123,7 +125,8 @@ final class WebRTCCoordinator: @unchecked Sendable {
         notify: Bool,
         source: JoinSource,
         joinResponseHandler: PassthroughSubject<JoinCallResponse, Error>,
-        policy: WebRTCJoinPolicy = .default
+        policy: WebRTCJoinPolicy = .default,
+        coordinatorJoinAttemptCount: Int = 0
     ) async throws {
         // We update the initial CallSettings so that we have a reference
         // on what CallSettings the caller wants to have after the user joins
@@ -133,6 +136,7 @@ final class WebRTCCoordinator: @unchecked Sendable {
         stateMachine.currentStage.context.joinSource = source
         stateMachine.currentStage.context.joinResponseHandler = joinResponseHandler
         stateMachine.currentStage.context.joinPolicy = policy
+        stateMachine.currentStage.context.coordinatorJoinAttemptCount = coordinatorJoinAttemptCount
 
         stateMachine.transition(
             .connecting(

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -568,7 +568,8 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
                     Bool,
                     Bool,
                     JoinSource,
-                    WebRTCJoinPolicy
+                    WebRTCJoinPolicy,
+                    Int
                 ).self,
                 for: .join
             )?.first?.5,
@@ -594,7 +595,8 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
                     Bool,
                     Bool,
                     JoinSource,
-                    WebRTCJoinPolicy
+                    WebRTCJoinPolicy,
+                    Int
                 ).self,
                 for: .join
             )?.first?.5,
@@ -622,7 +624,8 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
                     Bool,
                     Bool,
                     JoinSource,
-                    WebRTCJoinPolicy
+                    WebRTCJoinPolicy,
+                    Int
                 ).self,
                 for: .join
             )?.first?.2?.highScaleLivestreamPublisherHint,
@@ -647,7 +650,8 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
                     Bool,
                     Bool,
                     JoinSource,
-                    WebRTCJoinPolicy
+                    WebRTCJoinPolicy,
+                    Int
                 ).self,
                 for: .join
             )?.first

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -776,7 +776,8 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
             Bool,
             Bool,
             JoinSource,
-            WebRTCJoinPolicy
+            WebRTCJoinPolicy,
+            Int
         ).self
         let recordedInput = try XCTUnwrap(
             callController.recordedInputPayload(
@@ -790,6 +791,7 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         XCTAssertEqual(context.input.join?.ring, recordedInput.3)
         XCTAssertEqual(context.input.join?.notify, recordedInput.4)
         XCTAssertEqual(context.input.join?.source, recordedInput.5)
+        XCTAssertEqual(context.input.join?.currentNumberOfRetries, recordedInput.7)
 
         switch (context.input.join?.policy, recordedInput.6) {
         case (.default, .default):

--- a/StreamVideoTests/Mock/CallController_Mock.swift
+++ b/StreamVideoTests/Mock/CallController_Mock.swift
@@ -20,7 +20,8 @@ class CallController_Mock: CallController, @unchecked Sendable {
         ring: Bool = false,
         notify: Bool = false,
         source: JoinSource,
-        policy: WebRTCJoinPolicy = .default
+        policy: WebRTCJoinPolicy = .default,
+        coordinatorJoinAttemptCount: Int = 0
     ) async throws -> JoinCallResponse {
         mockResponseBuilder.makeJoinCallResponse(cid: super.call?.cId ?? "default:\(String.unique)")
     }

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -31,7 +31,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
             ring: Bool = false,
             notify: Bool = false,
             source: JoinSource,
-            policy: WebRTCJoinPolicy
+            policy: WebRTCJoinPolicy,
+            coordinatorJoinAttemptCount: Int
         )
 
         case leave(reason: String?)
@@ -63,9 +64,10 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 ring,
                 notify,
                 source,
-                policy
+                policy,
+                coordinatorJoinAttemptCount
             ):
-                return (create, callSettings, options, ring, notify, source, policy)
+                return (create, callSettings, options, ring, notify, source, policy, coordinatorJoinAttemptCount)
             case let .leave(reason):
                 return reason ?? ""
             case .observeWebRTCStateUpdated:
@@ -122,7 +124,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         ring: Bool = false,
         notify: Bool = false,
         source: JoinSource,
-        policy: WebRTCJoinPolicy = .default
+        policy: WebRTCJoinPolicy = .default,
+        coordinatorJoinAttemptCount: Int = 0
     ) async throws -> JoinCallResponse {
         stubbedFunctionInput[.join]?.append(
             .join(
@@ -132,7 +135,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 ring: ring,
                 notify: notify,
                 source: source,
-                policy: policy
+                policy: policy,
+                coordinatorJoinAttemptCount: coordinatorJoinAttemptCount
             )
         )
 
@@ -152,7 +156,8 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
                 ring: ring,
                 notify: notify,
                 source: source,
-                policy: policy
+                policy: policy,
+                coordinatorJoinAttemptCount: coordinatorJoinAttemptCount
             )
         }
     }

--- a/StreamVideoTests/Utils/ClientEventReporting/CoordinatorJoinClientEventScenarios_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/CoordinatorJoinClientEventScenarios_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 @testable import StreamVideo
 import XCTest
 
@@ -80,7 +81,8 @@ final class CoordinatorJoinClientEventScenarios_Tests: XCTestCase, @unchecked Se
         let subject = makeConnectingStage(
             harness: harness,
             reconnectAttempts: 0,
-            coordinatorJoinAttemptCount: 2
+            coordinatorJoinAttemptCount: 2,
+            hasPendingJoinCompletion: true
         )
 
         try await assertTransition(
@@ -102,7 +104,8 @@ final class CoordinatorJoinClientEventScenarios_Tests: XCTestCase, @unchecked Se
     private func makeConnectingStage(
         harness: ClientEventScenarioHarness,
         reconnectAttempts: UInt32,
-        coordinatorJoinAttemptCount: Int = 0
+        coordinatorJoinAttemptCount: Int = 0,
+        hasPendingJoinCompletion: Bool = false
     ) -> WebRTCCoordinator.StateMachine.Stage {
         var context = WebRTCCoordinator.StateMachine.Stage.Context(
             coordinator: harness.stack.coordinator,
@@ -110,6 +113,9 @@ final class CoordinatorJoinClientEventScenarios_Tests: XCTestCase, @unchecked Se
         )
         context.authenticator = harness.stack.webRTCAuthenticator
         context.coordinatorJoinAttemptCount = coordinatorJoinAttemptCount
+        if hasPendingJoinCompletion {
+            context.joinResponseHandler = PassthroughSubject<JoinCallResponse, Error>()
+        }
         return .connecting(
             context,
             create: true,

--- a/StreamVideoTests/Utils/ClientEventReporting/CoordinatorJoinClientEventScenarios_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/CoordinatorJoinClientEventScenarios_Tests.swift
@@ -62,17 +62,54 @@ final class CoordinatorJoinClientEventScenarios_Tests: XCTestCase, @unchecked Se
         XCTAssertEqual(trace.begun(.coordinatorJoin).first?.details.joinReason, .firstAttempt)
     }
 
+    func test_authenticationSucceedsAfterCallJoinRetry_reportsCoordinatorJoinSuccessWithJoinRetryCount(
+    ) async throws {
+        let harness = ClientEventScenarioHarness()
+        let response = JoinCallResponse.dummy(
+            call: .dummy(currentSessionId: "call-session-1")
+        )
+        harness.stack.webRTCAuthenticator.stub(
+            for: .authenticate,
+            with: Result<(SFUAdapter, JoinCallResponse), Error>
+                .success((harness.stack.sfuStack.adapter, response))
+        )
+        harness.stack.webRTCAuthenticator.stub(
+            for: .waitForAuthentication,
+            with: Result<Void, Error>.success(())
+        )
+        let subject = makeConnectingStage(
+            harness: harness,
+            reconnectAttempts: 0,
+            coordinatorJoinAttemptCount: 2
+        )
+
+        try await assertTransition(
+            subject,
+            from: .idle,
+            expectedTarget: .connected
+        ) { _ in }
+
+        let trace = await harness.trace
+        trace.assertCompleted(
+            .coordinatorJoin,
+            outcome: .success,
+            retryCount: 2
+        )
+    }
+
     // MARK: - Private
 
     private func makeConnectingStage(
         harness: ClientEventScenarioHarness,
-        reconnectAttempts: UInt32
+        reconnectAttempts: UInt32,
+        coordinatorJoinAttemptCount: Int = 0
     ) -> WebRTCCoordinator.StateMachine.Stage {
         var context = WebRTCCoordinator.StateMachine.Stage.Context(
             coordinator: harness.stack.coordinator,
             reconnectAttempts: reconnectAttempts
         )
         context.authenticator = harness.stack.webRTCAuthenticator
+        context.coordinatorJoinAttemptCount = coordinatorJoinAttemptCount
         return .connecting(
             context,
             create: true,

--- a/StreamVideoTests/Utils/ClientEventReporting/WSJoinClientEventScenarios_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/WSJoinClientEventScenarios_Tests.swift
@@ -42,13 +42,25 @@ final class WSJoinClientEventScenarios_Tests: XCTestCase, @unchecked Sendable {
         defer { WebRTCConfiguration.timeout = previousTimeout }
 
         let harness = ClientEventScenarioHarness()
-        let subject = try await makeJoiningStage(harness: harness, reconnectAttempts: 2)
+        let subject = try await makeJoiningStage(
+            harness: harness,
+            reconnectAttempts: 1,
+            coordinatorJoinAttemptCount: 2
+        )
 
         try await assertTransition(
             subject,
             from: .connected,
             expectedTarget: .disconnected
         ) { _ in }
+
+        let trace = await harness.trace
+        trace.assertCompleted(
+            .wsJoin,
+            outcome: .failure,
+            retryCount: 1,
+            failureCode: ClientEventFailureCode.requestTimeout.rawValue
+        )
     }
 
     func test_joinResponseAfterRetries_reportsWSJoinSuccessWithRetryCount() async throws {

--- a/StreamVideoTests/Utils/ClientEventReporting/WSJoinClientEventScenarios_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/WSJoinClientEventScenarios_Tests.swift
@@ -14,12 +14,16 @@ final class WSJoinClientEventScenarios_Tests: XCTestCase, @unchecked Sendable {
         defer { WebRTCConfiguration.timeout = previousTimeout }
 
         let harness = ClientEventScenarioHarness()
-        let subject = try await makeJoiningStage(harness: harness, reconnectAttempts: 2)
-
+        let subject = try await makeJoiningStage(
+            harness: harness,
+            reconnectAttempts: 0,
+            coordinatorJoinAttemptCount: 2
+        )
+        subject.context.joinResponseHandler = PassthroughSubject<JoinCallResponse, Error>()
         try await assertTransition(
             subject,
             from: .connected,
-            expectedTarget: .disconnected
+            expectedTarget: .error
         ) { _ in }
 
         let trace = await harness.trace
@@ -29,6 +33,22 @@ final class WSJoinClientEventScenarios_Tests: XCTestCase, @unchecked Sendable {
             retryCount: 2,
             failureCode: ClientEventFailureCode.requestTimeout.rawValue
         )
+    }
+
+    func test_joinResponseTimeout_whenJoinCompletionIsNotPending_transitionsToDisconnected(
+    ) async throws {
+        let previousTimeout = WebRTCConfiguration.timeout
+        WebRTCConfiguration.timeout.join = 0.1
+        defer { WebRTCConfiguration.timeout = previousTimeout }
+
+        let harness = ClientEventScenarioHarness()
+        let subject = try await makeJoiningStage(harness: harness, reconnectAttempts: 2)
+
+        try await assertTransition(
+            subject,
+            from: .connected,
+            expectedTarget: .disconnected
+        ) { _ in }
     }
 
     func test_joinResponseAfterRetries_reportsWSJoinSuccessWithRetryCount() async throws {
@@ -88,7 +108,8 @@ final class WSJoinClientEventScenarios_Tests: XCTestCase, @unchecked Sendable {
 
     private func makeJoiningStage(
         harness: ClientEventScenarioHarness,
-        reconnectAttempts: UInt32
+        reconnectAttempts: UInt32,
+        coordinatorJoinAttemptCount: Int = 0
     ) async throws -> WebRTCCoordinator.StateMachine.Stage {
         await harness.installSFUAdapter()
         harness.stack.webRTCAuthenticator.stub(
@@ -101,6 +122,7 @@ final class WSJoinClientEventScenarios_Tests: XCTestCase, @unchecked Sendable {
             currentSFU: "sfu-1"
         )
         context.authenticator = harness.stack.webRTCAuthenticator
+        context.coordinatorJoinAttemptCount = coordinatorJoinAttemptCount
         context.initialJoinCallResponse = .dummy(
             call: .dummy(currentSessionId: "call-session-1")
         )

--- a/StreamVideoTests/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter_Tests.swift
@@ -25,7 +25,8 @@ final class WebRTCPeerConnectionConnectReporter_Tests: XCTestCase, @unchecked Se
 
     private func makeSubject(
         peerConnectionType: PeerConnectionType = .publisher,
-        wasPreviouslyConnected: Bool = false
+        wasPreviouslyConnected: Bool = false,
+        retryCount: Int = 0
     ) {
         subject = .init(
             peerConnectionType: peerConnectionType,
@@ -33,6 +34,7 @@ final class WebRTCPeerConnectionConnectReporter_Tests: XCTestCase, @unchecked Se
             iceStatePublisher: iceStateSubject.eraseToAnyPublisher(),
             reporter: mockReporter,
             wasPreviouslyConnected: wasPreviouslyConnected,
+            retryCount: retryCount,
             details: .init(
                 sfuId: "sfu-1",
                 coordinatorConnectId: "85e8b199-d4ab-4eb7-a681-1d6916a86906"


### PR DESCRIPTION
### 🎯 Goal

Fix malformed client event reporting for join-related retries so dashboard traces show the correct retry attempt across CoordinatorJoin, CoordinatorWS, WSJoin, and PeerConnectionConnect stages.

### 📝 Summary

- Propagate the outer `Call.join()` retry attempt into the WebRTC coordinator flow.
- Use the correct retry source for client-event completions:
  - initial join retries use `coordinatorJoinAttemptCount`
  - in-call recovery uses `reconnectAttempts`
- Make initial `WSJoin` failures fail the pending join so the normal join retry loop can run.
- Pass retry counts through `PeerConnectionConnect` reporting instead of always reporting `0`.
- Add focused scenario coverage for CoordinatorJoin, WSJoin, and peer-connection reporting.

### 🛠 Implementation

The join retry count now flows from `Call.StateMachine.Context.JoinInput.currentNumberOfRetries` through `CallController.joinCall` into `WebRTCCoordinator.connect`.

`WebRTCCoordinator.StateMachine.Stage.Context` exposes `clientEventRetryCount` to centralize the distinction between initial join retries and WebRTC recovery retries. Initial join failures, including `WSJoin` timeout before the call is joined, now use the outer join attempt count. Recovery and reconnect flows continue using `reconnectAttempts`.

Initial `WSJoin` failures now transition to error while a join response handler is still pending, allowing `Call.join()` to receive the failure and retry. Recovery flows without a pending join handler still transition through the disconnected recovery path.

### 🧪 Manual Testing Notes

Validated with DemoApp chaos testing for:

- CoordinatorJoin failure and retry count progression.
- CoordinatorWS failure and retry count progression.
- WSJoin timeout retry behavior.
- PeerConnectionConnect ICE failure reporting for publish/subscribe.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinator join attempt indexing and forwarding so join attempts carry the correct retry context.

* **Bug Fixes**
  * Improved client-event `retryCount` reporting for coordinator join, WebSocket join, and peer connection connect.
  * Refined join failure handling so error/disconnect behavior is chosen based on whether join completion handling is active.

* **Tests**
  * Updated and expanded join/WS join and peer connection telemetry tests to validate the new `retryCount` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->