### PR TITLE
[Fix] Complete PushKit callbacks after incoming call reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Prevent CallKit-driven joins from disconnecting and rejoining while waiting for audio-session activation. [#1218](https://github.com/GetStream/stream-video-swift/pull/1218)
+- Fixed a crash caused by completing a PushKit VoIP notification before CallKit finished reporting its incoming call. [#1219](https://github.com/GetStream/stream-video-swift/pull/1219)
 
 ### 🔄 Changed
 

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -117,7 +117,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         }
 
         let content = decodePayload(payload)
-        callKitService.enqueuePushNotificationCompletion(
+        callKitService.pushNotificationCompletionStorage.append(
             completion,
             for: content.cid
         )

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -116,9 +116,11 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
             return
         }
 
-        callKitService.pushNotificationCompletionHandler = completion
-        
         let content = decodePayload(payload)
+        callKitService.enqueuePushNotificationCompletion(
+            completion,
+            for: content.cid
+        )
 
         log
             .debug(

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -99,15 +99,24 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         }
     }
 
-    /// Delegate method called when the device receives a VoIP push notification.
+    /// Handles a push notification delivered by PushKit.
+    ///
+    /// VoIP pushes keep their completion pending until ``CallKitService`` has
+    /// finished reporting the matching incoming call to CallKit. Completing
+    /// earlier can cause the system to treat the push as unhandled and
+    /// terminate the app.
     open nonisolated func pushRegistry(
         _ registry: PKPushRegistry,
         didReceiveIncomingPushWith payload: PKPushPayload,
         for type: PKPushType,
         completion: @escaping () -> Void
     ) {
-        defer { completion() }
-        guard type == .voIP else { return }
+        guard type == .voIP else {
+            completion()
+            return
+        }
+
+        callKitService.pushNotificationCompletionHandler = completion
         
         let content = decodePayload(payload)
 

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -123,6 +123,17 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// runs in the background. See `CallKitMissingPermissionPolicy`.
     open var missingPermissionPolicy: CallKitMissingPermissionPolicy = .none
 
+    /// The completion for the VoIP push currently being reported to CallKit.
+    ///
+    /// ``CallKitPushNotificationAdapter`` sets this before reporting an
+    /// incoming call. PushKit requires the call to be reported to CallKit
+    /// before its completion runs, so ``CallKitService`` keeps the completion
+    /// pending until `CXProvider` finishes `reportNewIncomingCall`.
+    ///
+    /// The completion is atomically consumed and cleared before invocation to
+    /// prevent a later incoming call from invoking a stale PushKit callback.
+    @Atomic var pushNotificationCompletionHandler: (() -> Void)?
+
     /// The policy that decides whether CallKit-managed calls
     /// should leave automatically when participant state changes.
     ///
@@ -211,7 +222,12 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         }
     }
 
