### PR TITLE
[Fix] Prevent camera flip from reverting to front camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Fixed camera flips reverting to the front camera during active calls. [#1206](https://github.com/GetStream/stream-video-swift/pull/1206)
+
 # [1.49.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.49.0)
 _July 08, 2026_
 

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler.swift
@@ -28,20 +28,67 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
         case running(session: AVCaptureSession, disposableBag: DisposableBag)
     }
 
+    /// Tracks one intentional camera-position transition from its expected
+    /// capture-session stop until the corresponding start notification.
+    ///
+    /// Instances provide transition identity in addition to ordering. This lets
+    /// failure rollback remove the exact in-flight change without completing an
+    /// older or newer change during rapid consecutive flips.
+    private final class CameraPositionChange {
+        /// Notification the transition is waiting to receive next.
+        enum State: Equatable {
+            /// The capture handler has not stopped the previous device yet.
+            case awaitingStop
+            /// The expected stop arrived; the replacement device has not started yet.
+            case awaitingStart
+        }
+
+        /// Start action to restore if a later action handler rejects this change.
+        let previousStartAction: StreamVideoCapturer.Action
+        /// Current notification phase for this transition.
+        var state: State = .awaitingStop
+
+        init(previousStartAction: StreamVideoCapturer.Action) {
+            self.previousStartAction = previousStartAction
+        }
+    }
+
     /// Maximum number of consecutive automatic restart attempts before giving
     /// up, to avoid a restart loop when the capture server cannot recover. The
     /// counter resets once capture successfully starts again.
     private static let maxRestartAttempts = 3
 
-    /// Serializes notification handling. All observers deliver on this queue
-    /// (via `receive(on:)`), so the restart bookkeeping below is mutated from a
-    /// single place.
+    /// Serializes lifecycle actions, failure callbacks, and notifications.
+    ///
+    /// All observers deliver on this queue through `receive(on:)`, while
+    /// ``handle(_:)`` and ``handleFailure(for:)`` enqueue synchronous operations.
+    /// Keeping every transition mutation here prevents capture actions from
+    /// racing delayed `AVCaptureSession` notifications.
     private let processingQueue = OperationQueue(maxConcurrentOperationCount: 1)
     private var state: State = .idle
     private var lastStartAction: StreamVideoCapturer.Action?
     private var restartAttempts = 0
     private var isInterrupted = false
     private var isRestarting = false
+
+    /// Intentional camera changes awaiting their stop/start notifications.
+    ///
+    /// Notification handlers consume this collection in FIFO order because
+    /// `AVCaptureSession` posts lifecycle notifications in transition order.
+    private var cameraPositionChanges: [CameraPositionChange] = []
+
+    /// Change staged by the most recent position-change pipeline invocation.
+    ///
+    /// ``handleFailure(for:)`` matches this identity against the FIFO before
+    /// rolling back. Once notifications complete and remove the transition, a
+    /// retained reference cannot roll back an already completed change.
+    private var currentCameraPositionChange: CameraPositionChange?
+
+    /// Whether automatic recovery must remain suppressed for an intentional
+    /// camera stop/start cycle.
+    private var isChangingCameraPosition: Bool {
+        !cameraPositionChanges.isEmpty
+    }
 
     /// Dispatches actions back through the capturer pipeline. Assigned by
     /// ``StreamVideoCapturer`` so the handler can issue a full capture restart.
