### PR TITLE
[StreamCore] Remove obsolete SFU event wrapper

### DIFF
--- a/Sources/StreamVideo/WebRTC/WebRTCEventDecoder.swift
+++ b/Sources/StreamVideo/WebRTC/WebRTCEventDecoder.swift
@@ -6,14 +6,6 @@ import Foundation
 import StreamCore
 
 /// Decodes raw SFU WebSocket frames into events for `StreamCore.WebSocketClient`.
-///
-/// Since the SFU socket now runs on StreamCore, this conforms to
-/// `StreamCore.AnyEventDecoder` and returns a `StreamCore.Event` (the SFU
-/// payload, which conforms through video's refined `Event` protocol).
-/// Previously it conformed to video's `AnyEventDecoder` and returned a
-/// `WrappedEvent.sfuEvent(...)`.
-///
-/// - TODO: [IOS-1812] Remove with the SFU isolation wrapper.
 struct WebRTCEventDecoder: AnyEventDecoder {
 
     func decode(from data: Data) throws -> StreamCore.Event {

--- a/Sources/StreamVideo/WebSockets/Events/Event.swift
+++ b/Sources/StreamVideo/WebSockets/Events/Event.swift
@@ -34,11 +34,9 @@ extension Event {
     }
 }
 
-/// An internal object that we use to wrap the kind of events that are handled by WS: SFU and coordinator events
 internal enum WrappedEvent: Event, Sendable, CustomStringConvertible {
     case internalEvent(Event)
     case coordinatorEvent(VideoEvent)
-    case sfuEvent(Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload)
     
     func healthcheck() -> StreamCore.HealthCheckInfo? {
         switch self {
@@ -53,12 +51,6 @@ internal enum WrappedEvent: Event, Sendable, CustomStringConvertible {
                     connectionId: connectedEvent.connectionId
                 )
             }
-        case let .sfuEvent(event):
-            if case let .healthCheckResponse(healthCheckEvent) = event {
-                return StreamCore.HealthCheckInfo(
-                    participantCount: Int(healthCheckEvent.participantCount.total)
-                )
-            }
         case .internalEvent:
             break
         }
@@ -71,11 +63,6 @@ internal enum WrappedEvent: Event, Sendable, CustomStringConvertible {
             if case let .typeConnectionErrorEvent(errorEvent) = event {
                 return errorEvent.error
             }
-        case let .sfuEvent(event):
-            if case let .error(errorEvent) = event {
-                return errorEvent.error
-            }
-            return nil
         case .internalEvent:
             break
         }
@@ -86,8 +73,6 @@ internal enum WrappedEvent: Event, Sendable, CustomStringConvertible {
         switch self {
         case let .coordinatorEvent(event):
             return "coordinator: \(event.type)"
-        case let .sfuEvent(event):
-            return "sfu: \(event.name)"
         case let .internalEvent(event):
             return "internal: \(event.name)"
         }
@@ -97,8 +82,6 @@ internal enum WrappedEvent: Event, Sendable, CustomStringConvertible {
         switch self {
         case let .coordinatorEvent(event):
             return "coordinator: \(event)"
-        case let .sfuEvent(event):
-            return "sfu: \(event)"
         case let .internalEvent(event):
             return "internal: \(event)"
         }

--- a/StreamVideoTests/Mock/MockSFUStack.swift
+++ b/StreamVideoTests/Mock/MockSFUStack.swift
@@ -45,9 +45,9 @@ struct MockSFUStack: @unchecked Sendable {
         webSocket.simulate(state: state)
     }
 
-    func receiveEvent(_ event: WrappedEvent) {
-        if case let .sfuEvent(payload) = event {
-            webSocket.receive(payload)
-        }
+    func receiveEvent(
+        _ payload: Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload
+    ) {
+        webSocket.receive(payload)
     }
 }

--- a/StreamVideoTests/Mock/MockWebRTCCoordinatorStack.swift
+++ b/StreamVideoTests/Mock/MockWebRTCCoordinatorStack.swift
@@ -75,21 +75,21 @@ final class MockWebRTCCoordinatorStack: @unchecked Sendable {
     func joinResponse(_ participants: [CallParticipant]) {
         var event = Stream_Video_Sfu_Event_JoinResponse()
         event.callState.participants = participants.map { .init($0) }
-        sfuStack.receiveEvent(.sfuEvent(.joinResponse(event)))
+        sfuStack.receiveEvent(.joinResponse(event))
     }
 
     func participantJoined(_ participant: CallParticipant) {
         var event = Stream_Video_Sfu_Event_ParticipantJoined()
         event.participant = .init(participant)
         event.callCid = callCid
-        sfuStack.receiveEvent(.sfuEvent(.participantJoined(event)))
+        sfuStack.receiveEvent(.participantJoined(event))
     }
 
     func participantLeft(_ participant: CallParticipant) {
         var event = Stream_Video_Sfu_Event_ParticipantLeft()
         event.participant = .init(participant)
         event.callCid = callCid
-        sfuStack.receiveEvent(.sfuEvent(.participantLeft(event)))
+        sfuStack.receiveEvent(.participantLeft(event))
     }
 
     func addTrack(
@@ -124,7 +124,7 @@ final class MockWebRTCCoordinatorStack: @unchecked Sendable {
             .sink { [weak self] _ in
                 guard let self else { return }
                 let event = Stream_Video_Sfu_Event_HealthCheckResponse()
-                sfuStack.receiveEvent(.sfuEvent(.healthCheckResponse(event)))
+                sfuStack.receiveEvent(.healthCheckResponse(event))
             }
     }
 }

--- a/StreamVideoTests/Utils/ClientEventReporting/ClientEventScenarioSupport.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/ClientEventScenarioSupport.swift
@@ -85,7 +85,7 @@ final class ClientEventScenarioHarness: @unchecked Sendable {
     }
 
     func sendJoinResponse(_ response: Stream_Video_Sfu_Event_JoinResponse = .init()) {
-        stack.sfuStack.receiveEvent(.sfuEvent(.joinResponse(response)))
+        stack.sfuStack.receiveEvent(.joinResponse(response))
     }
 }
 

--- a/StreamVideoTests/Utils/ClientEventReporting/ReconnectionClientEventScenarios_Tests.swift
+++ b/StreamVideoTests/Utils/ClientEventReporting/ReconnectionClientEventScenarios_Tests.swift
@@ -15,12 +15,10 @@ final class ReconnectionClientEventScenarios_Tests: XCTestCase, @unchecked Senda
             expectedTarget: .disconnected,
             trigger: {
                 harness.stack.sfuStack.receiveEvent(
-                    .sfuEvent(
-                        .error(
-                            SFUEventFactory.error(
-                                code: .internalServerError,
-                                reconnectStrategy: .fast
-                            )
+                    .error(
+                        SFUEventFactory.error(
+                            code: .internalServerError,
+                            reconnectStrategy: .fast
                         )
                     )
                 )
@@ -45,7 +43,7 @@ final class ReconnectionClientEventScenarios_Tests: XCTestCase, @unchecked Senda
                     reconnectStrategy: .rejoin
                 )
                 harness.stack.sfuStack.receiveEvent(
-                    .sfuEvent(.error(error))
+                    .error(error)
                 )
                 harness.stack.sfuStack.setConnectionState(
                     to: .disconnected(
@@ -66,12 +64,10 @@ final class ReconnectionClientEventScenarios_Tests: XCTestCase, @unchecked Senda
             expectedTarget: .disconnected,
             trigger: {
                 harness.stack.sfuStack.receiveEvent(
-                    .sfuEvent(
-                        .error(
-                            SFUEventFactory.error(
-                                code: .internalServerError,
-                                reconnectStrategy: .migrate
-                            )
+                    .error(
+                        SFUEventFactory.error(
+                            code: .internalServerError,
+                            reconnectStrategy: .migrate
                         )
                     )
                 )
@@ -89,7 +85,7 @@ final class ReconnectionClientEventScenarios_Tests: XCTestCase, @unchecked Senda
             expectedTarget: .disconnected,
             trigger: {
                 harness.stack.sfuStack.receiveEvent(
-                    .sfuEvent(.goAway(SFUEventFactory.goAway()))
+                    .goAway(SFUEventFactory.goAway())
                 )
             }
         ) { target in
@@ -105,12 +101,10 @@ final class ReconnectionClientEventScenarios_Tests: XCTestCase, @unchecked Senda
             expectedTarget: .leaving,
             trigger: {
                 harness.stack.sfuStack.receiveEvent(
-                    .sfuEvent(
-                        .error(
-                            SFUEventFactory.error(
-                                code: .internalServerError,
-                                reconnectStrategy: .disconnect
-                            )
+                    .error(
+                        SFUEventFactory.error(
+                            code: .internalServerError,
+                            reconnectStrategy: .disconnect
                         )
                     )
                 )

--- a/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
@@ -86,7 +86,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.connectionQualityChanged(event)),
+            payload: .connectionQualityChanged(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.connectionQuality == .good && $0[participantB.sessionId]?.connectionQuality == .excellent
@@ -111,7 +111,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.audioLevelChanged(event)),
+            payload: .audioLevelChanged(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.audioLevel == 0.8 && $0[participantB.sessionId]?.audioLevel == 0
@@ -136,7 +136,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.changePublishQuality(event)),
+            payload: .changePublishQuality(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) { [event] _ in
             let mockPublisher = try XCTUnwrap(publisher as? MockRTCPeerConnectionCoordinator)
@@ -158,7 +158,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            payload: .participantJoined(event),
             initialState: [.dummy()].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participant.sessionId] != nil && $0[participant.sessionId]?.showTrack == true
@@ -176,7 +176,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            payload: .participantJoined(event),
             initialState: [.dummy()].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             guard let pin = $0[participant.sessionId]?.pin else {
@@ -199,7 +199,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            payload: .participantJoined(event),
             initialState: [.dummy()].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participant.sessionId] != nil
@@ -218,7 +218,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             joinedEvent,
-            wrappedEvent: .sfuEvent(.participantJoined(joinedEvent)),
+            payload: .participantJoined(joinedEvent),
             initialState: [:]
         ) {
             $0[participant.sessionId]?.pin?.isLocal == false
@@ -236,7 +236,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             pinsChangedEvent,
-            wrappedEvent: .sfuEvent(.pinsUpdated(pinsChangedEvent)),
+            payload: .pinsUpdated(pinsChangedEvent),
             initialState: participantsAfterJoin
         ) {
             guard let pin = $0[participant.sessionId]?.pin else {
@@ -256,7 +256,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            payload: .participantJoined(event),
             initialState: [.dummy()].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participant.sessionId] == nil
@@ -273,7 +273,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantJoined(event)),
+            payload: .participantJoined(event),
             initialState: [
                 .dummy(),
                 .dummy(),
@@ -365,7 +365,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantLeft(event)),
+            payload: .participantLeft(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) { [trackLookupPrefix] participants in
             XCTAssertTrue(participants.isEmpty)
@@ -404,7 +404,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantLeft(event)),
+            payload: .participantLeft(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) { participants in
             participants.isEmpty == false
@@ -423,7 +423,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.dominantSpeakerChanged(event)),
+            payload: .dominantSpeakerChanged(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.isDominantSpeaker == true
@@ -441,7 +441,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.healthCheckResponse(event)),
+            payload: .healthCheckResponse(event),
             initialState: [:]
         ) { _ in
             let participantsCount = await self.stateAdapter.participantsCount
@@ -460,7 +460,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackPublished(event)),
+            payload: .trackPublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[participant.sessionId]?.hasAudio == true
@@ -475,7 +475,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackPublished(event)),
+            payload: .trackPublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[participant.sessionId]?.hasVideo == true
@@ -490,7 +490,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackPublished(event)),
+            payload: .trackPublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[participant.sessionId]?.isScreensharing == true
@@ -506,7 +506,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackPublished(event)),
+            payload: .trackPublished(event),
             initialState: [:]
         ) {
             $0.count == 1 && $0[participant.sessionId]?.hasAudio == true
@@ -523,7 +523,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[participant.sessionId]?.hasAudio == false
@@ -539,7 +539,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1
@@ -556,7 +556,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[participant.sessionId]?.hasVideo == false
@@ -572,7 +572,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1
@@ -589,7 +589,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[participant.sessionId]?.isScreensharing == false
@@ -605,7 +605,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1
@@ -623,7 +623,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.trackUnpublished(event)),
+            payload: .trackUnpublished(event),
             initialState: [:]
         ) {
             $0.count == 1 && $0[participant.sessionId]?.hasAudio == false
@@ -643,7 +643,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.pinsUpdated(event)),
+            payload: .pinsUpdated(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.pin != nil && $0[participantB.sessionId]?.pin == nil
@@ -661,7 +661,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.pinsUpdated(event)),
+            payload: .pinsUpdated(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.pin?.isLocal == false && $0[participantB.sessionId]?.pin == nil
@@ -679,7 +679,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.pinsUpdated(event)),
+            payload: .pinsUpdated(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.pin != nil && $0[participantB.sessionId]?.pin == nil
@@ -703,7 +703,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantUpdated(event)),
+            payload: .participantUpdated(event),
             initialState: [participant].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0.count == 1 && $0[expectedParticipant.sessionId] == expectedParticipant
@@ -720,7 +720,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.participantUpdated(event)),
+            payload: .participantUpdated(event),
             initialState: [:]
         ) {
             $0.count == 1 && $0[expectedParticipant.sessionId] == expectedParticipant
@@ -745,7 +745,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.changePublishOptions(event)),
+            payload: .changePublishOptions(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) { _ in await self.stateAdapter.publishOptions == expected }
     }
@@ -765,7 +765,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         ]
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.inboundStateNotification(event)),
+            payload: .inboundStateNotification(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.pausedTracks == [.video] && $0[participantB.sessionId]?.pausedTracks.isEmpty == true
@@ -794,7 +794,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         ]
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.inboundStateNotification(event)),
+            payload: .inboundStateNotification(event),
             initialState: [participantA, participantB, participantC]
                 .reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