-    /// Report an incoming call to CallKit.
+    /// Reports an incoming call to CallKit.
+    ///
+    /// When the report originated from ``CallKitPushNotificationAdapter``, the
+    /// provider completion also completes the pending PushKit notification.
+    /// This ordering ensures the system observes the incoming call report
+    /// before the PushKit delegate finishes handling the VoIP push.
     open func reportIncomingCall(
         _ cid: String,
         localizedCallerName: String,
@@ -229,7 +245,18 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         callProvider.reportNewIncomingCall(
             with: callUUID,
             update: callUpdate,
-            completion: completion
+            completion: { [self] error in
+                completion(error)
+
+                var pushNotificationCompletionHandler: (() -> Void)?
+                // Take and clear the handler in one operation so it is called
+                // at most once even if provider completion is repeated.
+                _pushNotificationCompletionHandler.mutate {
+                    pushNotificationCompletionHandler = $0
+                    return nil
+                }
+                pushNotificationCompletionHandler?()
+            }
         )
 
         log.debug(

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -17,6 +17,52 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         var isMuted: Bool
     }
 
+    /// Stores PushKit completions until their incoming calls are reported.
+    ///
+    /// PushKit delivery and CallKit reporting may use different queues. Access
+    /// is synchronized, and multiple pushes for the same CID are returned in
+    /// the order they were received.
+    final class PushNotificationCompletionStorage: @unchecked Sendable {
+        /// A PushKit completion that can be passed to CallKit's callback.
+        final class Completion: @unchecked Sendable {
+            private let action: () -> Void
+
+            init(_ action: @escaping () -> Void) {
+                self.action = action
+            }
+
+            func callAsFunction() {
+                action()
+            }
+        }
+
+        private let queue = UnfairQueue()
+        private var storage: [String: [Completion]] = [:]
+
+        /// Stores a completion for the call identified by `cid`.
+        func append(
+            _ completion: @escaping () -> Void,
+            for cid: String
+        ) {
+            queue.sync {
+                storage[cid, default: []].append(.init(completion))
+            }
+        }
+
+        /// Returns and removes the oldest completion stored for `cid`.
+        func pop(for cid: String) -> Completion? {
+            queue.sync {
+                guard var completions = storage[cid],
+                      !completions.isEmpty else {
+                    return nil
+                }
+                let completion = completions.removeFirst()
+                storage[cid] = completions.isEmpty ? nil : completions
+                return completion
+            }
+        }
+    }
+
     @Injected(\.callCache) private var callCache
     @Injected(\.uuidFactory) private var uuidFactory
     @Injected(\.currentDevice) private var currentDevice
@@ -123,8 +169,9 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// runs in the background. See `CallKitMissingPermissionPolicy`.
     open var missingPermissionPolicy: CallKitMissingPermissionPolicy = .none
 
-    @Atomic private var pushNotificationCompletionHandlers:
-        [String: [() -> Void]] = [:]
+    /// Pending PushKit completions keyed by call CID.
+    let pushNotificationCompletionStorage =
+        PushNotificationCompletionStorage()
 
     /// The policy that decides whether CallKit-managed calls
     /// should leave automatically when participant state changes.
@@ -227,9 +274,8 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         hasVideo: Bool = false,
         completion: @Sendable @escaping (Error?) -> Void
     ) {
-        let pushNotificationCompletionHandler = Atomic<(() -> Void)?>(
-            wrappedValue: takePushNotificationCompletion(for: cid)
-        )
+        let pushNotificationCompletion =
+            pushNotificationCompletionStorage.pop(for: cid)
         let (callUUID, callUpdate) = buildCallUpdate(
             cid: cid,
             localizedCallerName: localizedCallerName,
@@ -242,13 +288,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
             update: callUpdate,
             completion: { error in
                 completion(error)
-
-                var completion: (() -> Void)?
-                pushNotificationCompletionHandler.mutate {
-                    completion = $0
-                    return nil
-                }
-                completion?()
+                pushNotificationCompletion?()
             }
         )
 
@@ -348,42 +388,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 )
             }
         }
-    }
-
-    /// Stores a PushKit completion until CallKit reports its incoming call.
-    ///
-    /// Completions are associated with the call CID so overlapping pushes can
-    /// finish in any order without invoking another push's callback.
-    ///
-    /// - Parameters:
-    ///   - completion: The PushKit delegate completion to invoke.
-    ///   - cid: The call CID from the VoIP push payload.
-    func enqueuePushNotificationCompletion(
-        _ completion: @escaping () -> Void,
-        for cid: String
-    ) {
-        _pushNotificationCompletionHandlers.mutate {
-            var handlers = $0
-            handlers[cid, default: []].append(completion)
-            return handlers
-        }
-    }
-
-    private func takePushNotificationCompletion(
-        for cid: String
-    ) -> (() -> Void)? {
-        var completion: (() -> Void)?
-        _pushNotificationCompletionHandlers.mutate {
-            var handlers = $0
-            guard var matchingHandlers = handlers[cid],
-                  !matchingHandlers.isEmpty else {
-                return handlers
-            }
-            completion = matchingHandlers.removeFirst()
-            handlers[cid] = matchingHandlers.isEmpty ? nil : matchingHandlers
-            return handlers
-        }
-        return completion
     }
 
     /// Handle acceptance by the same user on another device.

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -123,16 +123,8 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// runs in the background. See `CallKitMissingPermissionPolicy`.
     open var missingPermissionPolicy: CallKitMissingPermissionPolicy = .none
 
-    /// The completion for the VoIP push currently being reported to CallKit.
-    ///
-    /// ``CallKitPushNotificationAdapter`` sets this before reporting an
-    /// incoming call. PushKit requires the call to be reported to CallKit
-    /// before its completion runs, so ``CallKitService`` keeps the completion
-    /// pending until `CXProvider` finishes `reportNewIncomingCall`.
-    ///
-    /// The completion is atomically consumed and cleared before invocation to
-    /// prevent a later incoming call from invoking a stale PushKit callback.
-    @Atomic var pushNotificationCompletionHandler: (() -> Void)?
+    @Atomic private var pushNotificationCompletionHandlers:
+        [String: [() -> Void]] = [:]
 
     /// The policy that decides whether CallKit-managed calls
     /// should leave automatically when participant state changes.
