### PR TITLE
[Fix] Constant audio route changes during join muting the microphone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Constant audio route changes while joining a call no longer mute the microphone, so captured audio reaches the published track. [#1172](https://github.com/GetStream/stream-video-swift/pull/1172)
 
 # [1.48.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.48.0)
 _June 19, 2026_

--- a/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.RouteChangeReason+Convenience.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/Extensions/AVAudioSession.RouteChangeReason+Convenience.swift
@@ -20,9 +20,17 @@ extension AVAudioSession.RouteChangeReason {
 
     /// Flags reasons that represent real hardware transitions so we can rebuild
     /// the audio graph when necessary.
+    ///
+    /// - Important: `.categoryChange` is intentionally excluded. It is emitted
+    ///   by our own category/mode reconfiguration and momentarily reports the
+    ///   default (receiver) route while a speaker override is still pending.
+    ///   Treating it as a hardware transition makes the route observer clobber
+    ///   the user's `speakerOn` selection, which kicks off an endless
+    ///   reconfiguration loop during call join that prevents captured
+    ///   microphone audio from reaching the published track.
     var requiresReconfiguration: Bool {
         switch self {
-        case .categoryChange, .override, .wakeFromSleep, .newDeviceAvailable, .oldDeviceUnavailable:
+        case .override, .wakeFromSleep, .newDeviceAvailable, .oldDeviceUnavailable:
             return true
         default:
             return false

--- a/StreamVideoTests/Utils/AudioSession/CallAudioSession/CallAudioSession_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/CallAudioSession/CallAudioSession_Tests.swift
@@ -643,6 +643,142 @@ final class CallAudioSession_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(policy.stubbedFunctionInput[.configuration]?.count ?? 0, 1)
     }
 
+    func test_routeChangeWithCategoryChangeReason_isIgnored() async {
+        let callSettingsSubject = PassthroughSubject<CallSettings, Never>()
+        let capabilitiesSubject = PassthroughSubject<Set<OwnCapability>, Never>()
+        let delegate = SpyAudioSessionAdapterDelegate()
+        let policy = MockAudioSessionPolicy()
+        let policyConfiguration = AudioSessionConfiguration(
+            isActive: true,
+            category: .playAndRecord,
+            mode: .voiceChat,
+            options: [.allowBluetoothHFP],
+            overrideOutputAudioPort: .speaker
+        )
+        policy.stub(for: .configuration, with: policyConfiguration)
+
+        subject = .init(policy: policy)
+        await claimOwnership(of: subject)
+        subject.activate(
+            callSettingsPublisher: callSettingsSubject.eraseToAnyPublisher(),
+            ownCapabilitiesPublisher: capabilitiesSubject.eraseToAnyPublisher(),
+            delegate: delegate,
+            statsAdapter: nil,
+            shouldSetActive: true
+        )
+
+        callSettingsSubject.send(CallSettings(audioOn: true, speakerOn: true))
+        capabilitiesSubject.send([.sendAudio])
+
+        await fulfillment {
+            (policy.stubbedFunctionInput[.configuration]?.count ?? 0) == 1
+        }
+        let initialCount = policy.stubbedFunctionInput[.configuration]?.count ?? 0
+
+        // A `.categoryChange` route notification is emitted by our own
+        // category/mode reconfiguration and momentarily reports the default
+        // (receiver) route while the desired override is the speaker. It must
+        // not be treated as a user-driven route change.
+        mockAudioStore.audioStore.dispatch(
+            .setCurrentRoute(
+                makeRoute(reason: .categoryChange, speakerOn: false)
+            )
+        )
+
+        await wait(for: 0.5)
+
+        XCTAssertFalse(delegate.speakerUpdates.contains(false))
+        XCTAssertEqual(
+            policy.stubbedFunctionInput[.configuration]?.count ?? 0,
+            initialCount
+        )
+    }
+
+    /// Reproduces the reported join scenario (no external device connected):
+    /// the OS emits a continuous stream of `.categoryChange` route
+    /// notifications while joining, each momentarily reporting the default
+    /// (receiver) route while the speaker override is still pending. The
+    /// speaker update is fed back into call settings exactly like
+    /// `WebRTCStateAdapter` does, which is what closes the loop. Before the fix
+    /// this oscillates `speakerOn` and reconfigures the session endlessly,
+    /// restarting the audio unit so captured microphone audio never reaches the
+    /// published track.
+    func test_categoryChangeStormDuringJoin_settlesWithoutReconfigurationLoop() async {
+        let callSettingsSubject = CurrentValueSubject<CallSettings, Never>(
+            .init(audioOn: true, speakerOn: true)
+        )
+        let capabilitiesSubject = CurrentValueSubject<Set<OwnCapability>, Never>(
+            [.sendAudio]
+        )
+        let policy = MockAudioSessionPolicy()
+        policy.stub(
+            for: .configuration,
+            with: AudioSessionConfiguration(
+                isActive: true,
+                category: .playAndRecord,
+                mode: .voiceChat,
+                options: [.allowBluetoothHFP],
+                overrideOutputAudioPort: .speaker
+            )
+        )
+        let delegate = SpeakerFeedbackAudioSessionAdapterDelegate(callSettingsSubject)
+
+        subject = .init(policy: policy)
+        await claimOwnership(of: subject)
+        subject.activate(
+            callSettingsPublisher: callSettingsSubject.eraseToAnyPublisher(),
+            ownCapabilitiesPublisher: capabilitiesSubject.eraseToAnyPublisher(),
+            delegate: delegate,
+            statsAdapter: nil,
+            shouldSetActive: true
+        )
+
+        await fulfillment {
+            (policy.stubbedFunctionInput[.configuration]?.count ?? 0) == 1
+        }
+
+        // Model the OS feedback that drives the real loop: each time the call
+        // reconfigures the AVAudioSession category, a `.categoryChange` route
+        // notification fires. We seed the first one and re-emit after every
+        // subsequent reconfiguration, capped so a regression surfaces as a
+        // bounded storm instead of hanging the test.
+        let injectionCap = 25
+        var injections = 0
+        var lastObservedCount = policy.stubbedFunctionInput[.configuration]?.count ?? 0
+
+        mockAudioStore.audioStore.dispatch(
+            .setCurrentRoute(makeRoute(reason: .categoryChange, speakerOn: false))
+        )
+        injections += 1
+
+        for _ in 0..<injectionCap {
+            await wait(for: 0.1)
+            let current = policy.stubbedFunctionInput[.configuration]?.count ?? 0
+            guard current > lastObservedCount, injections < injectionCap else {
+                continue
+            }
+            lastObservedCount = current
+            mockAudioStore.audioStore.dispatch(
+                .setCurrentRoute(makeRoute(reason: .categoryChange, speakerOn: false))
+            )
+            injections += 1
+        }
+
+        // With the fix the storm never starts: the seed notification is
+        // ignored, so it triggers no reconfiguration, no further notifications,
+        // and the speaker selection is preserved.
+        XCTAssertEqual(injections, 1)
+        XCTAssertEqual(policy.stubbedFunctionInput[.configuration]?.count ?? 0, 1)
+        XCTAssertFalse(delegate.speakerUpdates.contains(false))
+        XCTAssertEqual(callSettingsSubject.value.speakerOn, true)
+
+        // A genuine hardware transition is still honoured.
+        mockAudioStore.audioStore.dispatch(
+            .setCurrentRoute(makeRoute(reason: .oldDeviceUnavailable, speakerOn: false))
+        )
+        await fulfillment { delegate.speakerUpdates.contains(false) }
+    }
+
     // MARK: - muted speech detection
 
     func test_activate_whenMutedAndAllowed_enablesMutedSpeechDetection() async {
@@ -953,6 +1089,37 @@ private final class SpyAudioSessionAdapterDelegate: StreamAudioSessionAdapterDel
         line: UInt
     ) {
         speakerUpdates.append(speakerOn)
+    }
+
+    func audioSessionAdapterDidUpdateSpeakingWhileMuted(
+        _ isSpeakingWhileMuted: Bool
+    ) {
+        speakingWhileMutedUpdates.append(isSpeakingWhileMuted)
+    }
+}
+
+/// Mirrors `WebRTCStateAdapter` by feeding speaker updates back into the call
+/// settings the audio session observes, so route-change handling can be tested
+/// with the same feedback loop the SDK uses in production.
+private final class SpeakerFeedbackAudioSessionAdapterDelegate: StreamAudioSessionAdapterDelegate, @unchecked Sendable {
+    private let callSettingsSubject: CurrentValueSubject<CallSettings, Never>
+    private(set) var speakerUpdates: [Bool] = []
+    private(set) var speakingWhileMutedUpdates: [Bool] = []
+
+    init(_ callSettingsSubject: CurrentValueSubject<CallSettings, Never>) {
+        self.callSettingsSubject = callSettingsSubject
+    }
+
+    func audioSessionAdapterDidUpdateSpeakerOn(
+        _ speakerOn: Bool,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    ) {
+        speakerUpdates.append(speakerOn)
+        callSettingsSubject.send(
+            callSettingsSubject.value.withUpdatedSpeakerState(speakerOn)
+        )
     }
 
     func audioSessionAdapterDidUpdateSpeakingWhileMuted(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1775/bugconstant-audio-route-change-during-joining-a-call-causes-the

### 🎯 Goal

Fix a join-time bug where a user negotiates an audio track and the SFU accepts it via `setPublisher`, yet captured microphone audio never reaches the published WebRTC track. Reports showed the device repeatedly switching audio routes during join (built-in speaker ↔ receiver, no external device connected) with the participant mic icon greyed out.

### 📝 Summary

- Removed `.categoryChange` from `AVAudioSession.RouteChangeReason.requiresReconfiguration`, so self-induced category reconfigurations are no longer treated as real hardware route changes.
- Added a focused unit test proving a `.categoryChange` route notification is ignored.
- Added an end-to-end scenario test that reproduces the runaway reconfiguration storm during join (speaker feedback wired exactly like `WebRTCStateAdapter`) and verifies it now settles after a single configuration.

### 🛠 Implementation

The root cause was a self-reinforcing reconfiguration loop:

1. `CallAudioSession.applyConfiguration` reconfigures the AVAudioSession category/mode. In `RTCAudioStore+AVAudioSessionReducer.performUpdate`, `setConfiguration(...)` makes the OS emit a route-change notification with reason `.categoryChange`, momentarily reporting the default (receiver) route while the desired speaker override is still pending.
2. `requiresReconfiguration` wrongly included `.categoryChange`, so `CallAudioSession.configureCurrentRouteObservation` reacted to it. Because the transient route (`isSpeaker == false`) mismatched `callSettings.speakerOn == true`, it called `audioSessionAdapterDidUpdateSpeakerOn(false)`, which `WebRTCStateAdapter` fed back into `callSettings`, clobbering the user's selection.
3. Each resulting `applyConfiguration` ran `performUpdate` (`setActive(false)` → `setConfiguration(active: true)`), restarting the WebRTC audio unit and emitting yet another `.categoryChange` → endless loop. With capture perpetually restarting, mic frames never reached the published track.

This was confirmed by the dead `isValidRouteChange` helper, whose own doc says `.categoryChange` should be ignored as a "redundant callback", and by `requiresReconfiguration`'s own doc ("real hardware transitions") — `.categoryChange` is self-induced, not a hardware transition. The fix aligns the behaviour with both docs. Genuine transitions (`.override`, `.wakeFromSleep`, `.newDeviceAvailable`, `.oldDeviceUnavailable`) still trigger reconfiguration. The only consumer of `requiresReconfiguration` is the route observer, so the change is tightly scoped. Public API is unchanged.

### 🧪 Manual Testing Notes

- Join a call (audio on, speaker on) on a physical device and confirm the mic indicator is active and remote participants hear audio.
- Stress the audio routing during join (toggle speaker, connect/disconnect a Bluetooth/wired headset) and confirm the route settles and capture keeps working.
- Regression check: switching speaker on/off mid-call and plugging/unplugging a headset still updates the route and `speakerOn` as expected.

Automated:
- `test_categoryChangeStormDuringJoin_settlesWithoutReconfigurationLoop` — fails on the old code (runaway storm), passes with the fix.
- `test_routeChangeWithCategoryChangeReason_isIgnored`, `test_routeChangeWithDifferentSpeaker_notifiesDelegate`, `test_routeChangeWithMatchingSpeaker_reappliesPolicy` — all pass.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated audio route change handling so internal category changes no longer trigger unnecessary audio session reconfiguration.
  * Fixed an issue during call join where constant route changes could mute microphone audio, ensuring captured audio reaches the published track.
* **Tests**
  * Added coverage confirming `.categoryChange` route notifications are ignored for speaker update logic.
  * Added a stability test ensuring join-time “route change storms” settle without reconfiguration/oscillation while still reacting to real device disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->