@@ -51,6 +98,26 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
 
     /// Handles camera capture lifecycle actions.
     func handle(_ action: StreamVideoCapturer.Action) async throws {
+        try await processingQueue.addSynchronousTaskOperation { [weak self] in
+            self?.handleAction(action)
+        }
+    }
+
+    /// Rolls back a staged camera-position change rejected by a later handler.
+    ///
+    /// The callback runs on ``processingQueue`` so it is ordered with any stop
+    /// or start notification already emitted by the failed capture attempt.
+    func handleFailure(for action: StreamVideoCapturer.Action) async {
+        try? await processingQueue.addSynchronousTaskOperation { [weak self] in
+            self?.handleActionFailure(action)
+        }
+    }
+
+    // MARK: - Private
+
+    /// Applies lifecycle bookkeeping on ``processingQueue`` before downstream
+    /// handlers mutate the capture session.
+    private func handleAction(_ action: StreamVideoCapturer.Action) {
         switch action {
         /// Handle start capture event and register for session notifications.
         case let .startCapture(_, _, _, _, videoCapturer, _, _):
@@ -62,6 +129,13 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
             } else {
                 didStopCapture()
             }
+        case let .setCameraPosition(position, videoSource, videoCapturer, videoCapturerDelegate):
+            handleCameraPositionChange(
+                position: position,
+                videoSource: videoSource,
+                videoCapturer: videoCapturer,
+                videoCapturerDelegate: videoCapturerDelegate
+            )
         /// Handle stop capture event and cleanup.
         case .stopCapture:
             didStopCapture()
@@ -69,8 +143,6 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
             break
         }
     }
-
-    // MARK: - Private
 
     /// Sets up observers and state when camera capture starts.
     private func didStartCapture(
@@ -121,7 +193,7 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
             .default
             .publisher(for: AVCaptureSession.didStopRunningNotification, object: session)
             .receive(on: processingQueue)
-            .sink { [weak self] _ in self?.attemptRestart(reason: "session stopped unexpectedly") }
+            .sink { [weak self] _ in self?.handleDidStopRunning() }
             .store(in: disposableBag)
 
         /// Observe runtime errors and restart capture.
@@ -154,6 +226,77 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
         state = .running(session: session, disposableBag: disposableBag)
         lastStartAction = startAction
         isInterrupted = false
+        cameraPositionChanges.removeAll()
+        currentCameraPositionChange = nil
+    }
+
+    /// Stages the recovery configuration for a requested camera position.
+    ///
+    /// The new start action is cached immediately so a successful transition
+    /// recovers with the selected camera. The pending transition retains the
+    /// previous action so ``handleFailure(for:)`` can restore it if downstream
+    /// handling fails. Same-position requests refresh dependencies without
+    /// expecting a capture-session stop.
+    ///
+    /// - Parameters:
+    ///   - position: Camera position requested by the caller.
+    ///   - videoSource: Source that receives frames from the selected camera.
+    ///   - videoCapturer: Capturer performing the position change.
+    ///   - videoCapturerDelegate: Delegate receiving captured frames.
+    private func handleCameraPositionChange(
+        position: AVCaptureDevice.Position,
+        videoSource: RTCVideoSource,
+        videoCapturer: RTCVideoCapturer,
+        videoCapturerDelegate: RTCVideoCapturerDelegate
+    ) {
+        guard
+            let previousStartAction = lastStartAction,
+            case let .startCapture(
+                currentPosition,
+                dimensions,
+                frameRate,
+                _,
+                _,
+                _,
+                audioDeviceModule
+            ) = previousStartAction
+        else {
+            return
+        }
+        lastStartAction = .startCapture(
+            position: position,
+            dimensions: dimensions,
+            frameRate: frameRate,
+            videoSource: videoSource,
+            videoCapturer: videoCapturer,
+            videoCapturerDelegate: videoCapturerDelegate,
+            audioDeviceModule: audioDeviceModule
+        )
+        if currentPosition != position {
+            let change = CameraPositionChange(previousStartAction: previousStartAction)
+            cameraPositionChanges.append(change)
+            currentCameraPositionChange = change
+        } else {
+            currentCameraPositionChange = nil
+        }
+    }
+
+    /// Removes the exact transition staged by a failed position-change action
+    /// and restores its last successful recovery configuration.
+    ///
+    /// If the transition already completed, its identity is no longer present
+    /// and there is nothing to roll back.
+    private func handleActionFailure(_ action: StreamVideoCapturer.Action) {
+        guard
+            case .setCameraPosition = action,
+            let change = currentCameraPositionChange,
+            let index = cameraPositionChanges.firstIndex(where: { $0 === change })
+        else {
+            return
+        }
+        cameraPositionChanges.remove(at: index)
+        lastStartAction = change.previousStartAction
+        currentCameraPositionChange = nil
     }
 
     /// Cleans up resources and resets state when camera capture stops.
