### PR TITLE
[Fix] Restart camera capture when the session stops unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Local video could fail to start when joining a call if the camera capture session stopped unexpectedly (e.g. after a capture-server connection loss), because the capturer did not restart it. [#1175](https://github.com/GetStream/stream-video-swift/pull/1175)
 - Local video sometimes failed to start when joining a call, because the publisher negotiation was debounced on the main run loop and could be delayed while the call UI was presenting.[#1173](https://github.com/GetStream/stream-video-swift/pull/1173)
 - Constant audio route changes while joining a call no longer mute the microphone, so captured audio reaches the published track. [#1172](https://github.com/GetStream/stream-video-swift/pull/1172)
 

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler.swift
@@ -7,7 +7,17 @@ import Combine
 import Foundation
 import StreamWebRTC
 
-/// Handles camera-related interruptions by observing `AVCaptureSession` interruption notifications.
+/// Handles camera-related interruptions and unexpected capture-session stops by
+/// observing `AVCaptureSession` notifications.
+///
+/// Besides logging interruptions and restarting after an interruption ends,
+/// this handler recovers from the case where the capture session stops without
+/// an `AVCaptureSessionRuntimeError` — for example a capture-server connection
+/// loss on join (`kFigCaptureSessionError_ServerConnectionDied`). In that case
+/// the session reports as started while delivering no frames, no runtime error
+/// is posted (so `RTCCameraVideoCapturer`'s own recovery never triggers), and
+/// no interruption-ended notification arrives. The handler restarts capture
+/// with a full stop/start cycle, matching what a manual camera toggle does.
 final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unchecked Sendable {
 
     /// Represents the current camera session state (idle or running).
@@ -18,20 +28,37 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
         case running(session: AVCaptureSession, disposableBag: DisposableBag)
     }
 
-    private var state: State = .idle
-    /// Ensures serialized handling of interruption events.
+    /// Maximum number of consecutive automatic restart attempts before giving
+    /// up, to avoid a restart loop when the capture server cannot recover. The
+    /// counter resets once capture successfully starts again.
+    private static let maxRestartAttempts = 3
+
+    /// Serializes notification handling. All observers deliver on this queue
+    /// (via `receive(on:)`), so the restart bookkeeping below is mutated from a
+    /// single place.
     private let processingQueue = OperationQueue(maxConcurrentOperationCount: 1)
+    private var state: State = .idle
+    private var lastStartAction: StreamVideoCapturer.Action?
+    private var restartAttempts = 0
+    private var isInterrupted = false
+    private var isRestarting = false
+
+    /// Dispatches actions back through the capturer pipeline. Assigned by
+    /// ``StreamVideoCapturer`` so the handler can issue a full capture restart.
+    var actionDispatcher: ((StreamVideoCapturer.Action) async -> Void)?
 
     // MARK: - StreamVideoCapturerActionHandler
 
-    /// Handles camera-related actions triggered by the video capturer.
-    /// Handles camera interruption actions.
+    /// Handles camera capture lifecycle actions.
     func handle(_ action: StreamVideoCapturer.Action) async throws {
         switch action {
-        /// Handle start capture event and register for interruption notifications.
+        /// Handle start capture event and register for session notifications.
         case let .startCapture(_, _, _, _, videoCapturer, _, _):
             if let cameraCapturer = videoCapturer as? RTCCameraVideoCapturer {
-                didStartCapture(session: cameraCapturer.captureSession)
+                didStartCapture(
+                    session: cameraCapturer.captureSession,
+                    startAction: action
+                )
             } else {
                 didStopCapture()
             }
@@ -46,7 +73,10 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
     // MARK: - Private
 
     /// Sets up observers and state when camera capture starts.
-    private func didStartCapture(session: AVCaptureSession) {
+    private func didStartCapture(
+        session: AVCaptureSession,
+        startAction: StreamVideoCapturer.Action
+    ) {
         let disposableBag = DisposableBag()
 
         let interruptedNotification: Notification.Name = {
@@ -57,10 +87,11 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
             #endif
         }()
 
-        /// Observe AVCaptureSession interruptions and log reasons.
+        /// Observe AVCaptureSession interruptions, log reasons and remember that
+        /// an interruption is active so an unexpected stop isn't misread.
         NotificationCenter
             .default
-            .publisher(for: interruptedNotification)
+            .publisher(for: interruptedNotification, object: session)
             .compactMap { (notification: Notification) -> String? in
                 guard
                     let userInfo = notification.userInfo,
@@ -71,46 +102,136 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
                 }
                 return reason.description
             }
-            .compactMap { $0 }
             .log(.debug, subsystems: .webRTC) { "CameraCapture session was interrupted with reason: \($0)." }
             .receive(on: processingQueue)
-            .sink { _ in }
+            .sink { [weak self] _ in self?.setInterrupted(true) }
             .store(in: disposableBag)
 
         /// Observe end of AVCaptureSession interruptions and restart session if needed.
         NotificationCenter
             .default
-            .publisher(for: .AVCaptureSessionInterruptionEnded)
+            .publisher(for: .AVCaptureSessionInterruptionEnded, object: session)
             .log(.debug, subsystems: .webRTC) { _ in "CameraCapture session interruption ended." }
             .receive(on: processingQueue)
             .sink { [weak self] _ in self?.handleInterruptionEnded() }
             .store(in: disposableBag)
 
+        /// Observe unexpected session stops and restart capture.
+        NotificationCenter
+            .default
+            .publisher(for: AVCaptureSession.didStopRunningNotification, object: session)
+            .receive(on: processingQueue)
+            .sink { [weak self] _ in self?.attemptRestart(reason: "session stopped unexpectedly") }
+            .store(in: disposableBag)
+
+        /// Observe runtime errors and restart capture.
+        ///
+        /// `RTCCameraVideoCapturer` already restarts on runtime errors, but only
+        /// via a bare `startRunning`. Routing them through our full stop/start
+        /// recovery re-adds the device input, which is needed when a server
+        /// connection loss invalidates the current input. The shared restart
+        /// guard prevents this from racing the `didStopRunning` path.
+        NotificationCenter
+            .default
+            .publisher(for: AVCaptureSession.runtimeErrorNotification, object: session)
+            .receive(on: processingQueue)
+            .sink { [weak self] notification in
+                let error = notification.userInfo?[AVCaptureSessionErrorKey] as? AVError
+                self?.attemptRestart(
+                    reason: "runtime error: \(error.map { "\($0)" } ?? "unknown")"
+                )
+            }
+            .store(in: disposableBag)
+
+        /// Observe successful (re)starts to clear the restart bookkeeping.
+        NotificationCenter
+            .default
+            .publisher(for: AVCaptureSession.didStartRunningNotification, object: session)
+            .receive(on: processingQueue)
+            .sink { [weak self] _ in self?.handleDidStartRunning() }
+            .store(in: disposableBag)
+
         state = .running(session: session, disposableBag: disposableBag)
+        lastStartAction = startAction
+        isInterrupted = false
     }
 
     /// Cleans up resources and resets state when camera capture stops.
     private func didStopCapture() {
-        switch state {
-        case .idle:
-            break
-        case let .running(_, disposableBag):
+        if case let .running(_, disposableBag) = state {
             disposableBag.removeAll()
-            processingQueue.cancelAllOperations()
         }
         state = .idle
     }
 
+    private func setInterrupted(_ value: Bool) {
+        isInterrupted = value
+    }
+
     /// Restarts the session if it was interrupted and not running.
     private func handleInterruptionEnded() {
-        switch state {
-        case .idle:
-            break
-        case let .running(session, _):
-            guard !session.isRunning else {
-                return
-            }
-            session.startRunning()
+        isInterrupted = false
+        guard
+            case let .running(session, _) = state,
+            !session.isRunning
+        else {
+            return
+        }
+        session.startRunning()
+    }
+
+    /// Clears restart bookkeeping once capture is running again.
+    private func handleDidStartRunning() {
+        restartAttempts = 0
+        isRestarting = false
+    }
+
+    /// Restarts capture when the session stops or errors while we still expect
+    /// it running and no interruption we are tracking is active.
+    ///
+    /// Shared by the `didStopRunning` and `runtimeError` observers; the
+    /// `isRestarting` guard ensures only one restart runs even when both fire
+    /// for the same event.
+    private func attemptRestart(reason: String) {
+        guard
+            case .running = state,
+            !isInterrupted,
+            !isRestarting
+        else {
+            return
+        }
+        guard restartAttempts < Self.maxRestartAttempts else {
+            log.error(
+                "CameraCapture did not recover (\(reason)) after \(Self.maxRestartAttempts) attempts.",
+                subsystems: .webRTC
+            )
+            return
+        }
+
+        guard
+            let startAction = lastStartAction,
+            let actionDispatcher,
+            case let .startCapture(_, _, _, _, videoCapturer, _, _) = startAction
+        else {
+            return
+        }
+
+        restartAttempts += 1
+        isRestarting = true
+        let attempt = restartAttempts
+
+        log.warning(
+            "CameraCapture needs recovery (\(reason)). Restarting capture (attempt \(attempt)).",
+            subsystems: .webRTC
+        )
+
+        Task { [weak self] in
+            // A full stop/start cycle re-adds the device input and clears the
+            // capture handler's dedup guard, matching a manual camera toggle.
+            await actionDispatcher(.stopCapture(videoCapturer: videoCapturer))
+            await actionDispatcher(startAction)
+            // Hop back onto the serial queue to clear the restart flag.
+            self?.processingQueue.addOperation { [weak self] in self?.isRestarting = false }
         }
     }
 }

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoCapturer.swift
@@ -85,14 +85,20 @@ final class StreamVideoCapturer: StreamVideoCapturing, @unchecked Sendable {
             ]
         )
         #else
+        // The interruptions handler is placed before the capture handler so it
+        // updates its state and observers before the capture session is started
+        // or stopped. This keeps an intentional `stopCapture` from being misread
+        // as an unexpected stop, and ensures the stop observer is installed
+        // before capture begins.
+        let interruptionsHandler = CameraInterruptionsHandler()
         var actionHandlers: [StreamVideoCapturerActionHandler] = [
+            interruptionsHandler,
             CameraBackgroundAccessHandler(),
             CameraCaptureHandler(),
             CameraFocusHandler(),
             CameraCapturePhotoHandler(),
             CameraVideoOutputHandler(),
-            CameraZoomHandler(),
-            CameraInterruptionsHandler()
+            CameraZoomHandler()
         ]
 
         let systemPressureHandler = CameraSystemPressureHandler()
@@ -111,6 +117,18 @@ final class StreamVideoCapturer: StreamVideoCapturing, @unchecked Sendable {
             audioDeviceModule: audioDeviceModule,
             actionHandlers: actionHandlers
         )
+
+        interruptionsHandler.actionDispatcher = { [weak streamCapturer] action in
+            guard let streamCapturer else { return }
+            do {
+                try await streamCapturer.dispatch(action)
+            } catch {
+                log.error(
+                    "Failed to dispatch camera restart action: \(error).",
+                    subsystems: .videoCapturer
+                )
+            }
+        }
 
         if usesNewCapturingPipeline {
             systemPressureHandler.actionDispatcher = { [weak streamCapturer] action in


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1797](https://stream-io.atlassian.net/browse/IOS-1797)

### 🎯 Goal

Fix a bug where a participant's local video fails to start when joining a call (remote participants see no video), even though video is enabled. Toggling the camera off and on works around it.

### 📝 Summary

- Restart the camera capture session when it stops unexpectedly or errors (while we still expect it running), via a full stop/start cycle, with a bounded retry count.

### 🛠 Implementation

**Root cause (from device logs).** At join the encoder was configured with all simulcast layers active, but the local send stats showed `input_fps: 0.0` / `media_bps: 0` — the camera delivered no frames. During capture setup the system logged a burst of `kFigCaptureSessionError_ServerConnectionDied` / `kFigCaptureSourceError_ServerConnectionDied` (the capture-server connection was reset), and the session emitted `AVCaptureSessionDidStopRunning` (with no preceding `DidStartRunning`). Crucially there was **no** `AVCaptureSessionRuntimeError` anywhere in the logs, so `RTCCameraVideoCapturer`'s own runtime-error recovery (`handleCaptureSessionRuntimeError` → `handleNonFatalError`) never triggered, and `handleCaptureSessionDidStopRunning` only logs. The session stayed stopped, delivering no frames. A manual camera off→on (a full `stopCapture` + `startCapture`) recovered it (`input_fps: 30.0`).

**Fix.** `CameraInterruptionsHandler` now observes `AVCaptureSession.didStopRunningNotification` **and** `AVCaptureSession.runtimeErrorNotification` (scoped to its session). When the session stops/errors while we still expect it running and no interruption is active, it issues a **full capture restart** (`stopCapture` then the original `startCapture`) through an `actionDispatcher` — matching what a manual toggle does and clearing `CameraCaptureHandler`'s dedup guard via the stop. Both notifications funnel into one guarded restart path; an `isRestarting` flag plus a bounded retry count (max 3, reset on `DidStartRunning`) prevent restart loops and double restarts. The handler is ordered before the capture handler so an intentional `stopCapture` is not misread as an unexpected stop, and so the observers are installed before capture begins.

Routing runtime errors through the same full restart re-adds the device input, which WebRTC's own bare `startRunning` recovery does not — important when a server-connection loss invalidates the current input.

### 🎨 Showcase

_N/A — no UI changes._

|  Before  |  After  |
| -------- | ------- |
| Local video not published on join after a capture-server reset; fixed only by toggling the camera | Capture auto-restarts and video starts on join |

### 🧪 Manual Testing Notes

- Join a call with video enabled; if the capture session stops/errors during join (or simulate a capture-server reset), confirm video starts/recovers automatically without manually toggling the camera.
- Regression: intentional camera on/off, switching cameras, backgrounding/foregrounding, and interruptions (incoming calls / Control Center) still behave correctly and are not misread as unexpected stops.

Note: not unit-tested — `AVCaptureSession` stop/restart behaviour cannot be exercised on the simulator (no camera) and `AVCaptureSession` is not mockable. Relies on device QA.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where local video could fail to start after joining a call when the camera capture session stopped unexpectedly (for example, after a capture-server connection loss).
  * Improved camera recovery to restart capture more reliably when the capture session reports it started but fails to deliver frames or encounters runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->