### PR TITLE
[Fix] Recover microphone after an interruption ends while backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Local video could fail to start when joining a call if the camera capture session stopped unexpectedly (e.g. after a capture-server connection loss), because the capturer did not restart it. [#1175](https://github.com/GetStream/stream-video-swift/pull/1175)
+- The microphone now recovers after an audio-session interruption ends while the app is backgrounded, instead of staying silent (recording but capturing nothing) until you leave and rejoin the call. [#1174](https://github.com/GetStream/stream-video-swift/pull/1174)
 - Local video sometimes failed to start when joining a call, because the publisher negotiation was debounced on the main run loop and could be delayed while the call UI was presenting.[#1173](https://github.com/GetStream/stream-video-swift/pull/1173)
 - Constant audio route changes while joining a call no longer mute the microphone, so captured audio reaches the published track. [#1172](https://github.com/GetStream/stream-video-swift/pull/1172)
 

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore+InterruptionsEffect.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore+InterruptionsEffect.swift
@@ -57,10 +57,25 @@ extension RTCAudioStore {
                     state.audioDeviceModule != nil {
                     let isRecording = state.isRecording
                     let isMicrophoneMuted = state.isMicrophoneMuted
+                    let isMutedSpeechDetectionEnabled = state.isMutedSpeechDetectionEnabled
 
                     if isRecording {
+                        // Muted speech detection keeps WebRTC's input graph
+                        // "enabled" across a stop/start (persistent recording
+                        // mode), so resuming after an interruption looks like a
+                        // runtime mute toggle and the engine input — torn down
+                        // by the OS during the interruption — is never actually
+                        // restarted, leaving capture dead. Drop persistent mode
+                        // around the restart so the input-graph transition
+                        // forces a real engine restart, then restore it.
+                        if isMutedSpeechDetectionEnabled {
+                            actions.append(.setMutedSpeechDetectionEnabled(false))
+                        }
                         actions.append(.setRecording(false))
                         actions.append(.setRecording(true))
+                        if isMutedSpeechDetectionEnabled {
+                            actions.append(.setMutedSpeechDetectionEnabled(true))
+                        }
                     }
 
                     actions.append(.setMicrophoneMuted(isMicrophoneMuted))

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore_InterruptionsEffectTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore_InterruptionsEffectTests.swift
@@ -154,6 +154,55 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
         }
     }
 
+    func test_didEndInterruption_shouldResumeTrue_recordingAndMutedSpeechDetection_togglesPersistentModeAroundRestart() {
+        let dispatcherExpectation = expectation(description: "Dispatcher called")
+        dispatcherExpectation.assertForOverFulfill = false
+
+        subject.dispatcher = .init { [weak self] actions, _, _, _ in
+            self?.dispatched.append(actions)
+            dispatcherExpectation.fulfill()
+        }
+
+        let module = AudioDeviceModule(MockRTCAudioDeviceModule())
+        subject.stateProvider = { [weak self] in
+            self?.makeState(
+                isInterrupted: true,
+                isRecording: true,
+                isMicrophoneMuted: true,
+                isMutedSpeechDetectionEnabled: true,
+                audioDeviceModule: module
+            )
+        }
+
+        publisher.audioSessionDidEndInterruption(session, shouldResumeSession: true)
+
+        wait(for: [dispatcherExpectation], timeout: 1)
+
+        guard let actions = dispatched.first else {
+            return XCTFail("Expected dispatched actions.")
+        }
+
+        XCTAssertEqual(actions.count, 6)
+        guard case .setInterrupted(false) = actions[0].wrappedValue else {
+            return XCTFail("Expected action[0] setInterrupted(false).")
+        }
+        guard case .setMutedSpeechDetectionEnabled(false) = actions[1].wrappedValue else {
+            return XCTFail("Expected action[1] setMutedSpeechDetectionEnabled(false).")
+        }
+        guard case .setRecording(false) = actions[2].wrappedValue else {
+            return XCTFail("Expected action[2] setRecording(false).")
+        }
+        guard case .setRecording(true) = actions[3].wrappedValue else {
+            return XCTFail("Expected action[3] setRecording(true).")
+        }
+        guard case .setMutedSpeechDetectionEnabled(true) = actions[4].wrappedValue else {
+            return XCTFail("Expected action[4] setMutedSpeechDetectionEnabled(true).")
+        }
+        guard case .setMicrophoneMuted(true) = actions[5].wrappedValue else {
+            return XCTFail("Expected action[5] setMicrophoneMuted(true).")
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeState(
@@ -161,6 +210,7 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
         isInterrupted: Bool = false,
         isRecording: Bool = false,
         isMicrophoneMuted: Bool = false,
+        isMutedSpeechDetectionEnabled: Bool = false,
         hasRecordingPermission: Bool = false,
         activeSessionIdentifier: String = "",
         audioDeviceModule: AudioDeviceModule? = nil,
@@ -182,7 +232,7 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
             isInterrupted: isInterrupted,
             isRecording: isRecording,
             isMicrophoneMuted: isMicrophoneMuted,
-            isMutedSpeechDetectionEnabled: false,
+            isMutedSpeechDetectionEnabled: isMutedSpeechDetectionEnabled,
             hasRecordingPermission: hasRecordingPermission,
             activeSessionIdentifier: activeSessionIdentifier,
             audioDeviceModule: audioDeviceModule,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1773/gh-issueaudio-does-not-recover-after-avaudiosession-interruption-in
GH issue: https://github.com/GetStream/stream-video-swift/issues/1164

### 🎯 Goal

In Audio Rooms (and any call), the microphone could go permanently silent after the app spent time in the background with an audio interruption (e.g. another app playing audio). The participant appears unmuted and the SDK reports `isRecording: true`, but no audio is captured — and only leaving and rejoining the call restores it.

### 📝 Summary

- When recovering from an `AVAudioSession` interruption while muted-speech-detection is active, `InterruptionsEffect` now momentarily drops persistent recording mode around the recording restart, forcing WebRTC to actually restart the engine input instead of treating it as a no-op runtime toggle.
- Keeps the behaviour inside the existing `InterruptionsEffect` (no new type, no app-lifecycle coupling).
- Adds unit coverage asserting the dispatched recovery sequence for the muted-speech-detection path, while leaving the non-muted path unchanged.

### 🛠 Implementation

Root cause (confirmed against a customer log + the WebRTC fork):

- While the user is muted, the SDK enables muted-speech-detection, which puts WebRTC's ADM into persistent recording mode (`setRecordingAlwaysPreparedMode(true)` → `input_enabled_persistent_mode = true`).
- On interruption end, `InterruptionsEffect` restarts recording (`setRecording(false)` → `setRecording(true)`). But because persistent mode keeps `IsInputEnabled()` `true` across the stop/start, `DidUpdateAudioGraph()` is `false`, so `IsEngineRestartRequired()` is `false`. WebRTC applies it as a *runtime voice-processing mute update* and never restarts the input audio unit that the OS tore down during the interruption.
- Result: the engine reports `IsInputRunning: 1 / InputMuted: 0`, but the record device buffer delivers zero callbacks (`[REC` log stops at the interruption and never returns, while `[PLAY` keeps flowing). Playout works, capture is dead.
- `RTCAudioSession` re-delivers `didEndInterruption` on `handleApplicationDidBecomeActive`, so the recovery already runs in the foreground — but it still no-ops because of the masking above.

Fix:

- In `RTCAudioStore+InterruptionsEffect.didEndInterruption`, when `isRecording` and `isMutedSpeechDetectionEnabled`, dispatch `setMutedSpeechDetectionEnabled(false)` before `setRecording(false)/(true)` and `setMutedSpeechDetectionEnabled(true)` after. Disabling persistent mode makes the stop genuinely disable the input graph, so the subsequent start flips `IsInputEnabled` `false → true`, triggering a real engine restart and resurrecting capture.
- When muted-speech-detection is off (e.g. interrupted while unmuted), the sequence is unchanged — the normal stop/start already forces a restart there.

### 🎨 Showcase

_N/A — no UI changes._

| Before | After |
| ------ | ----- |
| Mic stays silent after a backgrounded interruption until leave/rejoin | Mic recovers automatically on returning to the foreground |

### 🧪 Manual Testing Notes

1. Join an Audio Room as a speaker (or any call while publishing audio) and mute yourself.
2. Background the app and play audio in another app (music/podcast/video) to trigger an `AVAudioSession` interruption; stop it / leave the app backgrounded for a bit.
3. Return to the foreground and unmute, then confirm:
   - Other participants can hear you again without leaving/rejoining.
   - WebRTC logs a `[REC : …]` device-buffer line again after the interruption (capture resumed) and outbound audio `packetsSent` increments.
   - `activeSessionIdentifier` does not change (no implicit leave/rejoin).
4. Regression: repeat background ⇄ foreground while unmuted and confirm the mic keeps working.

Automated: `RTCAudioStore_InterruptionsEffectTests` covers the recovery action sequence, including `test_didEndInterruption_shouldResumeTrue_recordingAndMutedSpeechDetection_togglesPersistentModeAroundRestart` and the unchanged non-muted path.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)