### PR TITLE
[Fix] Prevent os_unfair_lock crash when replacing a ringing call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Fixed a crash that could occur when starting a new ringing call replaced a previous one that was still ringing. [#1184](https://github.com/GetStream/stream-video-swift/pull/1184)
 - Fixed an audio crash that could occur when the audio device module was updated from multiple threads at the same time. [#1179](https://github.com/GetStream/stream-video-swift/pull/1179)
 - Local video could fail to start when joining a call if the camera capture session stopped unexpectedly (e.g. after a capture-server connection loss), because the capturer did not restart it. [#1175](https://github.com/GetStream/stream-video-swift/pull/1175)
 - The microphone now recovers after an audio-session interruption ends while the app is backgrounded, instead of staying silent (recording but capturing nothing) until you leave and rejoin the call. [#1174](https://github.com/GetStream/stream-video-swift/pull/1174)

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -33,7 +33,12 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
         /// This is set for both incoming calls and outgoing calls started
         /// with `Call.ring()`. The value is cleared after the call is
         /// joined, rejected, ended, or promoted to `activeCall`.
-        @Published public internal(set) var ringingCall: Call?
+        @Published public internal(set) var ringingCall: Call? {
+            // Keep the previous call alive until after the PublishedSubject lock is
+            // released: deallocating it inside the setter cancels its
+            // OutgoingRingingController subscription to $ringingCall and aborts.
+            didSet { _ = oldValue }
+        }
 
         private nonisolated let disposableBag = DisposableBag()
 

--- a/StreamVideoTests/StreamVideo_Tests.swift
+++ b/StreamVideoTests/StreamVideo_Tests.swift
@@ -210,6 +210,48 @@ final class StreamVideo_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
+    func test_streamVideo_ringingCallReplacement_releasesPreviousCallRetainedOnlyByRingingCall() async throws {
+        // Regression for IOS-1873: replacing `state.ringingCall` while it
+        // held the previous call's last strong reference deallocated that
+        // call inside the PublishedSubject lock. The deallocation cancelled
+        // the call's OutgoingRingingController subscription to $ringingCall,
+        // re-acquiring the same non-recursive lock and crashing.
+        let previousCallId = String(String.unique.prefix(10))
+        let previousCallCid = callCid(from: previousCallId, callType: callType)
+        let getCallResponse = GetCallResponse(
+            call: MockResponseBuilder().makeCallResponse(cid: previousCallCid),
+            duration: "1",
+            members: [],
+            ownCapabilities: []
+        )
+        httpClient.dataResponses = [try JSONEncoder.default.encode(getCallResponse)]
+
+        nonisolated(unsafe) weak var previousCall: Call?
+        do {
+            let call = streamVideo.call(callType: callType, callId: previousCallId)
+            previousCall = call
+            // ring() configures the call's OutgoingRingingController and
+            // sets it as `state.ringingCall`.
+            try await call.ring()
+            await fulfillment { [streamVideo] in
+                streamVideo?.state.ringingCall?.cId == previousCallCid
+            }
+            // Drop the cache reference so `state.ringingCall` remains the
+            // only strong reference, as with a rejected ring that was
+            // evicted from the cache before `ringingCall` was cleared.
+            InjectedValues[\.callCache].remove(for: previousCallCid)
+        }
+        XCTAssertNotNil(previousCall)
+
+        let nextCall = streamVideo.call(callType: callType, callId: callId)
+        await MainActor.run { [streamVideo] in
+            streamVideo?.state.ringingCall = nextCall
+        }
+
+        await fulfillment { previousCall == nil }
+        XCTAssertTrue(streamVideo.state.ringingCall === nextCall)
+    }
+
     func test_streamVideo_incomingCallAccept() async throws {
         // Given
         let streamVideo = StreamVideo.mock(httpClient: HTTPClient_Mock())


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1873/bugon-call-deinit

### 🎯 Goal

Starting a new outgoing ring call could crash the app with a recursive
`os_unfair_lock` abort (`EXC_BREAKPOINT`) inside Combine. This fixes that crash.

### 📝 Summary

- Keep the previous `StreamVideo.State.ringingCall` value alive until after the
  `@Published` setter releases its internal lock, so the old `Call` is no longer
  deallocated inside `PublishedSubject.send`.
- Add a regression test that reproduces the exact crash chain and verifies the
  previous call is still released (just safely, after the lock is released).

### 🛠 Implementation

`ringingCall` is `@Published`. When a new value is assigned while the previous
call's last strong reference lived in that same property, `PublishedSubject.send`
swapped the stored value **while holding its `os_unfair_lock`**. That released the
old `Call`, so `Call.deinit` ran synchronously inside the locked region. The
call's `OutgoingRingingController` owns a subscription to that same `$ringingCall`
publisher, so tearing it down called `PublishedSubject.disassociate(_:)`, which
tried to re-acquire the lock the current thread already held → recursive abort.

The fix adds a `didSet { _ = oldValue }` observer to `ringingCall`. Referencing
`oldValue` forces the compiler to retain the previous value in a local temporary
across the wrapped-value assignment, so its refcount stays ≥ 1 while the subject
holds its lock. `deinit` (and the subscription's `disassociate`) then run after
the setter returns and the lock is released. The explicit `_ = oldValue` is
required: an empty `didSet` lets the optimizer skip materializing `oldValue`,
which would silently reintroduce the bug.

### 🧪 Manual Testing Notes

Start an outgoing ring call, cancel/reject it (leaving it briefly retained only by
`state.ringingCall`), then start a new ring call. Before the fix this aborts with
`_os_unfair_lock_recursive_abort`; after the fix the previous call is released
cleanly and the new call rings.

The added test `StreamVideo_Tests.test_streamVideo_ringingCallReplacement_releasesPreviousCallRetainedOnlyByRingingCall`
crashes without the fix (reproducing the production stack frame-for-frame) and
passes with it.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when a new ringing call replaced an existing ringing call.
  * Improved ringing-call handling so the previous call is released safely after the state update completes.
  * Added regression coverage to help prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->