### PR TITLE
[Fix] Send ice_state on aborted PeerConnectionConnect client events

### DIFF
--- a/Sources/StreamVideo/Utils/ClientEventReporting/ClientEventReporter.swift
+++ b/Sources/StreamVideo/Utils/ClientEventReporting/ClientEventReporter.swift
@@ -166,6 +166,24 @@ actor ClientEventReporter: ClientEventReporting {
         deliver(event)
     }
 
+    func updateStage(
+        _ attempt: ClientEventStageAttempt,
+        details: ClientEventStageDetails
+    ) async {
+        guard let stored = activeAttempts[attempt.stageId] else {
+            // Already resolved (or aborted); nothing to keep current.
+            return
+        }
+        activeAttempts[attempt.stageId] = ClientEventStageAttempt(
+            stage: stored.stage,
+            stageId: stored.stageId,
+            peerConnection: stored.peerConnection,
+            joinAttemptId: stored.joinAttemptId,
+            startedAt: stored.startedAt,
+            details: stored.details.merging(details)
+        )
+    }
+
     func abortPendingStages(failure: ClientEventFailure) async {
         let pending = activeAttempts.values
         activeAttempts.removeAll()

--- a/Sources/StreamVideo/Utils/ClientEventReporting/ClientEventReporter.swift
+++ b/Sources/StreamVideo/Utils/ClientEventReporting/ClientEventReporter.swift
@@ -145,22 +145,25 @@ actor ClientEventReporter: ClientEventReporting {
         details: ClientEventStageDetails,
         failure: ClientEventFailure?
     ) async {
-        guard activeAttempts.removeValue(forKey: attempt.stageId) != nil else {
+        guard let stored = activeAttempts.removeValue(forKey: attempt.stageId) else {
             // The stage was already resolved (e.g. aborted on leave). Avoid
             // emitting a duplicate completion for the same `stage_id`.
             return
         }
-        let elapsed = Int(currentDate().timeIntervalSince(attempt.startedAt) * 1000)
+        // Build from the stored attempt so any details persisted via
+        // `updateStage(_:details:)` are honored on completion, not just on
+        // abort. Completion `details` still override them.
+        let elapsed = Int(currentDate().timeIntervalSince(stored.startedAt) * 1000)
         let event = makeEvent(
-            stage: attempt.stage,
+            stage: stored.stage,
             eventType: .completed,
-            stageId: attempt.stageId,
-            peerConnection: attempt.peerConnection,
-            joinAttemptId: attempt.joinAttemptId,
+            stageId: stored.stageId,
+            peerConnection: stored.peerConnection,
+            joinAttemptId: stored.joinAttemptId,
             outcome: outcome,
             elapsedTime: max(0, elapsed),
             retryCount: retryCount,
-            details: attempt.details.merging(details),
+            details: stored.details.merging(details),
             failure: outcome == .failure ? failure : nil
         )
         deliver(event)

--- a/Sources/StreamVideo/Utils/ClientEventReporting/ClientEventReporting.swift
+++ b/Sources/StreamVideo/Utils/ClientEventReporting/ClientEventReporting.swift
@@ -167,6 +167,20 @@ protocol ClientEventReporting: Sendable {
         failure: ClientEventFailure?
     ) async
 
+    /// Merges new stage-specific fields into a pending (begun but not yet
+    /// completed) stage attempt.
+    ///
+    /// Lets an in-progress stage keep its details current so a completion
+    /// forced by ``abortPendingStages(failure:)`` (user leave / backend end)
+    /// reports the last observed state (e.g. the ICE state of a
+    /// ``ClientEventStage/peerConnectionConnect`` still negotiating) instead of
+    /// omitting it. Non-nil fields override those captured at initiation; no-op
+    /// if the attempt has already resolved.
+    func updateStage(
+        _ attempt: ClientEventStageAttempt,
+        details: ClientEventStageDetails
+    ) async
+
     /// Completes every stage that was begun but not yet completed as a failure.
     ///
     /// Used when the user leaves the call or the backend ends it while a join

--- a/Sources/StreamVideo/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter.swift
+++ b/Sources/StreamVideo/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter.swift
@@ -97,7 +97,14 @@ final class WebRTCPeerConnectionConnectReporter: @unchecked Sendable {
                 iceConnectionState: iceConnectionState
             )
         } else if connectionState.isConnecting || iceConnectionState.isConnecting {
-            _ = await begin()
+            let attempt = await begin()
+            // Keep the pending attempt's ICE state current so a completion
+            // forced by an abort (user leave / backend end) mid-connect still
+            // reports the last observed ICE state instead of omitting it.
+            await reporter.updateStage(
+                attempt,
+                details: .init(iceState: ClientEventICEState(iceConnectionState))
+            )
         }
     }
 

--- a/StreamVideoTests/Mock/MockClientEventReporter.swift
+++ b/StreamVideoTests/Mock/MockClientEventReporter.swift
@@ -33,8 +33,14 @@ actor MockClientEventReporter: ClientEventReporting {
     private(set) var reportJoinInitiatedCallCount = 0
     private(set) var reportJoinInitiatedDetails: [ClientEventStageDetails] = []
     private(set) var reportedEvents: [ReportedEvent] = []
+    struct UpdatedStage: Sendable {
+        var attempt: ClientEventStageAttempt
+        var details: ClientEventStageDetails
+    }
+
     private(set) var begunStages: [BegunStage] = []
     private(set) var completedStages: [CompletedStage] = []
+    private(set) var updatedStages: [UpdatedStage] = []
     private(set) var abortedFailures: [ClientEventFailure] = []
 
     func reportJoinInitiated(details: ClientEventStageDetails) async {
@@ -91,6 +97,13 @@ actor MockClientEventReporter: ClientEventReporting {
                 failure: failure
             )
         )
+    }
+
+    func updateStage(
+        _ attempt: ClientEventStageAttempt,
+        details: ClientEventStageDetails
+    ) async {
+        updatedStages.append(.init(attempt: attempt, details: details))
     }
 
     func abortPendingStages(failure: ClientEventFailure) async {

--- a/StreamVideoTests/Mock/NoOpClientEventReporter.swift
+++ b/StreamVideoTests/Mock/NoOpClientEventReporter.swift
@@ -48,6 +48,12 @@ actor NoOpClientEventReporter: ClientEventReporting {
         failure: ClientEventFailure?
     ) async {}
 
+    /// Drops pending-stage detail updates.
+    func updateStage(
+        _ attempt: ClientEventStageAttempt,
+        details: ClientEventStageDetails
+    ) async {}
+
     /// Drops pending-stage aborts.
     func abortPendingStages(failure: ClientEventFailure) async {}
 }

--- a/StreamVideoTests/Utils/ClientEventReporting/ClientEventReporter_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/ClientEventReporter_Tests.swift
@@ -132,6 +132,22 @@ final class ClientEventReporter_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(completed?.callSessionId, "call-session-id")
     }
 
