### PR TITLE
[StreamCore] Preserve SFU reconnect close codes

### DIFF
--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUAdapter.swift
@@ -218,10 +218,7 @@ final class SFUAdapter: CustomStringConvertible, @unchecked Sendable {
         webSocketConfiguration: WebSocketConfiguration
     ) {
         log.debug("Will refresh \(self).", subsystems: .sfu)
-        // `StreamCore.WebSocketClient` can't be reconfigured in place, so a
-        // refresh tears down the current socket and builds a fresh one via the
-        // injected factory. 4002 is the SFU "refresh" close code.
-        webSocket.disconnect(code: .init(rawValue: 4002)!)
+        webSocket.disconnectForReconfiguration()
         requestDisposableBag.removeAll()
         webSocket = webSocketFactory(
             webSocketConfiguration.url,

--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUWebSocket.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUWebSocket.swift
@@ -128,20 +128,22 @@ struct SFUWebSocketCloseCodeProvider: WebSocketCloseCodeProviding {
     ) -> URLSessionWebSocketTask.CloseCode {
         switch context {
         case .disconnection(source: .noPongReceived):
-            // The SFU treats 4001 as an unhealthy transport. Unlike a normal
-            // closure, it keeps participant state available for fast reconnect.
+            // 4001 identifies the health-check timeout across Stream SDKs. The
+            // SFU treats every non-1000/non-1001 code as an abnormal close and
+            // preserves participant state during its reconnect grace period.
             return Self.connectionUnhealthy
         case .reconfiguration:
-            // The SFU reserves 4002 for replacing the signaling socket with a
-            // new configuration without treating the replacement as a leave.
+            // 4002 identifies a Swift socket replacement. It is not reserved by
+            // the SFU; using a custom code selects the abnormal-close path and
+            // avoids immediate participant teardown.
             return Self.reconfiguration
         case let .explicit(code, _):
             // Preserve callers that intentionally use a protocol close code,
             // such as `.goingAway` during adapter teardown.
             return code
         case .disconnection:
-            // Only no-pong is recoverable through fast reconnect. All other
-            // sources retain the existing normal-closure behavior.
+            // Preserve intentional-disconnect behavior. A normal closure tells
+            // the SFU it can tear down participant state immediately.
             return .normalClosure
         @unknown default:
             // A future StreamCore context is not implicitly recoverable.

--- a/Sources/StreamVideo/WebRTC/v2/SFU/SFUWebSocket.swift
+++ b/Sources/StreamVideo/WebRTC/v2/SFU/SFUWebSocket.swift
@@ -23,6 +23,7 @@ protocol SFUWebSocketProtocol: AnyObject {
     func connect()
     func disconnect() async
     func disconnect(code: URLSessionWebSocketTask.CloseCode)
+    func disconnectForReconfiguration()
     func send(_ message: any SendableEvent)
     func inject(_ payload: Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload)
 }
@@ -72,6 +73,7 @@ final class SFUWebSocket: SFUWebSocketProtocol, ConnectionStateDelegate, @unchec
             requiresAuth: false,
             // Keep SFU health checks below the call state's 15-second timeout.
             pingInterval: 5,
+            closeCodeProvider: SFUWebSocketCloseCodeProvider(),
             pingRequestBuilder: { makeSFUHealthCheckPing() }
         )
         webSocket.connectionStateDelegate = self
@@ -87,6 +89,10 @@ final class SFUWebSocket: SFUWebSocketProtocol, ConnectionStateDelegate, @unchec
 
     func disconnect(code: URLSessionWebSocketTask.CloseCode) {
         webSocket.disconnect(code: code, source: .userInitiated) {}
+    }
+
+    func disconnectForReconfiguration() {
+        webSocket.disconnect(context: .reconfiguration) {}
     }
 
     /// Sends an outbound SFU message over the WebSocket.
@@ -106,6 +112,41 @@ final class SFUWebSocket: SFUWebSocketProtocol, ConnectionStateDelegate, @unchec
         didUpdateConnectionState state: WebSocketConnectionState
     ) {
         connectionState = .init(state)
+    }
+}
+
+struct SFUWebSocketCloseCodeProvider: WebSocketCloseCodeProviding {
+    private static let connectionUnhealthy = URLSessionWebSocketTask.CloseCode(
+        rawValue: 4001
+    )!
+    private static let reconfiguration = URLSessionWebSocketTask.CloseCode(
+        rawValue: 4002
+    )!
+
+    func closeCode(
+        for context: WebSocketCloseContext
+    ) -> URLSessionWebSocketTask.CloseCode {
+        switch context {
+        case .disconnection(source: .noPongReceived):
+            // The SFU treats 4001 as an unhealthy transport. Unlike a normal
+            // closure, it keeps participant state available for fast reconnect.
+            return Self.connectionUnhealthy
+        case .reconfiguration:
+            // The SFU reserves 4002 for replacing the signaling socket with a
+            // new configuration without treating the replacement as a leave.
+            return Self.reconfiguration
+        case let .explicit(code, _):
+            // Preserve callers that intentionally use a protocol close code,
+            // such as `.goingAway` during adapter teardown.
+            return code
+        case .disconnection:
+            // Only no-pong is recoverable through fast reconnect. All other
+            // sources retain the existing normal-closure behavior.
+            return .normalClosure
+        @unknown default:
+            // A future StreamCore context is not implicitly recoverable.
+            return .normalClosure
+        }
     }
 }
 

--- a/StreamVideoTests/WebRTC/SFU/Mocks/MockSFUWebSocket.swift
+++ b/StreamVideoTests/WebRTC/SFU/Mocks/MockSFUWebSocket.swift
@@ -16,6 +16,7 @@ final class MockSFUWebSocket: SFUWebSocketProtocol, Mockable, @unchecked Sendabl
         case connect
         case disconnect
         case disconnectAsync
+        case disconnectForReconfiguration
         case send
         case inject
     }