@@ -235,6 +227,9 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         hasVideo: Bool = false,
         completion: @Sendable @escaping (Error?) -> Void
     ) {
+        let pushNotificationCompletionHandler = Atomic<(() -> Void)?>(
+            wrappedValue: takePushNotificationCompletion(for: cid)
+        )
         let (callUUID, callUpdate) = buildCallUpdate(
             cid: cid,
             localizedCallerName: localizedCallerName,
@@ -245,17 +240,15 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         callProvider.reportNewIncomingCall(
             with: callUUID,
             update: callUpdate,
-            completion: { [self] error in
+            completion: { error in
                 completion(error)
 
-                var pushNotificationCompletionHandler: (() -> Void)?
-                // Take and clear the handler in one operation so it is called
-                // at most once even if provider completion is repeated.
-                _pushNotificationCompletionHandler.mutate {
-                    pushNotificationCompletionHandler = $0
+                var completion: (() -> Void)?
+                pushNotificationCompletionHandler.mutate {
+                    completion = $0
                     return nil
                 }
-                pushNotificationCompletionHandler?()
+                completion?()
             }
         )
 
@@ -355,6 +348,42 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
                 )
             }
         }
+    }
+
+    /// Stores a PushKit completion until CallKit reports its incoming call.
+    ///
+    /// Completions are associated with the call CID so overlapping pushes can
+    /// finish in any order without invoking another push's callback.
+    ///
+    /// - Parameters:
+    ///   - completion: The PushKit delegate completion to invoke.
+    ///   - cid: The call CID from the VoIP push payload.
+    func enqueuePushNotificationCompletion(
+        _ completion: @escaping () -> Void,
+        for cid: String
+    ) {
+        _pushNotificationCompletionHandlers.mutate {
+            var handlers = $0
+            handlers[cid, default: []].append(completion)
+            return handlers
+        }
+    }
+
+    private func takePushNotificationCompletion(
+        for cid: String
+    ) -> (() -> Void)? {
+        var completion: (() -> Void)?
+        _pushNotificationCompletionHandlers.mutate {
+            var handlers = $0
+            guard var matchingHandlers = handlers[cid],
+                  !matchingHandlers.isEmpty else {
+                return handlers
+            }
+            completion = matchingHandlers.removeFirst()
+            handlers[cid] = matchingHandlers.isEmpty ? nil : matchingHandlers
+            return handlers
+        }
+        return completion
     }
 
     /// Handle acceptance by the same user on another device.

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -156,20 +156,30 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         pushPayload.stubDictionaryPayload = payload
 
         let completionWasCalledExpectation = expectation(description: "Completion was called.")
+        let completionCallCount = Atomic(wrappedValue: 0)
         subject.pushRegistry(
             subject.registry,
             didReceiveIncomingPushWith: pushPayload,
             for: pushPayload.type,
-            completion: { completionWasCalledExpectation.fulfill() }
+            completion: {
+                completionCallCount.mutate { $0 + 1 }
+                completionWasCalledExpectation.fulfill()
+            }
         )
 
-        await fulfillment(of: [completionWasCalledExpectation])
-
         guard contentType == .voIP else {
+            await fulfillment(of: [completionWasCalledExpectation])
+            XCTAssertEqual(completionCallCount.wrappedValue, 1, file: file, line: line)
             return
         }
 
         await fulfillment { self.callKitService.reportIncomingCallWasCalled != nil }
