### PR TITLE
[CI] Pin stream-core-swift to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Fixed the SPM resolution failure in 1.50.0 for version-pinned integrations, by pinning StreamCore to a released version instead of a branch. [#1215](https://github.com/GetStream/stream-video-swift/pull/1215)
+
 ### 🔄 Changed
 
 # [1.50.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.50.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fixed the SPM resolution failure in 1.50.0 for version-pinned integrations, by pinning StreamCore to a released version instead of a branch. [#1215](https://github.com/GetStream/stream-video-swift/pull/1215)
 
-### 🔄 Changed
-
 # [1.50.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.50.0)
 _July 29, 2026_
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.3.106)
+    fastlane-plugin-stream_actions (0.4.6)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -379,7 +379,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.3.106)
+  fastlane-plugin-stream_actions (= 0.4.6)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   json

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
         .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.12.0"),
-        .package(url: "https://github.com/GetStream/stream-core-swift.git", branch: "develop")
+        .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.10.1")
     ],
     targets: [
         .target(

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3367,8 +3367,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.10.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ before_all do |lane|
   if is_ci
     setup_ci
     setup_git_config
-    select_xcode(version: xcode_version) unless [:sonar_upload, :allure_launch, :allure_upload, :stop_e2e_helpers, :merge_main].include?(lane)
+    select_xcode(version: xcode_version) unless [:sonar_upload, :allure_launch, :allure_upload, :stop_e2e_helpers, :merge_main, :pr].include?(lane)
   elsif lane == :test_e2e
     stop_e2e_helpers
   end
@@ -702,4 +702,8 @@ lane :size_analyze do
   )
 
   show_detailed_sdk_size(sdk_names: sdk_names, threshold: 42)
+end
+
+lane :pr do
+  next_pr_number(github_repo: github_repo)
 end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,3 +1,3 @@
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.3.106'
+gem 'fastlane-plugin-stream_actions', '0.4.6'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Swift Package Manager resolution for version-pinned integrations by using a released StreamCore version instead of a development branch.
  * Improved compatibility and reliability when integrating the SDK through Swift Package Manager.

* **Chores**
  * Updated build automation and release tooling.
  * Refreshed supporting tooling to improve pull request and CI workflows.
  * Documented the dependency resolution fix in the upcoming changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->