@@ -24,6 +25,7 @@ final class MockSFUWebSocket: SFUWebSocketProtocol, Mockable, @unchecked Sendabl
         case connect
         case disconnect(code: URLSessionWebSocketTask.CloseCode)
         case disconnectAsync
+        case disconnectForReconfiguration
         case send(message: any StreamCore.SendableEvent)
         case inject(payload: Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload)
 
@@ -34,6 +36,8 @@ final class MockSFUWebSocket: SFUWebSocketProtocol, Mockable, @unchecked Sendabl
             case let .disconnect(code):
                 return code
             case .disconnectAsync:
+                return ()
+            case .disconnectForReconfiguration:
                 return ()
             case let .send(message):
                 return message
@@ -84,6 +88,12 @@ final class MockSFUWebSocket: SFUWebSocketProtocol, Mockable, @unchecked Sendabl
 
     func disconnect(code: URLSessionWebSocketTask.CloseCode) {
         stubbedFunctionInput[.disconnect]?.append(.disconnect(code: code))
+    }
+
+    func disconnectForReconfiguration() {
+        stubbedFunctionInput[.disconnectForReconfiguration]?.append(
+            .disconnectForReconfiguration
+        )
     }
 
     func send(_ message: any StreamCore.SendableEvent) {

--- a/StreamVideoTests/WebRTC/SFU/SFUAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUAdapter_Tests.swift
@@ -112,7 +112,10 @@ final class SFUAdapterTests: XCTestCase, @unchecked Sendable {
             )
         )
 
