### PR TITLE
CI: restore write permissions for release workflows

### DIFF
--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: read
 
 jobs:
@@ -22,6 +22,7 @@ jobs:
 
       - uses: actions/checkout@v4.1.1
         with:
+          token: ${{ secrets.ADMIN_API_TOKEN }}
           fetch-depth: 0
 
       - uses: ./.github/actions/ruby-cache

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:
@@ -18,6 +18,7 @@ jobs:
 
       - uses: actions/checkout@v4.1.1
         with:
+          token: ${{ secrets.ADMIN_API_TOKEN }}
           fetch-depth: 0
 
       - uses: ./.github/actions/ruby-cache


### PR DESCRIPTION
## Summary

- Confirms feedback on #1182: `release-merge.yml` and `release-publish.yml` need `contents: write` because Fastlane release lanes run `git push` (merge to `main`, publish SPM bumps, merge back to `develop`).
- PR #1182 limited `GITHUB_TOKEN` to `contents: read`, so checkout authenticated as `github-actions[bot]` and `git push` failed with 403 (see run https://github.com/GetStream/stream-video-swift/actions/runs/28923405694).
- Restores `contents: write` on both workflows and passes `ADMIN_API_TOKEN` to checkout on jobs that push, matching the existing `merge-main-to-develop` job pattern.

## Test plan

- [ ] Merge and approve PR
- [ ] Re-run `/merge release` on the 1.49.0 release PR (or trigger `release-merge` via workflow_dispatch)
- [ ] Confirm `git push origin main` succeeds and `release-publish` can complete the `merge-main-to-develop` job


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to support write-capable repository operations.
  * Improved the authentication used by release-related workflows for more reliable publishing and merge steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->