+    func test_completeStage_afterUpdateStage_includesPersistedDetails() async {
+        await subject.reportJoinInitiated()
+        let attempt = await subject.beginStage(
+            .peerConnectionConnect,
+            peerConnection: .publish,
+            details: .init(sfuId: "sfu-1", wasPreviouslyConnected: false)
+        )
+        // Persist a field the completion does not resend; it must survive.
+        await subject.updateStage(attempt, details: .init(iceState: .notConnected))
+        await subject.completeStage(attempt, outcome: .success)
+
+        await waitForEventCount(3)
+        let completed = event(stage: "PeerConnectionConnect", type: "completed")
+        XCTAssertEqual(completed?.iceState, "NOT_CONNECTED")
+    }
+
     func test_beginStage_withJoinReason_includesJoinReason() async {
         await subject.reportJoinInitiated()
 

--- a/StreamVideoTests/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter_Tests.swift
@@ -122,13 +122,13 @@ final class WebRTCPeerConnectionConnectReporter_Tests: XCTestCase, @unchecked Se
         XCTAssertEqual(completed?.failure?.code, ClientEventFailureCode.iceConnectivityFailed.rawValue)
     }
 
-    func test_whenConnecting_keepsPendingAttemptICEStateCurrentForAbort() async {
+    func test_connecting_keepsPendingAttemptICEStateCurrentForAbort() async {
         makeSubject()
 
         stateSubject.send(.connecting)
         iceStateSubject.send(.checking)
 
-        await waitUntil { await self.mockReporter.updatedStages.isEmpty == false }
+        await fulfillment { await self.mockReporter.updatedStages.isEmpty == false }
         let updated = await mockReporter.updatedStages.last
         let completed = await mockReporter.completedStages
         // Still negotiating: no completion yet, but the pending attempt now

--- a/StreamVideoTests/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/WebRTCPeerConnectionConnectReporter_Tests.swift
@@ -122,6 +122,21 @@ final class WebRTCPeerConnectionConnectReporter_Tests: XCTestCase, @unchecked Se
         XCTAssertEqual(completed?.failure?.code, ClientEventFailureCode.iceConnectivityFailed.rawValue)
     }
 
+    func test_whenConnecting_keepsPendingAttemptICEStateCurrentForAbort() async {
+        makeSubject()
+
+        stateSubject.send(.connecting)
+        iceStateSubject.send(.checking)
+
+        await waitUntil { await self.mockReporter.updatedStages.isEmpty == false }
+        let updated = await mockReporter.updatedStages.last
+        let completed = await mockReporter.completedStages
+        // Still negotiating: no completion yet, but the pending attempt now
+        // carries an ICE state so an abort mid-connect reports it.
+        XCTAssertTrue(completed.isEmpty)
+        XCTAssertEqual(updated?.details.iceState, .notConnected)
+    }
+
     func test_jumpStraightToConnected_stillReportsInitiatedAndCompletion() async {
         makeSubject()
 


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1807](https://linear.app/stream/issue/IOS-1807)

### 🎯 Goal

A `PeerConnectionConnect` client event completed via `abortPendingStages` (the user leaves, or the backend ends/blocks the call, while a peer connection is still negotiating) was reported as a failure **without an `ice_state`**. The backend requires `ice_state` on `PeerConnectionConnect` failures, so these aborted-mid-connect events arrived incomplete.

### 📝 Summary

- Aborted `PeerConnectionConnect` failures now carry `ice_state` (`NOT_CONNECTED` for a connection still negotiating).
- Added `updateStage(_:details:)` to `ClientEventReporting` so a pending stage attempt can keep its stage-specific details current before an abort forces its completion.
- `WebRTCPeerConnectionConnectReporter` now pushes the latest observed ICE state onto the pending attempt while connecting.
- Updated the `MockClientEventReporter` / `NoOpClientEventReporter` test doubles for the new protocol requirement and added coverage.

### 🛠 Implementation

The root cause: `ice_state` was only merged into an attempt's details at `completeStage` time (via `WebRTCPeerConnectionConnectReporter.complete`). `abortPendingStages` bypasses that path and emits a failure using the details captured at `beginStage`, which never included `ice_state`.

Rather than fragment the abort logic (the abort path also handles non–peer-connection stages and applies stage-agnostic failure codes like `CLIENT_ABORTED` / `BACKEND_LEAVE`), the fix keeps the actor's stored pending attempt current:

- `ClientEventReporting.updateStage(_:details:)` merges non-nil fields into the stored `activeAttempts` entry and is a no-op once the attempt has resolved.
- `WebRTCPeerConnectionConnectReporter.consume(...)` calls `updateStage` with the current ICE state on every connecting observation, so the pending attempt always reflects the last observed ICE state.

Because a `connected`/`failed` state resolves the stage through the normal completion path (removing it from `activeAttempts`), an attempt that reaches the abort path is by definition still negotiating — so the reported `ice_state` is the accurate `NOT_CONNECTED`. Organic ICE/connection failures already carried `ice_state` and are unchanged.

### 🧪 Manual Testing Notes

Join a call and, while a peer connection is still negotiating (before it reaches `connected`), leave the call (or have the backend end/block it). The emitted `PeerConnectionConnect` `completed`/`failure` client event should now include `ice_state: NOT_CONNECTED` alongside the `CLIENT_ABORTED` / `BACKEND_LEAVE` failure code.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating in-progress stage details, so connection-related information stays current during setup.

* **Bug Fixes**
  * Stage completion now uses the stored in-progress attempt details, preventing duplicate or stale completion events.
  * Ensures the latest ICE/connection state is preserved when a connection is aborted/interrupted and when completion follows an update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->