-        XCTAssertEqual(mockWebSocket.timesCalled(.disconnect), 1)
+        XCTAssertEqual(
+            mockWebSocket.timesCalled(.disconnectForReconfiguration),
+            1
+        )
     }
 
     func test_refresh_oldWebSocketDisconnectsNoLongerReceivesCalls() throws {

--- a/StreamVideoTests/WebRTC/SFU/SFUWebSocket_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUWebSocket_Tests.swift
@@ -4,10 +4,49 @@
 
 import Combine
 import Foundation
+import StreamCore
 @testable import StreamVideo
 import XCTest
 
 final class SFUWebSocket_Tests: XCTestCase, @unchecked Sendable {
+
+    func test_closeCodeProvider_noPongReceived_returns4001() {
+        let subject = SFUWebSocketCloseCodeProvider()
+
+        let closeCode = subject.closeCode(
+            for: .disconnection(source: .noPongReceived)
+        )
+
+        XCTAssertEqual(closeCode.rawValue, 4001)
+    }
+
+    func test_closeCodeProvider_reconfiguration_returns4002() {
+        let subject = SFUWebSocketCloseCodeProvider()
+
+        let closeCode = subject.closeCode(for: .reconfiguration)
+
+        XCTAssertEqual(closeCode.rawValue, 4002)
+    }
+
+    func test_closeCodeProvider_disconnection_returnsNormalClosure() {
+        let subject = SFUWebSocketCloseCodeProvider()
+
+        let closeCode = subject.closeCode(
+            for: .disconnection(source: .systemInitiated)
+        )
+
+        XCTAssertEqual(closeCode, .normalClosure)
+    }
+
+    func test_closeCodeProvider_explicitCode_returnsRequestedCode() {
+        let subject = SFUWebSocketCloseCodeProvider()
+
+        let closeCode = subject.closeCode(
+            for: .explicit(code: .goingAway, source: .userInitiated)
+        )
+
+        XCTAssertEqual(closeCode, .goingAway)
+    }
 
     func test_inject_typedPayload_publishesSamePayload() {
         let subject = SFUWebSocket(

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_FastReconnectingStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_FastReconnectingStageTests.swift
@@ -104,14 +104,8 @@ final class WebRTCCoordinatorStateMachine_FastReconnectingStageTests: XCTestCase
         _ = subject.transition(from: .disconnected(subject.context))
         await wait(for: 0.5)
 
-        XCTAssertEqual(webSocket.timesCalled(.disconnect), 1)
-        XCTAssertEqual(
-            webSocket.recordedInputPayload(
-                URLSessionWebSocketTask.CloseCode.self,
-                for: .disconnect
-            )?.first,
-            .init(rawValue: 4002)
-        )
+        XCTAssertEqual(webSocket.timesCalled(.disconnectForReconfiguration), 1)
+        XCTAssertEqual(webSocket.timesCalled(.disconnect), 0)
     }
 
     func test_transition_refreshWasCalledOnSFUAdapter_newWebSocketClientWasConfiguredCorrectly() async throws {


### PR DESCRIPTION
### 🔗 Issue Links

- Preserves the behavior introduced by [GetStream/stream-video-swift#1201](https://github.com/GetStream/stream-video-swift/pull/1201)

### 🎯 Goal

Preserve Stream Video’s SFU-specific WebSocket close-code behavior after migrating signaling infrastructure to StreamCore.

An unhealthy SFU connection must close with `4001` so the SFU does not interpret the disconnect as an intentional departure and remove participant state. Coordinator and ordinary disconnections should retain their existing normal-closure behavior.

### 📝 Summary

- Inject an SFU-specific close-code provider into StreamCore’s `WebSocketClient`.
- Use `4001` when the SFU health check stops receiving pong responses.
- Use `4002` when replacing an SFU socket with updated configuration.
- Preserve explicitly requested close codes and normal closure for other disconnections.
- Express SFU refresh as a semantic reconfiguration instead of selecting `4002` in `SFUAdapter`.
- Add unit tests for every close-code decision and the refresh route.

### 🛠 Implementation

`SFUWebSocketCloseCodeProvider` keeps the product-specific close-code policy inside Stream Video while StreamCore remains product-neutral.

It maps StreamCore close contexts as follows:

- `.disconnection(source: .noPongReceived)` → `4001`, indicating an unhealthy SFU connection that can recover through fast reconnect.
- `.reconfiguration` → `4002`, indicating that the signaling socket is being replaced without leaving the call.
- `.explicit(code:source:)` → the requested close code.
- Other disconnections → `.normalClosure`.

The provider is injected only into `SFUWebSocket`. Coordinator signaling continues using StreamCore’s default provider.

`SFUAdapter.refresh` now calls `disconnectForReconfiguration()`, allowing the provider to choose `4002` from the operation’s context instead of having the adapter select a raw protocol code.

### 🎨 Showcase

Not applicable. This change has no UI impact.

### 🧪 Manual Testing Notes

Automated coverage is provided by `SFUAdapterTests` and `SFUWebSocket_Tests`.

For manual verification:

1. Join a call with two participants.
2. Interrupt SFU signaling long enough to trigger the no-pong path.
3. Restore connectivity.
4. Verify the client fast-reconnects and participant media recovers without requiring either participant to leave and rejoin.
5. Exercise an SFU configuration refresh and verify the signaling socket is replaced without leaving the call.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)