### PR TITLE
ci: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   record:
     name: Record

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -3,8 +3,11 @@ name: "Merge release"
 on:
   issue_comment:
     types: [created]
-
   workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
 
 jobs:
   merge-release-to-main:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,6 +3,9 @@ name: "Publish new release"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Publish new release

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -8,6 +8,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   test-release:
     name: Start new release

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -16,6 +16,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   sdk_size:
     name: Metrics

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -24,6 +24,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.2)"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -21,6 +21,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   deploy:
     runs-on: macos-15

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -10,6 +10,9 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+
 jobs:
   copyright:
     name: Copyright


### PR DESCRIPTION
## Summary
- Add explicit workflow-level `permissions` blocks for CodeQL `actions/missing-workflow-permissions` alerts.
- Minimal scopes only; `actions: write` where `gh workflow run` / cancel is used.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI passes
- [ ] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple GitHub Actions workflows to explicitly set least-privilege token permissions.
  * Tightened CI workflow access to primarily read-only repository data, with narrowly scoped write permissions only where needed.
  * Improves workflow security by avoiding reliance on default token permission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->