### PR TITLE
[Enhancement]Restore WebRTC log level synchronization

### DIFF
--- a/Sources/StreamVideo/Utils/Logger/Logger+WebRTC.swift
+++ b/Sources/StreamVideo/Utils/Logger/Logger+WebRTC.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 import StreamCore
 import StreamWebRTC
@@ -31,11 +32,6 @@ extension StreamCore.Logger {
             didSet { RTCLogger.default.didUpdate(mode: mode) }
         }
 
-        // TODO: [StreamCore migration] Previously video's `LogConfig.level`
-        // `didSet` kept this WebRTC severity in sync. StreamCore's `LogConfig`
-        // (lock-backed) has no such hook, so severity is only seeded from the
-        // level at init and no longer auto-updates. Restore syncing if/when
-        // StreamCore exposes a level-change hook (or wire it explicitly).
         nonisolated(unsafe) static var severity: RTCLoggingSeverity = .init(StreamCore.LogConfig.level) {
             didSet { RTCLogger.default.didUpdate(severity: severity) }
         }
@@ -73,8 +69,12 @@ extension StreamCore.Logger.WebRTC {
         private let logger = RTCCallbackLogger()
         private var isRunning = false
         private let processingQueue = OperationQueue(maxConcurrentOperationCount: 1)
+        private let levelCancellable: AnyCancellable
 
         private init() {
+            levelCancellable = StreamCore.LogConfig.levelPublisher
+                .dropFirst()
+                .sink { severity = .init($0) }
             didUpdate(mode: mode)
         }
 

--- a/StreamVideoTests/Utils/Logger/LoggerConcurrency_Tests.swift
+++ b/StreamVideoTests/Utils/Logger/LoggerConcurrency_Tests.swift
@@ -7,6 +7,16 @@ import XCTest
 
 final class LoggerConcurrency_Tests: XCTestCase, @unchecked Sendable {
 
+    func test_logLevelChanged_afterWebRTCLoggerInitialization_updatesSeverity() {
+        let originalLevel = LogConfig.level
+        defer { LogConfig.level = originalLevel }
+
+        _ = Logger.WebRTC.RTCLogger.default
+        LogConfig.level = .debug
+
+        XCTAssertEqual(Logger.WebRTC.severity, .verbose)
+    }
+
     func test_concurrentLoggingProcessesAllMessages() {
         let iterations = 200
         let expectation = expectation(description: "All log messages are processed")


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-1814](https://linear.app/stream/issue/IOS-1814)

Depends on StreamCore [PR #65](https://github.com/GetStream/stream-core-swift/pull/65).

### 🎯 Goal

Restore synchronization between StreamCore's configured log level and the internal WebRTC logger severity after the StreamCore logging migration.

### 📝 Summary

- Observe `StreamCore.LogConfig.levelPublisher` for WebRTC severity changes.
- Remove the completed StreamCore migration TODO.
- Add a focused regression test for updates after WebRTC logger initialization.

### 🛠 Implementation

`RTCLogger` retains one Combine cancellable for the shared level publisher. The publisher's immediate `CurrentValueSubject` emission is dropped because `Logger.WebRTC.severity` is already initialized from the current level; subsequent values continue through the existing severity setter and update the WebRTC callback logger without recursively initializing `RTCLogger.default`.

### 🎨 Showcase

Not applicable — no UI changes.

### 🧪 Manual Testing Notes

Manual QA is not required. The focused unit test runs with the `Test` configuration and `STREAM_TESTS=1`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)