@@ -162,6 +305,8 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
             disposableBag.removeAll()
         }
         state = .idle
+        cameraPositionChanges.removeAll()
+        currentCameraPositionChange = nil
     }
 
     private func setInterrupted(_ value: Bool) {
@@ -180,10 +325,27 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
         session.startRunning()
     }
 
-    /// Clears restart bookkeeping once capture is running again.
+    /// Clears restart bookkeeping and completes the oldest transition awaiting
+    /// its start notification.
+    ///
+    /// FIFO completion prevents a delayed start from an earlier flip from
+    /// clearing suppression for a newer flip.
     private func handleDidStartRunning() {
         restartAttempts = 0
         isRestarting = false
+        if let index = cameraPositionChanges.firstIndex(where: { $0.state == .awaitingStart }) {
+            cameraPositionChanges.remove(at: index)
+        }
+    }
+
+    /// Consumes an expected position-change stop or starts recovery for a
+    /// genuinely unexpected session stop.
+    private func handleDidStopRunning() {
+        guard let index = cameraPositionChanges.firstIndex(where: { $0.state == .awaitingStop }) else {
+            attemptRestart(reason: "session stopped unexpectedly")
+            return
+        }
+        cameraPositionChanges[index].state = .awaitingStart
     }
 
     /// Restarts capture when the session stops or errors while we still expect
@@ -196,7 +358,8 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
         guard
             case .running = state,
             !isInterrupted,
-            !isRestarting
+            !isRestarting,
+            !isChangingCameraPosition
         else {
             return
         }

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler.swift
@@ -285,7 +285,8 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
     /// and restores its last successful recovery configuration.
     ///
     /// If the transition already completed, its identity is no longer present
-    /// and there is nothing to roll back.
+    /// and there is nothing to roll back. If capture already stopped, recovery
+    /// restarts with the restored configuration.
     private func handleActionFailure(_ action: StreamVideoCapturer.Action) {
         guard
             case .setCameraPosition = action,
@@ -294,9 +295,13 @@ final class CameraInterruptionsHandler: StreamVideoCapturerActionHandler, @unche
         else {
             return
         }
+        let shouldRestart = change.state == .awaitingStart
         cameraPositionChanges.remove(at: index)
         lastStartAction = change.previousStartAction
         currentCameraPositionChange = nil
+        if shouldRestart {
+            attemptRestart(reason: "camera position change failed after session stopped")
+        }
     }
 
     /// Cleans up resources and resets state when camera capture stops.

