### PR TITLE
[WebRTC]Upgrade to m148

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
-        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.8.0")
+        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "148.0.0")
     ],
     targets: [
         .target(

--- a/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
+++ b/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
@@ -9,5 +9,5 @@ extension SystemEnvironment {
   /// A Stream Video version.
   public static let version: String = "1.50.0-SNAPSHOT"
   /// The WebRTC version.
-  public static let webRTCVersion: String = "145.8.0"
+  public static let webRTCVersion: String = "148.0.0"
 }

--- a/StreamVideo-XCFramework.podspec
+++ b/StreamVideo-XCFramework.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
 
   spec.prepare_command = <<-CMD
     mkdir -p Frameworks/
-    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/145.8.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
+    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/148.0.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
     unzip -o Frameworks/StreamWebRTC.zip -d Frameworks/
     rm Frameworks/StreamWebRTC.zip
   CMD

--- a/StreamVideo.podspec
+++ b/StreamVideo.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |spec|
 
   spec.prepare_command = <<-CMD
     mkdir -p Frameworks/
-    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/145.8.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
+    curl -sL "https://github.com/GetStream/stream-video-swift-webrtc/releases/download/148.0.0/StreamWebRTC.xcframework.zip" -o Frameworks/StreamWebRTC.zip
     unzip -o Frameworks/StreamWebRTC.zip -d Frameworks/
     rm Frameworks/StreamWebRTC.zip
   CMD

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3317,7 +3317,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-video-swift-webrtc.git";
 			requirement = {
 				kind = exactVersion;
-				version = 145.8.0;
+				version = 148.0.0;
 			};
 		};
 		40F445C32A9E1D91004BE3DA /* XCRemoteSwiftPackageReference "stream-chat-swift-test-helpers" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1876/webrtcmigrate-to-m148

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled WebRTC framework to version 148.0.0.
  * Ensured Swift Package Manager, CocoaPods, and Xcode integrations use the same WebRTC release.
  * Includes the latest upstream WebRTC fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->