@@ -816,7 +816,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         ]
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.inboundStateNotification(event)),
+            payload: .inboundStateNotification(event),
             initialState: [participantA, participantB].reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
             $0[participantA.sessionId]?.pausedTracks.isEmpty == true
@@ -846,7 +846,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         ]
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.inboundStateNotification(event)),
+            payload: .inboundStateNotification(event),
             initialState: [participantA, participantB, participantC]
                 .reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
@@ -879,7 +879,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         ]
         try await assert(
             event,
-            wrappedEvent: .sfuEvent(.inboundStateNotification(event)),
+            payload: .inboundStateNotification(event),
             initialState: [participantA, participantB, participantC]
                 .reduce(into: [String: CallParticipant]()) { $0[$1.sessionId] = $1 }
         ) {
@@ -893,7 +893,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
     private func assert<T>(
         _ event: T,
-        wrappedEvent: WrappedEvent,
+        payload: Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload,
         initialState: [String: CallParticipant],
         handler: @Sendable @escaping ([String: CallParticipant]) async throws -> Bool
     ) async throws {
@@ -907,9 +907,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
         /// the stateAdapter spins up another task to complete the update.
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                if case let .sfuEvent(payload) = wrappedEvent {
-                    self.mockWebSocket.receive(payload)
-                }
+                self.mockWebSocket.receive(payload)
                 await self.fulfillment(of: [eventExpectation], timeout: defaultTimeout)
             }
             group.addTask {

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/Adapters/ICEAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/Adapters/ICEAdapter_Tests.swift
@@ -118,7 +118,7 @@ final class ICEAdapterTests: XCTestCase, @unchecked Sendable {
         await wait(for: 0.5)
         var candidate = Stream_Video_Sfu_Models_ICETrickle()
         candidate.iceCandidate = iceCandidate.sdp
-        mockSFUStack.receiveEvent(.sfuEvent(.iceTrickle(candidate)))
+        mockSFUStack.receiveEvent(.iceTrickle(candidate))
         await wait(for: 1.0) // Wait until the event has been processed from the ICEAdapter
 
         mockPeerConnection
@@ -164,7 +164,7 @@ final class ICEAdapterTests: XCTestCase, @unchecked Sendable {
         }
         """
         event.sessionID = .unique
-        mockSFUStack.receiveEvent(.sfuEvent(.iceTrickle(event)))
+        mockSFUStack.receiveEvent(.iceTrickle(event))
 
         await fulfillment { self.mockPeerConnection.timesCalled(.addCandidate) == 1 }
         let candidate = try XCTUnwrap(
@@ -198,7 +198,7 @@ final class ICEAdapterTests: XCTestCase, @unchecked Sendable {
         }
         """
 
-        mockSFUStack.receiveEvent(.sfuEvent(.iceTrickle(event)))
+        mockSFUStack.receiveEvent(.iceTrickle(event))
         await wait(for: 0.5)
 
         XCTAssertEqual(mockPeerConnection.timesCalled(.addCandidate), 0)
@@ -242,7 +242,7 @@ final class ICEAdapterTests: XCTestCase, @unchecked Sendable {
         }
         """
 
-        mockSFUStack.receiveEvent(.sfuEvent(.iceTrickle(event)))
+        mockSFUStack.receiveEvent(.iceTrickle(event))
         await wait(for: 0.5)
 
         XCTAssertEqual(mockPeerConnection.timesCalled(.addCandidate), 0)

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
@@ -621,7 +621,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
     func test_handleSubscriberOffer_subjectIsPublisher_doesNotCallSetRemoteDescription() async throws {
         _ = subject
 
-        mockSFUStack.receiveEvent(.sfuEvent(.subscriberOffer(Stream_Video_Sfu_Event_SubscriberOffer())))
+        mockSFUStack.receiveEvent(.subscriberOffer(Stream_Video_Sfu_Event_SubscriberOffer()))
 
         await wait(for: 1)
         XCTAssertEqual(mockPeerConnection?.timesCalled(.setRemoteDescription), 0)
@@ -635,7 +635,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var offer = Stream_Video_Sfu_Event_SubscriberOffer()
         offer.sdp = .unique
-        mockSFUStack.receiveEvent(.sfuEvent(.subscriberOffer(offer)))
+        mockSFUStack.receiveEvent(.subscriberOffer(offer))
 
         await fulfillment { [mockPeerConnection] in
             mockPeerConnection?.timesCalled(.setRemoteDescription) == 1
@@ -656,7 +656,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var offer = Stream_Video_Sfu_Event_SubscriberOffer()
         offer.sdp = .unique
-        mockSFUStack.receiveEvent(.sfuEvent(.subscriberOffer(offer)))
+        mockSFUStack.receiveEvent(.subscriberOffer(offer))
 
         await fulfillment { [mockPeerConnection] in
             mockPeerConnection?.timesCalled(.answer) == 1
@@ -671,7 +671,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var offer = Stream_Video_Sfu_Event_SubscriberOffer()
         offer.sdp = .unique
-        mockSFUStack.receiveEvent(.sfuEvent(.subscriberOffer(offer)))
+        mockSFUStack.receiveEvent(.subscriberOffer(offer))
 
         await fulfillment { [mockPeerConnection] in
             mockPeerConnection?.timesCalled(.setLocalDescription) == 1
@@ -696,7 +696,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
             with: RTCSessionDescription(type: .offer, sdp: sdp)
         )
 
-        mockSFUStack.receiveEvent(.sfuEvent(.subscriberOffer(Stream_Video_Sfu_Event_SubscriberOffer())))
+        mockSFUStack.receiveEvent(.subscriberOffer(Stream_Video_Sfu_Event_SubscriberOffer()))
 
         await fulfillment { [mockSFUStack] in
             mockSFUStack?.service.sendAnswerWasCalledWithRequest != nil
@@ -802,7 +802,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var payload = Stream_Video_Sfu_Event_ICERestart()
         payload.peerType = .publisherUnspecified
-        mockSFUStack.receiveEvent(.sfuEvent(.iceRestart(payload)))
+        mockSFUStack.receiveEvent(.iceRestart(payload))
 
         await fulfillment { [mockPeerConnection] in
             mockPeerConnection?.timesCalled(.offer) == 1
@@ -822,7 +822,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var payload = Stream_Video_Sfu_Event_ICERestart()
         payload.peerType = .publisherUnspecified
-        mockSFUStack.receiveEvent(.sfuEvent(.iceRestart(payload)))
+        mockSFUStack.receiveEvent(.iceRestart(payload))
 
         await wait(for: 1)
         XCTAssertEqual(mockPeerConnection?.timesCalled(.offer), 0)
@@ -835,7 +835,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var payload = Stream_Video_Sfu_Event_ICERestart()
         payload.peerType = .subscriber
-        mockSFUStack.receiveEvent(.sfuEvent(.iceRestart(payload)))
+        mockSFUStack.receiveEvent(.iceRestart(payload))
 
         await wait(for: 1)
         XCTAssertEqual(mockPeerConnection?.timesCalled(.offer), 0)
@@ -849,7 +849,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var payload = Stream_Video_Sfu_Event_ICERestart()
         payload.peerType = .subscriber
-        mockSFUStack.receiveEvent(.sfuEvent(.iceRestart(payload)))
+        mockSFUStack.receiveEvent(.iceRestart(payload))
 
         await fulfillment { [mockSFUStack] in
             mockSFUStack?.service.iceRestartWasCalledWithRequest?.sessionID == self.sessionId
@@ -863,7 +863,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
         var payload = Stream_Video_Sfu_Event_ICERestart()
         payload.peerType = .publisherUnspecified
-        mockSFUStack.receiveEvent(.sfuEvent(.iceRestart(payload)))
+        mockSFUStack.receiveEvent(.iceRestart(payload))
 
         await wait(for: 1)
         XCTAssertNil(mockSFUStack?.service.iceRestartWasCalledWithRequest)

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoinedStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoinedStageTests.swift
@@ -161,10 +161,8 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
         )
         subject.context.migrationStatusObserver = migrationStatusObserver
         let cancellable = receiveEvent(
-            .sfuEvent(
-                .participantMigrationComplete(
-                    Stream_Video_Sfu_Event_ParticipantMigrationComplete()
-                )
+            .participantMigrationComplete(
+                Stream_Video_Sfu_Event_ParticipantMigrationComplete()
             ),
             every: 0.1
         )
@@ -416,7 +414,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
             trigger: { [mockCoordinatorStack] in
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.callEnded(Stream_Video_Sfu_Event_CallEnded())))
+                    .receiveEvent(.callEnded(Stream_Video_Sfu_Event_CallEnded()))
             }
         ) { _ in }
     }
@@ -435,7 +433,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .migrate
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { target in
             XCTAssertEqual(target.context.reconnectionStrategy, .migrate)
@@ -453,7 +451,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .rejoin
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { target in
             XCTAssertEqual(target.context.reconnectionStrategy, .rejoin)
@@ -472,7 +470,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .fast
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { target in
             switch target.context.reconnectionStrategy {
@@ -494,7 +492,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
             trigger: { [mockCoordinatorStack] in
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.goAway(Stream_Video_Sfu_Event_GoAway())))
+                    .receiveEvent(.goAway(Stream_Video_Sfu_Event_GoAway()))
             }
         ) { target in
             XCTAssertEqual(target.context.reconnectionStrategy, .migrate)
@@ -515,7 +513,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .disconnect
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { _ in }
     }
@@ -536,7 +534,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.error.code = .participantSignalLost
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { stage in
             switch stage.context.reconnectionStrategy {
@@ -563,7 +561,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .migrate
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { stage in
             XCTAssertEqual(stage.context.reconnectionStrategy, .migrate)
@@ -584,7 +582,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .migrate
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { stage in
             XCTAssertEqual(stage.context.reconnectionStrategy, .migrate)
@@ -605,7 +603,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .migrate
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { stage in
             XCTAssertEqual(stage.context.reconnectionStrategy, .migrate)
@@ -626,7 +624,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .rejoin
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { stage in
             XCTAssertEqual(stage.context.reconnectionStrategy, .rejoin)
@@ -666,7 +664,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
         subject.context.webSocketHealthTimeout = 5
 
         await assertResultAfterTrigger {
-            self.mockCoordinatorStack.sfuStack.receiveEvent(.sfuEvent(.healthCheckResponse(.init())))
+            self.mockCoordinatorStack.sfuStack.receiveEvent(.healthCheckResponse(.init()))
         } validationHandler: { expectation in
             guard
                 let currentLastHealthCheckReceivedAt = self.subject.context.lastHealthCheckReceivedAt,
@@ -745,7 +743,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .fast
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { target in
             switch target.context.reconnectionStrategy {
@@ -769,7 +767,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
                 error.reconnectStrategy = .rejoin
                 mockCoordinatorStack?
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.error(error)))
+                    .receiveEvent(.error(error))
             }
         ) { target in
             XCTAssertEqual(target.context.reconnectionStrategy, .rejoin)
@@ -1066,7 +1064,7 @@ final class WebRTCCoordinatorStateMachine_JoinedStageTests: XCTestCase, @uncheck
     }
 
     private func receiveEvent(
-        _ event: WrappedEvent,
+        _ event: Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload,
         every timeInterval: TimeInterval
     ) -> AnyCancellable {
         Foundation

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -97,7 +97,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
 
         subject.willTransitionAway()
         mockCoordinatorStack.sfuStack.receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse()))
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse())
         )
 
         await fulfillment(of: [unexpectedTransition], timeout: 0.2)
@@ -255,7 +255,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -280,7 +280,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -312,7 +312,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         var response = Stream_Video_Sfu_Event_JoinResponse()
         response.fastReconnectDeadlineSeconds = 22
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -333,7 +333,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -359,7 +359,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -403,7 +403,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             participantBuilder()
         ]
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -430,7 +430,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         var response = Stream_Video_Sfu_Event_JoinResponse()
         response.fastReconnectDeadlineSeconds = 22
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -458,7 +458,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -510,7 +510,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
 
         let eventCancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -544,7 +544,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
 
         let eventCancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -582,7 +582,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
         let start = Date()
@@ -622,7 +622,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
         let start = Date()
@@ -845,7 +845,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -871,7 +871,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -904,7 +904,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         var response = Stream_Video_Sfu_Event_JoinResponse()
         response.fastReconnectDeadlineSeconds = 22
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -925,7 +925,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -951,7 +951,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -998,7 +998,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             participantBuilder(subject.context.isRejoiningFromSessionID)
         ]
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -1025,7 +1025,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         var response = Stream_Video_Sfu_Event_JoinResponse()
         response.fastReconnectDeadlineSeconds = 22
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -1052,7 +1052,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1227,7 +1227,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             participantBuilder()
         ]
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -1259,7 +1259,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1492,7 +1492,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1518,7 +1518,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
 
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1551,7 +1551,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         var response = Stream_Video_Sfu_Event_JoinResponse()
         response.fastReconnectDeadlineSeconds = 22
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -1573,7 +1573,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1600,7 +1600,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1645,7 +1645,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             participantBuilder()
         ]
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -1673,7 +1673,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
         var response = Stream_Video_Sfu_Event_JoinResponse()
         response.fastReconnectDeadlineSeconds = 22
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(response)),
+            .joinResponse(response),
             every: 0.3
         )
 
@@ -1701,7 +1701,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             .set(sfuAdapter: mockCoordinatorStack.sfuStack.adapter)
         mockCoordinatorStack.webRTCAuthenticator.stubbedFunction[.waitForConnect] = Result<Void, Error>.success(())
         let cancellable = receiveEvent(
-            .sfuEvent(.joinResponse(Stream_Video_Sfu_Event_JoinResponse())),
+            .joinResponse(Stream_Video_Sfu_Event_JoinResponse()),
             every: 0.3
         )
 
@@ -1813,7 +1813,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
     }
 
     private func receiveEvent(
-        _ event: WrappedEvent,
+        _ event: Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload,
         every timeInterval: TimeInterval
     ) -> AnyCancellable {
         Foundation

--- a/StreamVideoTests/WebRTC/v2/WebRTCMigrationStatusObserver_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCMigrationStatusObserver_Tests.swift
@@ -37,7 +37,7 @@ final class WebRTCMigrationStatusObserver_Tests: XCTestCase, @unchecked Sendable
                 await self.wait(for: 0.5)
                 self
                     .sfuStack
-                    .receiveEvent(.sfuEvent(.participantMigrationComplete(Stream_Video_Sfu_Event_ParticipantMigrationComplete())))
+                    .receiveEvent(.participantMigrationComplete(Stream_Video_Sfu_Event_ParticipantMigrationComplete()))
             }
 
             try await group.waitForAll()

--- a/StreamVideoTests/WebRTC/v2/WebRTCSFUFullObserver_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCSFUFullObserver_Tests.swift
@@ -43,7 +43,7 @@ final class WebRTCSFUFullObserver_Tests: XCTestCase, @unchecked Sendable {
 
         var error = Stream_Video_Sfu_Event_Error()
         error.error.code = .sfuFull
-        sfuStack.receiveEvent(.sfuEvent(.error(error)))
+        sfuStack.receiveEvent(.error(error))
 
         await fulfillment(of: [transitionExpectation], timeout: defaultTimeout)
         XCTAssertEqual(try XCTUnwrap(subject.shouldMigrateError).error.code, .sfuFull)
@@ -52,7 +52,7 @@ final class WebRTCSFUFullObserver_Tests: XCTestCase, @unchecked Sendable {
     func test_publisher_whenErrorCodeIsNotSFUFull_doesNotEmitOrUpdateState() async {
         var error = Stream_Video_Sfu_Event_Error()
         error.error.code = .participantSignalLost
-        sfuStack.receiveEvent(.sfuEvent(.error(error)))
+        sfuStack.receiveEvent(.error(error))
 
         await wait(for: 0.2)
         XCTAssertNil(subject.shouldMigrateError)


### PR DESCRIPTION
### 🎯 Goal

Remove the obsolete `WrappedEvent.sfuEvent` path now that SFU events are decoded and delivered directly through StreamCore.

### 📝 Summary

- Remove `WrappedEvent.sfuEvent` and its mapping logic.
- Send typed SFU payloads directly in test helpers.
- Remove the stale SFU decoder migration TODO.
- Keep coordinator and internal event wrapping unchanged.

### 🛠 Implementation

`WebRTCEventDecoder` continues decoding SFU frames directly into StreamCore events. Tests now inject `OneOf_EventPayload` values into the SFU WebSocket mock without wrapping them in `WrappedEvent`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)