### PR TITLE
[Fix]Use SFU no-pong close code for fast reconnect

### DIFF
--- a/Sources/StreamVideo/WebSockets/Client/WebSocketClient.swift
+++ b/Sources/StreamVideo/WebSockets/Client/WebSocketClient.swift
@@ -295,7 +295,14 @@ extension WebSocketClient: WebSocketPingControllerDelegate {
 
     func disconnectOnNoPongReceived() {
         log.debug("disconnecting from \(connectURL)", subsystems: .webSocket)
-        disconnect(source: .noPongReceived) {
+        let closeCode: URLSessionWebSocketTask.CloseCode
+        switch webSocketClientType {
+        case .coordinator:
+            closeCode = .normalClosure
+        case .sfu:
+            closeCode = .init(rawValue: 4001)!
+        }
+        disconnect(code: closeCode, source: .noPongReceived) {
             log.debug("Websocket is disconnected because of no pong received", subsystems: .webSocket)
         }
     }

--- a/StreamVideoTests/Mock/WebSocketEngine_Mock.swift
+++ b/StreamVideoTests/Mock/WebSocketEngine_Mock.swift
@@ -18,6 +18,7 @@ final class WebSocketEngine_Mock: WebSocketEngine, @unchecked Sendable {
 
     /// How many times was `disconnect()` called
     @Atomic var disconnect_calledCount = 0
+    @Atomic var disconnect_closeCode: URLSessionWebSocketTask.CloseCode?
 
     /// How many times was `sendPing()` called
     @Atomic var sendPing_calledCount = 0
@@ -41,6 +42,7 @@ final class WebSocketEngine_Mock: WebSocketEngine, @unchecked Sendable {
     }
 
     func disconnect(with code: URLSessionWebSocketTask.CloseCode) {
+        disconnect_closeCode = code
         disconnect_calledCount += 1
     }
 

--- a/StreamVideoTests/WebSocketClient/WebSocketClient_Tests.swift
+++ b/StreamVideoTests/WebSocketClient/WebSocketClient_Tests.swift
@@ -151,6 +151,7 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
 
         // Assert disconnect is called
         AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
+        XCTAssertEqual(engine!.disconnect_closeCode, .normalClosure)
     }
 
     func test_whenConnectedAndEngineDisconnectsWithServerError_itIsTreatedAsServerInitiatedDisconnect() {
@@ -263,7 +264,7 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
         AssertAsync.willBeEqual(pingController.pongReceivedCount, 2)
     }
 
-    func test_webSocketPingController_disconnectOnNoPongReceived_disconnectsEngine() {
+    func test_webSocketPingController_disconnectOnNoPongReceived_coordinatorUsesNormalClosure() {
         // Simulate connection to make sure web socket engine exists
         test_connectionFlow()
 
@@ -275,6 +276,30 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
             Assert.willBeEqual(self.webSocketClient.connectionState, .disconnecting(source: .noPongReceived))
             Assert.willBeEqual(self.engine!.disconnect_calledCount, 1)
         }
+        XCTAssertEqual(engine!.disconnect_closeCode, .normalClosure)
+    }
+
+    func test_webSocketPingController_disconnectOnNoPongReceived_sfuUsesUnhealthyConnectionClosure() {
+        var environment = WebSocketClient.Environment.mock
+        environment.timerType = VirtualTimeTimer.self
+        webSocketClient = WebSocketClient(
+            sessionConfiguration: .ephemeral,
+            eventDecoder: decoder,
+            eventNotificationCenter: eventNotificationCenter,
+            webSocketClientType: .sfu,
+            environment: environment,
+            connectURL: connectURL
+        )
+        webSocketClient.connect()
+        AssertAsync.willBeEqual(engine!.connect_calledCount, 1)
+
+        pingController.delegate?.disconnectOnNoPongReceived()
+
+        AssertAsync {
+            Assert.willBeEqual(self.webSocketClient.connectionState, .disconnecting(source: .noPongReceived))
+            Assert.willBeEqual(self.engine!.disconnect_calledCount, 1)
+        }
+        XCTAssertEqual(engine!.disconnect_closeCode?.rawValue, 4001)
     }
 
     // MARK: - Event handling tests


### PR DESCRIPTION
### 🔗 Issue Links

- IOS-1891

### 🎯 Goal

Prevent an SFU WebSocket ping timeout from being interpreted as an intentional
participant departure, which can invalidate the server state needed by a
subsequent fast reconnect.

### 📝 Summary

- Close an unhealthy SFU WebSocket with code `4001`.
- Keep coordinator no-pong and intentional disconnects on normal closure
  (`1000`).
- Preserve the existing SFU refresh close code (`4002`).
- Add unit coverage for all affected close-code boundaries.

### 🛠 Implementation

`WebSocketClient.disconnectOnNoPongReceived()` now selects the close code from
the WebSocket client type:

- SFU: `4001`, identifying an unhealthy connection.
- Coordinator: `.normalClosure`.

The generic `disconnect` default, subscriber offer observation, and fast
reconnect state machine are unchanged.

### 🎨 Showcase

Not applicable.

### 🧪 Manual Testing Notes

- `WebSocketClient_Tests`: 17/17 passed.
- `WebRTCCoordinatorStateMachine_FastReconnectingStageTests`: 11/11 passed,
  including the existing `4002` refresh assertion.
- StreamVideo Debug iOS Simulator build passed.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7T9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is not required for this internal reconnect behavior
- [x] New code is covered by unit tests
- [x] Comparison screenshots are not applicable
- [x] Documentation is not affected

### 🎁 Meme

Not applicable.
