### PR TITLE
Fix] Local video failing to start when joining a call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Local video sometimes failed to start when joining a call, because the publisher negotiation was debounced on the main run loop and could be delayed while the call UI was presenting.
 
 # [1.48.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.48.0)
 _June 19, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator.swift
@@ -275,7 +275,13 @@ class RTCPeerConnectionCoordinator: @unchecked Sendable {
         if peerType == .publisher {
             peerConnection
                 .publisher(eventType: StreamRTCPeerConnection.ShouldNegotiateEvent.self)
-                .debounce(for: 0.5, scheduler: RunLoop.main)
+                // Debounce on a global dispatch queue rather than `RunLoop.main`.
+                // A `RunLoop`-scheduled timer only fires in the run loop's default
+                // mode, so while the main run loop is parked in a tracking/event
+                // mode (UI presentation, scrolling, animations) or the main thread
+                // is saturated during call join, the publisher negotiation can be
+                // delayed or never start, leaving local tracks unpublished.
+                .debounce(for: 0.5, scheduler: DispatchQueue.global(qos: .userInteractive))
                 .log(.debug) { _ in "Publisher will negotiate" }
                 .receive(on: dispatchQueue)
                 .map { _ in () }

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
@@ -312,6 +312,46 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         }
     }
 
+    /// Regression test: the publisher negotiation must start even when the main
+    /// run loop is not being pumped (e.g. while the call UI is presenting during
+    /// join). Debouncing the negotiation trigger on `RunLoop.main` makes the
+    /// timer fire only in the run loop's default mode, so a busy/blocked main
+    /// thread delays — or never starts — negotiation, leaving local tracks
+    /// unpublished. This is intentionally a synchronous test so blocking the
+    /// current thread also blocks the main run loop, reproducing that condition.
+    func test_negotiate_subjectIsPublisher_whenMainRunLoopBlocked_startsNegotiation() {
+        _ = subject
+        let negotiationStarted = DispatchSemaphore(value: 0)
+        let peerConnection = mockPeerConnection!
+
+        // Observe the negotiation (createOffer) from a background thread so the
+        // check never relies on the main run loop being pumped.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let deadline = Date().addingTimeInterval(5)
+            while Date() < deadline {
+                if peerConnection.timesCalled(.offer) > 0 {
+                    negotiationStarted.signal()
+                    return
+                }
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+        }
+
+        mockPeerConnection
+            .subject
+            .send(StreamRTCPeerConnection.ShouldNegotiateEvent())
+
+        // Blocking here keeps the main run loop from running its timers; a
+        // `RunLoop.main`-scheduled debounce would never fire under this wait.
+        let result = negotiationStarted.wait(timeout: .now() + 3)
+
+        XCTAssertEqual(
+            result,
+            .success,
+            "Publisher negotiation did not start while the main run loop was blocked."
+        )
+    }
+
     func test_negotiate_subjectIsPublisher_callsSetLocalDescriptionWithExpectedOffer() async throws {
         _ = subject
         let offer = "useinbandfec=1;\r\n00:11 opus/;\r\n12:13: red/48000/2"


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1797/bugvideo-didnt-start-on-joining-the-call

### 🎯 Goal

Fix a bug where a participant's local video sometimes fails to start when joining a call (remote participants see no video), even though video is enabled. Toggling the camera off and on works around it.

### 📝 Summary

- Restart the camera capture session on `AVCaptureSession` runtime errors so capture recovers automatically (primary fix).
- Start publisher negotiation reliably during join by debouncing it off the main run loop (related robustness improvement).
- CHANGELOG updated.

### 🛠 Implementation

**Root cause (from device logs).** At join the encoder was configured with all simulcast layers active, but the local send stats showed `input_fps: 0.0` / `media_bps: 0` — the camera delivered no frames. During capture setup the system logged a burst of `kFigCaptureSessionError_ServerConnectionDied` / `kFigCaptureSourceError_ServerConnectionDied` (the capture-server / media-services connection was reset). The `AVCaptureSession` kept reporting as started while delivering zero frames, and no interruption-ended notification arrived, so nothing recovered it. After a manual camera toggle (which fully restarts capture), stats showed `input_fps: 30.0` and video flowed.

`CameraInterruptionsHandler` only observed `AVCaptureSession` **interruption** notifications. A server/media-services reset is delivered as an **`AVCaptureSessionRuntimeError`**, which was not observed — so the dead-but-"running" session was never restarted.

**Fix.** `CameraInterruptionsHandler` now also observes `AVCaptureSession.runtimeErrorNotification` (scoped to its session) and restarts the session (`stopRunning` when needed → `startRunning`). This mirrors the documented Apple recovery for `mediaServicesWereReset` and matches what a manual camera toggle already does.

**Related improvement.** While investigating, the publisher's `ShouldNegotiate` trigger was found to be debounced on `RunLoop.main`, whose timer only fires in the run loop's default mode; during a busy call-join the negotiation start could slip (observed ~0.8s beyond the nominal 0.5s in logs). It now debounces on a global, user-interactive dispatch queue so negotiation starts deterministically. This is covered by a unit test that blocks the main thread and asserts negotiation still starts.

### 🎨 Showcase

_N/A — no UI changes._

| Before | After |
| ------ | ----- |
| Local video occasionally not published on join after a capture-server reset; fixed only by toggling the camera | Capture auto-recovers and video starts on join |

### 🧪 Manual Testing Notes

- Camera-recovery (primary): join a call with video enabled; if the capture server resets during join (or simulate a media-services reset), confirm video starts/recovers automatically without manually toggling the camera. Regression: camera on/off, switching cameras, backgrounding/foregrounding, and interruptions (calls/Control Center) still recover correctly.
- Negotiation: join repeatedly on a busy/older device and confirm remote participants see local media without a toggle.

Note: the camera runtime-error recovery is not unit-tested because `AVCaptureSession` runtime-error recovery cannot be exercised on the simulator (no camera, `startRunning` is a no-op) and `AVCaptureSession` is not mockable — it relies on device QA.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where local video could fail to start when joining a call.
  * Improved call setup reliability so negotiation can proceed even if the app’s main thread is busy or temporarily blocked.
* **Tests**
  * Added regression coverage for the join flow to help prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->