### PR TITLE
[Fix] Configure Picture-in-Picture regardless of state update order

### DIFF
--- a/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureController.swift
+++ b/Sources/StreamVideoSwiftUI/Utils/PictureInPicture/PictureInPictureController.swift
@@ -25,6 +25,9 @@ final class PictureInPictureController: @unchecked Sendable {
     // MARK: - Properties
 
     private let store: PictureInPictureStore
+    private let makePictureInPictureController: @MainActor (
+        AVPictureInPictureController.ContentSource
+    ) -> AVPictureInPictureController
 
     private let proxyDelegate: PictureInPictureDelegateProxy = .init()
 
@@ -53,22 +56,43 @@ final class PictureInPictureController: @unchecked Sendable {
     /// Creates a new Picture-in-Picture controller.
     ///
     /// - Parameter store: The store managing Picture-in-Picture state
+    /// - Parameter isPictureInPictureSupported: Whether the device supports
+    ///   Picture-in-Picture.
+    /// - Parameter makePictureInPictureController: Creates the system
+    ///   Picture-in-Picture controller.
     /// - Returns: `nil` if Picture-in-Picture is not supported on the device
     @MainActor
     init?(
-        store: PictureInPictureStore
+        store: PictureInPictureStore,
+        isPictureInPictureSupported: Bool = AVPictureInPictureController
+            .isPictureInPictureSupported(),
+        makePictureInPictureController: @escaping @MainActor (
+            AVPictureInPictureController.ContentSource
+        ) -> AVPictureInPictureController = {
+            AVPictureInPictureController(contentSource: $0)
+        }
     ) {
-        guard AVPictureInPictureController.isPictureInPictureSupported() else {
+        guard isPictureInPictureSupported else {
+            log.warning(
+                "Picture-in-Picture isn't supported on this device.",
+                subsystems: .pictureInPicture
+            )
             return nil
         }
 
         self.store = store
+        self.makePictureInPictureController = makePictureInPictureController
 
-        store
-            .publisher(for: \.sourceView)
-            .removeDuplicates()
-            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in self?.didUpdate($0) }
-            .store(in: disposableBag)
+        Publishers.CombineLatest(
+            store
+                .publisher(for: \.call)
+                .removeDuplicates { $0?.cId == $1?.cId },
+            store.publisher(for: \.sourceView).removeDuplicates()
+        )
+        .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in
+            self?.didUpdate(call: $0, sourceView: $1)
+        }
+        .store(in: disposableBag)
 
         proxyDelegate
             .publisher
@@ -85,10 +109,11 @@ final class PictureInPictureController: @unchecked Sendable {
             .store(in: disposableBag)
     }
 
-    /// Updates the Picture-in-Picture controller when the source view changes.
+    /// Updates the Picture-in-Picture controller when the call or source view
+    /// changes.
     @MainActor
-    private func didUpdate(_ sourceView: UIView?) {
-        guard let sourceView, store.state.call != nil else {
+    private func didUpdate(call: Call?, sourceView: UIView?) {
+        guard call != nil, let sourceView else {
             /// We ensure to cleanUp every Picture-in-Picture interacting component so that the next
             /// Call will start with clean state.
             pictureInPictureController?.stopPictureInPicture()
@@ -121,9 +146,7 @@ final class PictureInPictureController: @unchecked Sendable {
         )
 
         if pictureInPictureController == nil {
-            pictureInPictureController = .init(
-                contentSource: contentSource
-            )
+            pictureInPictureController = makePictureInPictureController(contentSource)
             pictureInPictureController?.canStartPictureInPictureAutomaticallyFromInline = store
                 .state
                 .canStartPictureInPictureAutomaticallyFromInline
@@ -145,7 +168,7 @@ final class PictureInPictureController: @unchecked Sendable {
             store: store
         )
 
-        didUpdate(store.state.sourceView)
+        didUpdate(call: store.state.call, sourceView: store.state.sourceView)
     }
 
     /// Handles updates to the Picture-in-Picture controller state.

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 				Utils/ParticipantEventResetAdapter/ParticipantEventResetAdapter_Tests.swift,
 				Utils/PictureInPicture/MockAVPictureInPictureController.swift,
 				Utils/PictureInPicture/PictureInPictureContentProviderTests.swift,
+				Utils/PictureInPicture/PictureInPictureController_Tests.swift,
 				Utils/PictureInPicture/PictureInPictureContentViewTests.swift,
 				Utils/PictureInPicture/PictureInPictureEnforcedStopAdapterTests.swift,
 				Utils/PictureInPicture/PictureInPictureParticipantModifierTests.swift,

--- a/StreamVideoSwiftUITests/Utils/PictureInPicture/PictureInPictureController_Tests.swift
+++ b/StreamVideoSwiftUITests/Utils/PictureInPicture/PictureInPictureController_Tests.swift
@@ -1,0 +1,133 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import AVKit
+@testable import StreamVideo
+@testable import StreamVideoSwiftUI
+import UIKit
+import XCTest
+
+@available(iOS 15.0, *)
+final class PictureInPictureControllerTests: XCTestCase, @unchecked Sendable {
+
+    private var mockStreamVideo: MockStreamVideo! = .init()
+
+    override func tearDown() async throws {
+        mockStreamVideo = nil
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func test_sourceViewUpdatedBeforeCall_callUpdated_controllerWasConfigured() async {
+        let configured = await makeConfiguredSubject(callFirst: false)
+
+        XCTAssertNotNil(configured.subject)
+    }
+
+    @MainActor
+    func test_callUpdatedBeforeSourceView_sourceViewUpdated_controllerWasConfigured() async {
+        let configured = await makeConfiguredSubject(callFirst: true)
+
+        XCTAssertNotNil(configured.subject)
+    }
+
+    @MainActor
+    func test_callCleared_callRestored_controllerWasReconfigured() async {
+        let configured = await makeConfiguredSubject(callFirst: true)
+
+        configured.store.dispatch(.setCall(nil))
+        await fulfilmentInMainActor { configured.store.state.call == nil }
+        configured.store.dispatch(.setCall(MockCall()))
+        await fulfilmentInMainActor { configured.store.state.call != nil }
+
+        await assertControllerWasConfigured(configured.factory, count: 2)
+        XCTAssertNotNil(configured.subject)
+    }
+
+    @MainActor
+    func test_sourceViewCleared_sourceViewRestored_controllerWasReconfigured() async {
+        let configured = await makeConfiguredSubject(callFirst: true)
+
+        configured.store.dispatch(.setSourceView(nil))
+        await fulfilmentInMainActor { configured.store.state.sourceView == nil }
+        configured.store.dispatch(.setSourceView(UIView()))
+        await fulfilmentInMainActor { configured.store.state.sourceView != nil }
+
+        await assertControllerWasConfigured(configured.factory, count: 2)
+        XCTAssertNotNil(configured.subject)
+    }
+
+    @MainActor
+    func test_pictureInPictureUnsupported_initializationReturnsNil() {
+        let subject = PictureInPictureController(
+            store: .init(),
+            isPictureInPictureSupported: false
+        )
+
+        XCTAssertNil(subject)
+    }
+
+    // MARK: - Private
+
+    @MainActor
+    private func makeConfiguredSubject(
+        callFirst: Bool
+    ) async -> (
+        subject: PictureInPictureController?,
+        store: PictureInPictureStore,
+        factory: Factory
+    ) {
+        let store = PictureInPictureStore()
+        let factory = Factory()
+        let subject = PictureInPictureController(
+            store: store,
+            isPictureInPictureSupported: true,
+            makePictureInPictureController: factory.make
+        )
+        if callFirst {
+            store.dispatch(.setCall(MockCall()))
+            await fulfilmentInMainActor { store.state.call != nil }
+            store.dispatch(.setSourceView(UIView()))
+            await fulfilmentInMainActor { store.state.sourceView != nil }
+        } else {
+            store.dispatch(.setSourceView(UIView()))
+            await fulfilmentInMainActor { store.state.sourceView != nil }
+            store.dispatch(.setCall(MockCall()))
+            await fulfilmentInMainActor { store.state.call != nil }
+        }
+        await assertControllerWasConfigured(factory)
+        return (subject, store, factory)
+    }
+
+    @MainActor
+    private func assertControllerWasConfigured(
+        _ factory: Factory,
+        count: Int = 1,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        await fulfilmentInMainActor(filePath: file, line: line) {
+            factory.controllers.count == count
+        }
+        XCTAssertEqual(factory.controllers.count, count, file: file, line: line)
+        XCTAssertEqual(factory.contentSources.count, count, file: file, line: line)
+    }
+}
+
+@available(iOS 15.0, *)
+@MainActor
+private final class Factory {
+
+    private(set) var contentSources: [AVPictureInPictureController.ContentSource] = []
+    private(set) var controllers: [AVPictureInPictureController] = []
+
+    func make(
+        contentSource: AVPictureInPictureController.ContentSource
+    ) -> AVPictureInPictureController {
+        contentSources.append(contentSource)
+        let controller = AVPictureInPictureController(contentSource: contentSource)
+        controllers.append(controller)
+        return controller
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-19
29/bugpicture-in-picture-not-starting
### 🎯 Goal

Ensure Picture-in-Picture is configured when the call and source view become available in either order.

### 📝 Summary

- Observe both call and source-view updates before configuring Picture-in-Picture.
- Release and recreate the controller when either dependency is cleared.
- Log when Picture-in-Picture is unsupported.
- Add regression coverage for lifecycle and update-order scenarios.

### 🛠 Implementation

Uses `CombineLatest` to react whenever the call or source view changes, configuring the controller only when both are available. Internal AVKit constructor injection enables deterministic Simulator tests without changing the public API.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ x This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Picture in Picture setup when call and video source information becomes available in either order.
  * Picture in Picture state now resets and reconfigures correctly when the call or source view is cleared or restored.
  * Unsupported Picture in Picture scenarios are handled safely.

* **Tests**
  * Added coverage for Picture in Picture configuration, state changes, and unsupported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->