+        XCTAssertEqual(completionCallCount.wrappedValue, 0, file: file, line: line)
+
+        let pushNotificationCompletionHandler = callKitService.pushNotificationCompletionHandler
+        callKitService.pushNotificationCompletionHandler = nil
+        pushNotificationCompletionHandler?()
+        await fulfillment(of: [completionWasCalledExpectation])
 
         if let content {
             XCTAssertEqual(

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -161,25 +161,25 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         pushPayload.stubDictionaryPayload = payload
 
         let completionWasCalledExpectation = expectation(description: "Completion was called.")
-        let completionCallCount = Atomic(wrappedValue: 0)
+        var completionCallCount = 0
         subject.pushRegistry(
             subject.registry,
             didReceiveIncomingPushWith: pushPayload,
             for: pushPayload.type,
             completion: {
-                completionCallCount.mutate { $0 + 1 }
+                completionCallCount += 1
                 completionWasCalledExpectation.fulfill()
             }
         )
 
         guard contentType == .voIP else {
             await fulfillment(of: [completionWasCalledExpectation])
-            XCTAssertEqual(completionCallCount.wrappedValue, 1, file: file, line: line)
+            XCTAssertEqual(completionCallCount, 1, file: file, line: line)
             return
         }
 
         await fulfillment { self.callKitService.reportIncomingCallWasCalled != nil }
-        XCTAssertEqual(completionCallCount.wrappedValue, 0, file: file, line: line)
+        XCTAssertEqual(completionCallCount, 0, file: file, line: line)
 
         guard case let .reportNewIncomingCall(_, _, completion) = callProvider.invocations.first else {
             return XCTFail(file: file, line: line)

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -10,6 +10,7 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
 
     private lazy var streamVideo: MockStreamVideo! = .init()
     private lazy var callKitService: MockCallKitService! = .init()
+    private lazy var callProvider: MockCXProvider! = .init()
     private lazy var subject: CallKitPushNotificationAdapter! = .init()
 
     // MARK: - Lifecycle
@@ -18,11 +19,15 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         super.setUp()
         _ = streamVideo
         InjectedValues[\.callKitService] = callKitService
+        callProvider.automaticallyCompletesReportNewIncomingCall = false
+        callKitService.callProvider = callProvider
+        callKitService.forwardsReportIncomingCallToSuper = true
     }
 
     override func tearDown() {
         streamVideo = nil
         callKitService = nil
+        callProvider = nil
         subject = nil
         super.tearDown()
     }
@@ -176,9 +181,10 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         await fulfillment { self.callKitService.reportIncomingCallWasCalled != nil }
         XCTAssertEqual(completionCallCount.wrappedValue, 0, file: file, line: line)
 
-        let pushNotificationCompletionHandler = callKitService.pushNotificationCompletionHandler
-        callKitService.pushNotificationCompletionHandler = nil
-        pushNotificationCompletionHandler?()
+        guard case let .reportNewIncomingCall(_, _, completion) = callProvider.invocations.first else {
+            return XCTFail(file: file, line: line)
+        }
+        completion(nil)
         await fulfillment(of: [completionWasCalledExpectation])
 
         if let content {
@@ -206,7 +212,6 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
                 file: file,
                 line: line
             )
-            callKitService.reportIncomingCallWasCalled?.completion(nil)
         } else {
             XCTAssertNil(
                 callKitService.reportIncomingCallWasCalled,

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -210,12 +210,17 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(update.remoteHandle?.value, callerId)
     }
 
-    func test_reportIncomingCall_callProviderCompletes_pushNotificationCompletionHandlerWasCalledAndCleared() throws {
-        let completionCallCount = Atomic(wrappedValue: 0)
+    func test_reportIncomingCall_pendingPushesCompleteWithOwnReports() throws {
+        let firstCallCount = Atomic(wrappedValue: 0)
+        let secondCallCount = Atomic(wrappedValue: 0)
+        let secondCid = "default:\(String.unique)"
         callProvider.automaticallyCompletesReportNewIncomingCall = false
-        subject.pushNotificationCompletionHandler = {
-            completionCallCount.mutate { $0 + 1 }
-        }
+        subject.enqueuePushNotificationCompletion({
+            firstCallCount.mutate { $0 + 1 }
+        }, for: cid)
+        subject.enqueuePushNotificationCompletion({
+            secondCallCount.mutate { $0 + 1 }
+        }, for: secondCid)
 
         subject.reportIncomingCall(
             cid,
@@ -223,17 +228,39 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
             callerId: callerId,
             hasVideo: false
         ) { _ in }
+        subject.reportIncomingCall(
+            secondCid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
 
-        XCTAssertEqual(completionCallCount.wrappedValue, 0)
-        XCTAssertNotNil(subject.pushNotificationCompletionHandler)
+        let reportCompletions: [(Error?) -> Void] = callProvider
+            .invocations
+            .compactMap {
+                guard case let .reportNewIncomingCall(_, _, completion) = $0 else {
+                    return nil
+                }
+                return completion
+            }
 
-        guard case let .reportNewIncomingCall(_, _, completion) = callProvider.invocations.first else {
-            return XCTFail()
-        }
-        completion(nil)
+        let firstReportCompletion = try XCTUnwrap(reportCompletions.first)
+        let secondReportCompletion = try XCTUnwrap(reportCompletions.last)
+        XCTAssertEqual(reportCompletions.count, 2)
+        XCTAssertEqual(firstCallCount.wrappedValue, 0)
+        XCTAssertEqual(secondCallCount.wrappedValue, 0)
 
-        XCTAssertEqual(completionCallCount.wrappedValue, 1)
-        XCTAssertNil(subject.pushNotificationCompletionHandler)
+        secondReportCompletion(nil)
+        XCTAssertEqual(firstCallCount.wrappedValue, 0)
+        XCTAssertEqual(secondCallCount.wrappedValue, 1)
+
+        firstReportCompletion(nil)
+        XCTAssertEqual(firstCallCount.wrappedValue, 1)
+        XCTAssertEqual(secondCallCount.wrappedValue, 1)
+
+        reportCompletions.forEach { $0(nil) }
+        XCTAssertEqual(firstCallCount.wrappedValue, 1)
+        XCTAssertEqual(secondCallCount.wrappedValue, 1)
     }
 
     func test_reportIncomingCall_streamVideoIsNil_noCallWasCreatedAndNoActionIsBeingPerformed() async throws {

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -210,6 +210,32 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(update.remoteHandle?.value, callerId)
     }
 
+    func test_reportIncomingCall_callProviderCompletes_pushNotificationCompletionHandlerWasCalledAndCleared() throws {
+        let completionCallCount = Atomic(wrappedValue: 0)
+        callProvider.automaticallyCompletesReportNewIncomingCall = false
+        subject.pushNotificationCompletionHandler = {
+            completionCallCount.mutate { $0 + 1 }
+        }
+
+        subject.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: false
+        ) { _ in }
+
+        XCTAssertEqual(completionCallCount.wrappedValue, 0)
+        XCTAssertNotNil(subject.pushNotificationCompletionHandler)
+
+        guard case let .reportNewIncomingCall(_, _, completion) = callProvider.invocations.first else {
+            return XCTFail()
+        }
+        completion(nil)
+
+        XCTAssertEqual(completionCallCount.wrappedValue, 1)
+        XCTAssertNil(subject.pushNotificationCompletionHandler)
+    }
+
     func test_reportIncomingCall_streamVideoIsNil_noCallWasCreatedAndNoActionIsBeingPerformed() async throws {
         try await assertWithoutRequestTransaction {
             subject.reportIncomingCall(

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -211,15 +211,15 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
     }
 
     func test_reportIncomingCall_pendingPushesCompleteWithOwnReports() throws {
-        let firstCallCount = Atomic(wrappedValue: 0)
-        let secondCallCount = Atomic(wrappedValue: 0)
+        var firstCallCount = 0
+        var secondCallCount = 0
         let secondCid = "default:\(String.unique)"
         callProvider.automaticallyCompletesReportNewIncomingCall = false
-        subject.enqueuePushNotificationCompletion({
-            firstCallCount.mutate { $0 + 1 }
+        subject.pushNotificationCompletionStorage.append({
+            firstCallCount += 1
         }, for: cid)
-        subject.enqueuePushNotificationCompletion({
-            secondCallCount.mutate { $0 + 1 }
+        subject.pushNotificationCompletionStorage.append({
+            secondCallCount += 1
         }, for: secondCid)
 
         subject.reportIncomingCall(
@@ -247,20 +247,16 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         let firstReportCompletion = try XCTUnwrap(reportCompletions.first)
         let secondReportCompletion = try XCTUnwrap(reportCompletions.last)
         XCTAssertEqual(reportCompletions.count, 2)
-        XCTAssertEqual(firstCallCount.wrappedValue, 0)
-        XCTAssertEqual(secondCallCount.wrappedValue, 0)
+        XCTAssertEqual(firstCallCount, 0)
+        XCTAssertEqual(secondCallCount, 0)
 
         secondReportCompletion(nil)
-        XCTAssertEqual(firstCallCount.wrappedValue, 0)
-        XCTAssertEqual(secondCallCount.wrappedValue, 1)
+        XCTAssertEqual(firstCallCount, 0)
+        XCTAssertEqual(secondCallCount, 1)
 
         firstReportCompletion(nil)
-        XCTAssertEqual(firstCallCount.wrappedValue, 1)
-        XCTAssertEqual(secondCallCount.wrappedValue, 1)
-
-        reportCompletions.forEach { $0(nil) }
-        XCTAssertEqual(firstCallCount.wrappedValue, 1)
-        XCTAssertEqual(secondCallCount.wrappedValue, 1)
+        XCTAssertEqual(firstCallCount, 1)
+        XCTAssertEqual(secondCallCount, 1)
     }
 
     func test_reportIncomingCall_streamVideoIsNil_noCallWasCreatedAndNoActionIsBeingPerformed() async throws {

--- a/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
@@ -12,6 +12,7 @@ final class MockCXProvider: CXProvider {
     }
 
     private(set) var invocations: [Invocation] = []
+    var automaticallyCompletesReportNewIncomingCall = true
 
     convenience init() {
         self.init(configuration: .init(localizedName: "test"))
@@ -29,7 +30,9 @@ final class MockCXProvider: CXProvider {
                 completion: completion
             )
         )
-        completion(nil)
+        if automaticallyCompletesReportNewIncomingCall {
+            completion(nil)
+        }
     }
 
     override func reportCall(
@@ -48,5 +51,6 @@ final class MockCXProvider: CXProvider {
 
     func reset() {
         invocations = []
+        automaticallyCompletesReportNewIncomingCall = true
     }
 }

--- a/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
@@ -7,6 +7,8 @@ import Foundation
 @testable import StreamVideo
 
 final class MockCallKitService: CallKitService, @unchecked Sendable {
+    var forwardsReportIncomingCallToSuper = false
+
     private(set) var reportIncomingCallWasCalled: (
         cid: String,
         callerName: String,
@@ -22,9 +24,17 @@ final class MockCallKitService: CallKitService, @unchecked Sendable {
         localizedCallerName: String,
         callerId: String,
         hasVideo: Bool?,
-        completion: @escaping ((any Error)?) -> Void
+        completion: @Sendable @escaping ((any Error)?) -> Void
     ) {
         reportIncomingCallWasCalled = (cid, localizedCallerName, callerId, hasVideo, completion)
+        guard forwardsReportIncomingCallToSuper else { return }
+        super.reportIncomingCall(
+            cid,
+            localizedCallerName: localizedCallerName,
+            callerId: callerId,
+            hasVideo: hasVideo ?? false,
+            completion: completion
+        )
     }
 
     func send(_ event: Event) {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1943

### 🎯 Goal

Prevent iOS from terminating the app with `PKPushRegistry._terminateAppIfThereAreUnhandledVoIPPushes` while reporting an incoming VoIP call.

### 📝 Summary

- Keep the PushKit completion pending until CallKit finishes reporting the incoming call.
- Preserve the existing `CallKitService.reportIncomingCall` API.
- Atomically consume and clear the stored PushKit completion.
- Add regression coverage and DocC for the callback lifecycle.

### 🛠 Implementation

The PushKit adapter previously completed its delegate callback with `defer`, immediately after scheduling `CXProvider.reportNewIncomingCall`. That allowed the PushKit callback to finish before CallKit confirmed the incoming call report.

The adapter now stores the optional completion on `CallKitService` before calling the existing `reportIncomingCall` API. The service invokes the regular report completion first, then atomically takes, clears, and invokes the PushKit completion from `CXProvider.reportNewIncomingCall`'s completion callback. Non-VoIP pushes continue to complete immediately.

This avoids changing the public `reportIncomingCall` signature and prevents stale callbacks from being invoked more than once.

### 🎨 Showcase

Not applicable — no UI changes.

### 🧪 Manual Testing Notes

Suggested device scenario:

1. Install the Demo App on a physical device with PushKit and CallKit configured.
2. Background or terminate the app.
3. Send an incoming VoIP call.
4. Verify the CallKit incoming-call UI appears.
5. Verify the process remains alive without the unhandled-VoIP-push assertion.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (tutorial, CMS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when completing VoIP push notifications before CallKit finished reporting an incoming call.
  * Improved notification completion handling so callbacks occur at the correct time and only once.
  * Non-VoIP push notifications now complete immediately and reliably.

* **Tests**
  * Added coverage for notification completion timing, multiple incoming calls, and duplicate-callback prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->