### PR TITLE
[DemoApp] Prevent chat from deactivating the call's AVAudioSession

### DIFF
--- a/DemoApp/Sources/Components/Chat/DemoChatAdapter.swift
+++ b/DemoApp/Sources/Components/Chat/DemoChatAdapter.swift
@@ -10,10 +10,31 @@ import class StreamChat.ChatChannelController
 import protocol StreamChat.ChatChannelControllerDelegate
 import class StreamChat.ChatClient
 import enum StreamChat.EntityChange
+import struct StreamChat.StreamAssetPropertyLoader
+import class StreamChat.StreamAudioPlayer
+import class StreamChat.StreamAudioRecorder
+import class StreamChat.StreamAudioSessionConfigurator
 import struct StreamChat.Token
 import StreamChatSwiftUI
 import StreamVideo
 import StreamVideoSwiftUI
+
+/// In the DemoApp chat is only reachable while a call is active, and during a
+/// call StreamVideo owns the shared `AVAudioSession`. StreamChat's default
+/// configurator deactivates that session (`setActive(false)`) when its audio
+/// player or recorder stops — e.g. `ChatChannelViewModel.deinit` stops the
+/// audio player when the chat sheet is presented/dismissed — which tears down
+/// the call's audio I/O and mutes both mic and speakers (IOS-1821). Keep chat
+/// away from the session entirely: playback/recording of voice messages still
+/// works against the already-active call session.
+/// ponytail: unconditional no-op; if chat ever becomes reachable outside a
+/// call, gate these on `AppState.shared.activeCall == nil` instead.
+final class DemoChatAudioSessionConfigurator: StreamAudioSessionConfigurator, @unchecked Sendable {
+    override func activateRecordingSession() throws {}
+    override func deactivateRecordingSession() throws {}
+    override func activatePlaybackSession() throws {}
+    override func deactivatePlaybackSession() throws {}
+}
 
 struct DemoChatAdapter {
 
@@ -25,7 +46,22 @@ struct DemoChatAdapter {
         let chatClient = ChatClient(config: .init(apiKeyString: AppState.shared.apiKey))
 
         self.chatClient = chatClient
-        self.streamChatUI = .init(chatClient: chatClient)
+
+        let utils = StreamChatSwiftUI.Utils()
+        let audioSessionConfigurator = DemoChatAudioSessionConfigurator()
+        utils.audioPlayerBuilder = {
+            StreamAudioPlayer(
+                assetPropertyLoader: StreamAssetPropertyLoader(),
+                audioSessionConfigurator: audioSessionConfigurator
+            )
+        }
+        utils.audioRecorderBuilder = {
+            StreamAudioRecorder(
+                configuration: .default,
+                audioSessionConfigurator: audioSessionConfigurator
+            )
+        }
+        self.streamChatUI = .init(chatClient: chatClient, utils: utils)
 
         InjectionKey.currentValue = self
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1821/bugaudio-issue-when-chat-opens

### 🎯 Goal

Fix local audio (mic **and** speaker) dying when the chat sheet is opened during a call in the DemoApp.

### 📝 Summary

- Added `DemoChatAudioSessionConfigurator`, a no-op `StreamAudioSessionConfigurator` subclass, so the chat SDK never activates/deactivates the shared `AVAudioSession` while integrated alongside StreamVideo.
- Injected it into StreamChat's audio player and audio recorder via `Utils.audioPlayerBuilder` / `Utils.audioRecorderBuilder` when creating the `StreamChat` instance in `DemoChatAdapter`.

### 🛠 Implementation

**Root cause:** When the chat sheet opens, SwiftUI creates (and discards) `ChatChannelViewModel` instances. Since chat v5, `ChatChannelViewModel.deinit` runs `cleanupAudioPlayer()` (guarded by `isVoiceRecordingEnabled`, which [stream-chat-swiftui#1340](https://github.com/GetStream/stream-chat-swiftui/pull/1340) flipped to `true` by default in 5.0.0). That calls `StreamAudioPlayer.stop()` → `StreamAudioSessionConfigurator.deactivatePlaybackSession()` → `AVAudioSession.sharedInstance().setActive(false)` on the main thread — deactivating the session the ongoing call is using. The route loses its input (`inputs:[]`), WebRTC's audio unit stops getting I/O callbacks, and both capture and playout die. No interruption fires for a same-process deactivation, so the SDK has no signal to recover from. The DemoApp picked this up with the chat v5 migration (#1159); on chat v4 the voice-recording flag defaulted to `false`, keeping the path dormant.

**Fix:** In the DemoApp, chat is only reachable while a call is active, where StreamVideo owns the audio session. We inject a configurator that no-ops all activate/deactivate calls, keeping chat away from the session entirely. Voice-message playback/recording in chat still works because the call session is already active with `.playAndRecord`/`.voiceChat`.

### 🧪 Manual Testing Notes

1. Start a call between two participants (e.g. iPad + another device) with audio and video on.
2. Verify both sides hear each other.
3. On one device, tap the chat button (bottom right) to open the chat sheet.
4. Verify audio keeps flowing in both directions while the sheet is open, after sending messages, and after dismissing it.
5. Optionally play/record a voice message in chat during the call and verify call audio survives.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes (N/A — DemoApp-only change)
- [ ] New code is covered by unit tests (N/A — DemoApp wiring)
- [ ] Comparison screenshots added for visual changes (N/A)
- [ ] Affected documentation updated (tutorial, CMS) (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice-message playback and recording in chat by preventing the app’s shared audio session from being deactivated.
  * Reduced audio interruptions when using chat audio features, leading to smoother voice note handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->