### PR TITLE
[Fix] CallKit audio playout recovery

### DIFF
--- a/Sources/StreamVideo/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule.swift
@@ -298,6 +298,29 @@ final class AudioDeviceModule: NSObject, RTCAudioDeviceModuleDelegate, Encodable
         }
     }
 
+    /// Forces WebRTC playout to stop and start again.
+    ///
+    /// This is intentionally lower level than ``setPlayout(_:)`` because
+    /// recovery paths may need to restart playout even when the cached ADM
+    /// state still reports `isPlaying == true` after a failed engine start.
+    func resetPlayout() {
+        log.throwing(subsystems: .audioSession) {
+            try throwingExecution("Unable to stop playout") {
+                source.stopPlayout()
+            }
+
+            if source.isPlayoutInitialized {
+                try throwingExecution("Unable to start playout") {
+                    source.startPlayout()
+                }
+            } else {
+                try throwingExecution("Unable to initAndStart playout") {
+                    source.initAndStartPlayout()
+                }
+            }
+        }
+    }
+
     /// Enables or disables recording on the wrapped audio device module.
     /// - Parameter isEnabled: When `true` recording starts, otherwise stops.
     /// - Throws: `ClientError` when the underlying module reports a failure.

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore+CallKitRecoveryMiddleware.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore+CallKitRecoveryMiddleware.swift
@@ -7,8 +7,8 @@ import StreamWebRTC
 
 extension RTCAudioStore {
 
-    /// Restores microphone capture after CallKit hands the audio session to
-    /// the app.
+    /// Restores ADM playout and microphone capture after CallKit hands the
+    /// audio session to the app.
     ///
     /// With CallKit joins the answer action is fulfilled only once the call
     /// has joined, so the WebRTC layer configures the peer connections (and
@@ -21,16 +21,19 @@ extension RTCAudioStore {
     /// replaying the same recovery `InterruptionsEffect` uses: stop and start
     /// recording, then re-apply the current microphone mute state.
     ///
-    /// Playout needs no equivalent treatment: WebRTC restarts its audio unit
-    /// when the activation is forwarded through `audioSessionDidActivate`,
-    /// and the deferred policy application re-issues `setAudioEnabled`,
-    /// which maps to `setPlayout` on the ADM.
+    /// The same activation window can also leave playout in a stale state:
+    /// WebRTC may report `isPlaying == true` even after its audio engine
+    /// failed to start against a temporarily unavailable output route. The
+    /// middleware therefore forces a playout restart before applying any
+    /// recording-specific recovery.
     final class CallKitRecoveryMiddleware: Middleware<RTCAudioStore.Namespace>,
         @unchecked Sendable {
 
-        /// Dispatches a recording restart when CallKit activates the audio
-        /// session while recording was already on. Activations with recording
-        /// off are left untouched.
+        /// Forces playout to restart when CallKit activates the audio session.
+        ///
+        /// If recording was already on, this also dispatches the existing
+        /// recording restart sequence so the microphone recovers against the
+        /// now-active audio session.
         override func apply(
             state: RTCAudioStore.StoreState,
             action: RTCAudioStore.StoreAction,
@@ -40,22 +43,25 @@ extension RTCAudioStore {
         ) {
             guard
                 case .callKit(.activate) = action,
-                state.audioDeviceModule != nil,
-                state.isRecording
+                let audioDeviceModule = state.audioDeviceModule
             else {
                 return
             }
+            
+            audioDeviceModule.resetPlayout()
 
-            // The follow-up actions are enqueued on the store's serial
-            // processing queue, so they execute after `CallKitReducer` has
-            // forwarded the activation to the WebRTC session. The restart
-            // therefore runs against an active audio session.
-            let actions: [Namespace.Action] = [
-                .setRecording(false),
-                .setRecording(true),
-                .setMicrophoneMuted(state.isMicrophoneMuted)
-            ]
-            dispatcher?.dispatch(actions.map(\.box))
+            if state.isRecording {
+                // The follow-up actions are enqueued on the store's serial
+                // processing queue, so they execute after `CallKitReducer` has
+                // forwarded the activation to the WebRTC session. The restart
+                // therefore runs against an active audio session.
+                var actions: [Namespace.Action] = [
+                    .setRecording(false),
+                    .setRecording(true),
+                    .setMicrophoneMuted(state.isMicrophoneMuted)
+                ]
+                dispatcher?.dispatch(actions.map(\.box))
+            }
         }
     }
 }

--- a/StreamVideoTests/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule_Tests.swift
@@ -82,6 +82,32 @@ final class AudioDeviceModule_Tests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - resetPlayout
+
+    func test_resetPlayout_whenPlayoutInitialized_restartsPlayout() {
+        source.stub(for: \.isPlaying, with: true)
+        source.stub(for: \.isPlayoutInitialized, with: true)
+        makeSubject()
+
+        subject.resetPlayout()
+
+        XCTAssertEqual(source.timesCalled(.stopPlayout), 1)
+        XCTAssertEqual(source.timesCalled(.startPlayout), 1)
+        XCTAssertEqual(source.timesCalled(.initAndStartPlayout), 0)
+    }
+
+    func test_resetPlayout_whenPlayoutNotInitialized_reinitializesPlayout() {
+        source.stub(for: \.isPlaying, with: true)
+        source.stub(for: \.isPlayoutInitialized, with: false)
+        makeSubject()
+
+        subject.resetPlayout()
+
+        XCTAssertEqual(source.timesCalled(.stopPlayout), 1)
+        XCTAssertEqual(source.timesCalled(.startPlayout), 0)
+        XCTAssertEqual(source.timesCalled(.initAndStartPlayout), 1)
+    }
+
     // MARK: - setRecording
 
     func test_setRecording_whenActivatingInitialized_callsStartRecording() throws {

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore_CallKitRecoveryMiddlewareTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Middleware/RTCAudioStore_CallKitRecoveryMiddlewareTests.swift
@@ -30,7 +30,7 @@ final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked
     // MARK: - apply
 
     func test_apply_activateWhileRecording_dispatchesRecordingRestart() {
-        let (module, _) = makeModule(isRecording: true)
+        let (module, mock) = makeModule(isRecording: true)
         let state = makeState(
             isRecording: true,
             isMicrophoneMuted: true,
@@ -55,10 +55,54 @@ final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked
         else {
             return XCTFail("Unexpected restart actions: \(actions).")
         }
+        XCTAssertEqual(mock.timesCalled(.stopPlayout), 1)
+        XCTAssertEqual(mock.timesCalled(.initAndStartPlayout), 1)
+    }
+
+    func test_apply_activateWithInitializedPlayout_restartsPlayout() {
+        let (module, mock) = makeModule(
+            isRecording: false,
+            isPlayoutInitialized: true
+        )
+        let state = makeState(audioDeviceModule: module)
+
+        subject.apply(
+            state: state,
+            action: .callKit(.activate(AVAudioSession.sharedInstance())),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+        XCTAssertEqual(mock.timesCalled(.stopPlayout), 1)
+        XCTAssertEqual(mock.timesCalled(.startPlayout), 1)
+        XCTAssertEqual(mock.timesCalled(.initAndStartPlayout), 0)
+    }
+
+    func test_apply_activateWithUninitializedPlayout_reinitializesPlayout() {
+        let (module, mock) = makeModule(
+            isRecording: false,
+            isPlayoutInitialized: false
+        )
+        let state = makeState(audioDeviceModule: module)
+
+        subject.apply(
+            state: state,
+            action: .callKit(.activate(AVAudioSession.sharedInstance())),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+        XCTAssertEqual(mock.timesCalled(.stopPlayout), 1)
+        XCTAssertEqual(mock.timesCalled(.startPlayout), 0)
+        XCTAssertEqual(mock.timesCalled(.initAndStartPlayout), 1)
     }
 
     func test_apply_activateWhileNotRecording_doesNotDispatch() {
-        let (module, _) = makeModule(isRecording: false)
+        let (module, mock) = makeModule(isRecording: false)
         let state = makeState(
             isRecording: false,
             audioDeviceModule: module
@@ -73,6 +117,8 @@ final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked
         )
 
         XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+        XCTAssertEqual(mock.timesCalled(.stopPlayout), 1)
+        XCTAssertEqual(mock.timesCalled(.initAndStartPlayout), 1)
     }
 
     func test_apply_activateWhileRecordingWithoutAudioDeviceModule_doesNotDispatch() {
@@ -93,7 +139,7 @@ final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked
     }
 
     func test_apply_deactivateWhileRecording_doesNotDispatch() {
-        let (module, _) = makeModule(isRecording: true)
+        let (module, mock) = makeModule(isRecording: true)
         let state = makeState(
             isRecording: true,
             audioDeviceModule: module
@@ -108,10 +154,13 @@ final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked
         )
 
         XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+        XCTAssertEqual(mock.timesCalled(.stopPlayout), 0)
+        XCTAssertEqual(mock.timesCalled(.startPlayout), 0)
+        XCTAssertEqual(mock.timesCalled(.initAndStartPlayout), 0)
     }
 
     func test_apply_nonCallKitActionWhileRecording_doesNotDispatch() {
-        let (module, _) = makeModule(isRecording: true)
+        let (module, mock) = makeModule(isRecording: true)
         let state = makeState(
             isRecording: true,
             audioDeviceModule: module
@@ -126,17 +175,22 @@ final class RTCAudioStore_CallKitRecoveryMiddlewareTests: XCTestCase, @unchecked
         )
 
         XCTAssertTrue(receivedActions.wrappedValue.isEmpty)
+        XCTAssertEqual(mock.timesCalled(.stopPlayout), 0)
+        XCTAssertEqual(mock.timesCalled(.startPlayout), 0)
+        XCTAssertEqual(mock.timesCalled(.initAndStartPlayout), 0)
     }
 
     // MARK: - Helpers
 
     private func makeModule(
         isRecording: Bool,
-        isMicrophoneMuted: Bool = false
+        isMicrophoneMuted: Bool = false,
+        isPlayoutInitialized: Bool = false
     ) -> (AudioDeviceModule, MockRTCAudioDeviceModule) {
         let source = MockRTCAudioDeviceModule()
         source.stub(for: \.isRecording, with: isRecording)
         source.stub(for: \.isMicrophoneMuted, with: isMicrophoneMuted)
+        source.stub(for: \.isPlayoutInitialized, with: isPlayoutInitialized)
 
         let module = AudioDeviceModule(source)
         return (module, source)


### PR DESCRIPTION
### 🎯 Goal

Recover audio playback when CallKit activates the audio session after WebRTC has already attempted to start playout and the ADM state may be stale.

### 📝 Summary

- Add `AudioDeviceModule.resetPlayout()` to force a stop/start playout cycle.
- Trigger playout reset from `RTCAudioStore.CallKitRecoveryMiddleware` on CallKit activation.
- Preserve the existing recording restart recovery path.
- Add focused unit tests for playout reset and CallKit activation recovery.

### 🛠 Implementation

`resetPlayout()` bypasses the cached `isPlaying` guard used by `setPlayout(_:)`, because WebRTC can report playout as active even after a failed audio engine start. The CallKit recovery middleware now forces playout recovery whenever CallKit activates the audio session, then applies the existing recording restart only when recording was active.

### 🧪 Manual Testing Notes

Run an incoming CallKit call while the app is backgrounded and the thermal state is serious and verify remote audio playback after answering.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CallKit activation recovery to reliably reset audio playout and restore recording state, addressing edge cases where the audio engine may report incorrect playback status after interruptions.

* **Tests**
  * Added comprehensive test coverage for playout lifecycle management and CallKit recovery behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->