--- a/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoCapturer.swift
+++ b/Sources/StreamVideo/WebRTC/v2/VideoCapturing/StreamVideoCapturer.swift
@@ -38,6 +38,22 @@ protocol StreamVideoCapturerActionHandler: Sendable {
     /// - Parameter action: The action to handle. Conformers should inspect the
     ///   case and respond only to the actions they support.
     func handle(_ action: StreamVideoCapturer.Action) async throws
+
+    /// Notifies the handler that processing an action failed in the pipeline.
+    ///
+    /// ``StreamVideoCapturer`` invokes this callback for every handler after any
+    /// ``handle(_:)`` implementation throws and before rethrowing the original
+    /// error. A handler that stages state before a later handler runs should
+    /// restore that state here. Handlers without staged state can use the
+    /// default no-op implementation.
+    ///
+    /// - Parameter action: Action whose handler pipeline failed.
+    func handleFailure(for action: StreamVideoCapturer.Action) async
+}
+
+extension StreamVideoCapturerActionHandler {
+    /// Default failure callback for handlers that do not stage rollback state.
+    func handleFailure(for action: StreamVideoCapturer.Action) async {}
 }
 
 final class StreamVideoCapturer: StreamVideoCapturing, @unchecked Sendable {
@@ -508,8 +524,15 @@ final class StreamVideoCapturer: StreamVideoCapturing, @unchecked Sendable {
                 return
             }
             let actionHandlers = self.actionHandlers
-            for actionHandler in actionHandlers {
-                try await actionHandler.handle(action)
+            do {
+                for actionHandler in actionHandlers {
+                    try await actionHandler.handle(action)
+                }
+            } catch {
+                for actionHandler in actionHandlers {
+                    await actionHandler.handleFailure(for: action)
+                }
+                throw error
             }
             log.debug(
                 "VideoCapturer completed execution of action:\(action).",

--- a/StreamVideoTests/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler_Tests.swift
@@ -1,0 +1,239 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import AVFoundation
+@testable import StreamVideo
+import StreamWebRTC
+import XCTest
+
+final class CameraInterruptionsHandler_Tests: XCTestCase, @unchecked Sendable {
+
+    private var subject: CameraInterruptionsHandler!
+    private var videoSource: RTCVideoSource!
+    private var videoCapturer: RTCCameraVideoCapturer!
+    private var videoCapturerDelegate: RTCVideoCapturerDelegate!
+    private var audioDeviceModule: AudioDeviceModule!
+
+    override func setUp() {
+        super.setUp()
+        subject = .init()
+        videoSource = PeerConnectionFactory
+            .mock()
+            .makeVideoSource(forScreenShare: false)
+        videoCapturerDelegate = MockRTCVideoCapturerDelegate()
+        videoCapturer = RTCCameraVideoCapturer(
+            delegate: videoCapturerDelegate,
+            captureSession: AVCaptureSession()
+        )
+        audioDeviceModule = .init(MockRTCAudioDeviceModule())
+    }
+
+    override func tearDown() {
+        audioDeviceModule = nil
+        videoCapturerDelegate = nil
+        videoCapturer = nil
+        videoSource = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_handle_setCameraPosition_whenSessionStops_doesNotRestartCapture() async throws {
+        let recorder = ActionRecorder()
+        let unexpectedRecovery = expectation(description: "Capture should not recover.")
+        unexpectedRecovery.isInverted = true
+        unexpectedRecovery.assertForOverFulfill = false
+
+        try await subject.handle(makeStartAction(position: .front))
+        try await subject.handle(makeSetCameraPositionAction(position: .back))
+        subject.actionDispatcher = { action in
+            await recorder.record(action)
+            unexpectedRecovery.fulfill()
+        }
+
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+
+        await safeFulfillment(of: [unexpectedRecovery], timeout: 0.5)
+        let actions = await recorder.actions
+        XCTAssertTrue(actions.isEmpty)
+    }
+
+    func test_handle_setCameraPosition_whenSessionsStopDuringConsecutiveChanges_doesNotRestartCapture() async throws {
+        let recorder = ActionRecorder()
+        let unexpectedRecovery = expectation(description: "Capture should not recover.")
+        unexpectedRecovery.isInverted = true
+        unexpectedRecovery.assertForOverFulfill = false
+
+        try await subject.handle(makeStartAction(position: .front))
+        subject.actionDispatcher = { action in
+            await recorder.record(action)
+            unexpectedRecovery.fulfill()
+        }
+
+        try await subject.handle(makeSetCameraPositionAction(position: .back))
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+
+        try await subject.handle(makeSetCameraPositionAction(position: .front))
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStartRunningNotification,
+            object: videoCapturer.captureSession
+        )
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+
+        await safeFulfillment(of: [unexpectedRecovery], timeout: 0.5)
+        let actions = await recorder.actions
+        XCTAssertTrue(actions.isEmpty)
+    }
+
+    func test_handle_setCameraPosition_whenSessionStopsUnexpectedlyAfterRestart_restartsUsingCurrentPosition() async throws {
+        let recorder = ActionRecorder()
+
+        try await subject.handle(makeStartAction(position: .front))
+        try await subject.handle(makeSetCameraPositionAction(position: .back))
+        subject.actionDispatcher = { action in await recorder.record(action) }
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStartRunningNotification,
+            object: videoCapturer.captureSession
+        )
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+
+        await fulfillment("Expected capture recovery actions.") {
+            await recorder.actions.count >= 2
+        }
+        let actions = await recorder.actions
+        assertStopCapture(actions[0])
+        assertStartCapture(actions[1], position: .back)
+    }
+
+    func test_handle_startCapture_whenSessionStopsUnexpectedly_restartsUsingLastConfiguration() async throws {
+        let recorder = ActionRecorder()
+
+        try await subject.handle(makeStartAction(position: .front))
+        subject.actionDispatcher = { action in await recorder.record(action) }
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+
+        await fulfillment("Expected capture recovery actions.") {
+            await recorder.actions.count >= 2
+        }
+        let actions = await recorder.actions
+        assertStopCapture(actions[0])
+        assertStartCapture(actions[1], position: .front)
+    }
+
+    func test_handleFailure_setCameraPosition_whenSessionStopsLater_recoversUsingLastSuccessfulPosition() async throws {
+        let recorder = ActionRecorder()
+        let streamCapturer = StreamVideoCapturer(
+            videoSource: videoSource,
+            videoCapturer: videoCapturer,
+            videoCapturerDelegate: videoCapturerDelegate,
+            audioDeviceModule: audioDeviceModule,
+            actionHandlers: [subject, FailingCameraPositionHandler()]
+        )
+
+        try await subject.handle(makeStartAction(position: .front))
+        do {
+            try await streamCapturer.setCameraPosition(.back)
+            XCTFail("Expected the camera position change to fail.")
+        } catch is FailingCameraPositionHandler.Failure {
+            // Expected failure from the downstream handler.
+        }
+
+        subject.actionDispatcher = { action in await recorder.record(action) }
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+
+        await fulfillment("Expected capture recovery actions.") {
+            await recorder.actions.count >= 2
+        }
+        let actions = await recorder.actions
+        assertStopCapture(actions[0])
+        assertStartCapture(actions[1], position: .front)
+    }
+
+    private func makeStartAction(
+        position: AVCaptureDevice.Position
+    ) -> StreamVideoCapturer.Action {
+        .startCapture(
+            position: position,
+            dimensions: CGSize(width: 1280, height: 720),
+            frameRate: 30,
+            videoSource: videoSource,
+            videoCapturer: videoCapturer,
+            videoCapturerDelegate: videoCapturerDelegate,
+            audioDeviceModule: audioDeviceModule
+        )
+    }
+
+    private func makeSetCameraPositionAction(
+        position: AVCaptureDevice.Position
+    ) -> StreamVideoCapturer.Action {
+        .setCameraPosition(
+            position: position,
+            videoSource: videoSource,
+            videoCapturer: videoCapturer,
+            videoCapturerDelegate: videoCapturerDelegate
+        )
+    }
+
+    private func assertStopCapture(
+        _ action: StreamVideoCapturer.Action,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .stopCapture = action else {
+            XCTFail("Expected stopCapture action, got \(action).", file: file, line: line)
+            return
+        }
+    }
+
+    private func assertStartCapture(
+        _ action: StreamVideoCapturer.Action,
+        position expectedPosition: AVCaptureDevice.Position,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case let .startCapture(position, _, _, _, _, _, _) = action else {
+            XCTFail("Expected startCapture action, got \(action).", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(position, expectedPosition, file: file, line: line)
+    }
+}
+
+private actor ActionRecorder {
+    private(set) var actions: [StreamVideoCapturer.Action] = []
+
+    func record(_ action: StreamVideoCapturer.Action) {
+        actions.append(action)
+    }
+}
+
+private struct FailingCameraPositionHandler: StreamVideoCapturerActionHandler {
+    struct Failure: Error {}
+
+    func handle(_ action: StreamVideoCapturer.Action) async throws {
+        guard case .setCameraPosition = action else { return }
+        throw Failure()
+    }
+}

--- a/StreamVideoTests/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/VideoCapturing/ActionHandlers/Camera/CameraInterruptionsHandler_Tests.swift
@@ -171,6 +171,37 @@ final class CameraInterruptionsHandler_Tests: XCTestCase, @unchecked Sendable {
         assertStartCapture(actions[1], position: .front)
     }
 
+    func test_handleFailure_setCameraPosition_whenSessionAlreadyStopped_restartsUsingLastSuccessfulPosition() async throws {
+        let recorder = ActionRecorder()
+        let action = makeSetCameraPositionAction(position: .back)
+        let unexpectedRecovery = expectation(description: "Capture should not recover.")
+        unexpectedRecovery.isInverted = true
+        unexpectedRecovery.assertForOverFulfill = false
+        let expectedRecovery = expectation(description: "Capture should recover.")
+        expectedRecovery.expectedFulfillmentCount = 2
+
+        try await subject.handle(makeStartAction(position: .front))
+        try await subject.handle(action)
+        subject.actionDispatcher = { _ in unexpectedRecovery.fulfill() }
+        NotificationCenter.default.post(
+            name: AVCaptureSession.didStopRunningNotification,
+            object: videoCapturer.captureSession
+        )
+        await safeFulfillment(of: [unexpectedRecovery], timeout: 0.5)
+
+        subject.actionDispatcher = { action in
+            await recorder.record(action)
+            expectedRecovery.fulfill()
+        }
+        await subject.handleFailure(for: action)
+
+        await fulfillment(of: [expectedRecovery], timeout: 1)
+        let actions = await recorder.actions
+        guard actions.count >= 2 else { return }
+        assertStopCapture(actions[0])
+        assertStartCapture(actions[1], position: .front)
+    }
+
     private func makeStartAction(
         position: AVCaptureDevice.Position
     ) -> StreamVideoCapturer.Action {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1894/bugflip-camera-issue-on-1490
- Closes [#1199](https://github.com/GetStream/stream-video-swift/issues/1199)

### 🎯 Goal

Fix the camera-flip regression introduced in 1.49.0. An intentional capture-session stop while switching cameras was treated as an unexpected failure, causing recovery to restart the cached front-camera configuration after the back camera had already started.

The selected camera should remain active and stay aligned with `call.camera.direction`, while genuine unexpected capture-session stops should continue to recover normally.

### 📝 Summary

- Track intentional camera-position transitions across capture-session stop/start notifications.
- Keep the cached recovery action aligned with the latest requested camera position.
- Roll back staged transition state when a downstream capture-action handler fails.
- Cover single and consecutive flips, expected and unexpected stops, and rollback behavior with focused tests.

### 🛠 Implementation

`CameraInterruptionsHandler` now serializes capture actions and session notifications on its existing processing queue. Camera-position changes enqueue an identity-bearing transition that moves from `awaitingStop` to `awaitingStart`; matching notifications consume transitions in FIFO order. Automatic recovery remains suppressed while intentional transitions are pending, including during rapid consecutive flips.

Handling `.setCameraPosition` also rebuilds the cached start action with the requested position and current capture dependencies. A later genuine unexpected stop therefore restarts the camera using the latest successful position instead of the join-time position.

`StreamVideoCapturer` now invokes `handleFailure(for:)` on its action handlers when any handler throws. `CameraInterruptionsHandler` uses that callback to remove the exact staged transition and restore the previous recovery configuration before the original error is rethrown.

### 🧪 Manual Testing Notes

1. Run the DemoApp on a physical device.
2. Join an active video call with the front camera enabled.
3. Flip once to the back camera.
4. Verify the back camera remains active and `call.camera.direction` stays `.back`.
5. Flip repeatedly between front and back cameras and verify each selected camera remains active.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes (not applicable — no visual changes)
- [ ] Affected documentation updated (DocC; no tutorial or CMS changes required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for capture-session interruptions and unexpected stops.
  * Prevented automatic restart during intentional camera position changes.
  * Ensured failed position changes roll back to the last successful camera position.
  * Fixed camera flips no longer reverting to the front camera during active calls.
* **New Features**
  * Added failure/rollback handling for action handlers so staged state can be restored when a handler fails.
* **Tests**
  * Added XCTest coverage for interruption, consecutive position changes, failed transitions, and restart sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->