### PR TITLE
[Fix] Simplify PushKit completion handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Prevent CallKit-driven joins from disconnecting and rejoining while waiting for audio-session activation. [#1218](https://github.com/GetStream/stream-video-swift/pull/1218)
+- Fixed a crash caused by completing a PushKit VoIP notification before CallKit finished reporting its incoming call. [#1221](https://github.com/GetStream/stream-video-swift/pull/1221)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Prevent CallKit-driven joins from disconnecting and rejoining while waiting for audio-session activation. [#1218](https://github.com/GetStream/stream-video-swift/pull/1218)
-- Fixed a crash caused by completing a PushKit VoIP notification before CallKit finished reporting its incoming call. [#1219](https://github.com/GetStream/stream-video-swift/pull/1219)
 
 ### 🔄 Changed
 

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -99,28 +99,17 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         }
     }
 
-    /// Handles a push notification delivered by PushKit.
-    ///
-    /// VoIP pushes keep their completion pending until ``CallKitService`` has
-    /// finished reporting the matching incoming call to CallKit. Completing
-    /// earlier can cause the system to treat the push as unhandled and
-    /// terminate the app.
+    /// Delegate method called when the device receives a VoIP push notification.
     open nonisolated func pushRegistry(
         _ registry: PKPushRegistry,
         didReceiveIncomingPushWith payload: PKPushPayload,
         for type: PKPushType,
         completion: @escaping () -> Void
     ) {
-        guard type == .voIP else {
-            completion()
-            return
-        }
-
+        defer { completion() }
+        guard type == .voIP else { return }
+        
         let content = decodePayload(payload)
-        callKitService.pushNotificationCompletionStorage.append(
-            completion,
-            for: content.cid
-        )
 
         log
             .debug(

--- a/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
+++ b/Sources/StreamVideo/CallKit/CallKitPushNotificationAdapter.swift
@@ -99,22 +99,29 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
         }
     }
 
-    /// Delegate method called when the device receives a VoIP push notification.
+    /// Handles a push notification delivered by PushKit.
+    ///
+    /// VoIP pushes complete after CallKit finishes reporting the incoming
+    /// call.
     open nonisolated func pushRegistry(
         _ registry: PKPushRegistry,
         didReceiveIncomingPushWith payload: PKPushPayload,
         for type: PKPushType,
         completion: @escaping () -> Void
     ) {
-        defer { completion() }
-        guard type == .voIP else { return }
-        
+        guard type == .voIP else {
+            completion()
+            return
+        }
+
         let content = decodePayload(payload)
 
         log
             .debug(
                 "Received VoIP push notification with cid:\(content.cid) callerId:\(content.callerId) callerName:\(content.localizedCallerName)."
             )
+
+        let sendableCompletion = UncheckedSendableBox(completion)
 
         callKitService.reportIncomingCall(
             content.cid,
@@ -125,6 +132,7 @@ open class CallKitPushNotificationAdapter: NSObject, PKPushRegistryDelegate, Obs
                 if let error {
                     log.error(error, subsystems: .callKit)
                 }
+                sendableCompletion.value()
             }
         )
     }

--- a/Sources/StreamVideo/CallKit/CallKitService.swift
+++ b/Sources/StreamVideo/CallKit/CallKitService.swift
@@ -17,52 +17,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         var isMuted: Bool
     }
 
-    /// Stores PushKit completions until their incoming calls are reported.
-    ///
-    /// PushKit delivery and CallKit reporting may use different queues. Access
-    /// is synchronized, and multiple pushes for the same CID are returned in
-    /// the order they were received.
-    final class PushNotificationCompletionStorage: @unchecked Sendable {
-        /// A PushKit completion that can be passed to CallKit's callback.
-        final class Completion: @unchecked Sendable {
-            private let action: () -> Void
-
-            init(_ action: @escaping () -> Void) {
-                self.action = action
-            }
-
-            func callAsFunction() {
-                action()
-            }
-        }
-
-        private let queue = UnfairQueue()
-        private var storage: [String: [Completion]] = [:]
-
-        /// Stores a completion for the call identified by `cid`.
-        func append(
-            _ completion: @escaping () -> Void,
-            for cid: String
-        ) {
-            queue.sync {
-                storage[cid, default: []].append(.init(completion))
-            }
-        }
-
-        /// Returns and removes the oldest completion stored for `cid`.
-        func pop(for cid: String) -> Completion? {
-            queue.sync {
-                guard var completions = storage[cid],
-                      !completions.isEmpty else {
-                    return nil
-                }
-                let completion = completions.removeFirst()
-                storage[cid] = completions.isEmpty ? nil : completions
-                return completion
-            }
-        }
-    }
-
     @Injected(\.callCache) private var callCache
     @Injected(\.uuidFactory) private var uuidFactory
     @Injected(\.currentDevice) private var currentDevice
@@ -169,10 +123,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
     /// runs in the background. See `CallKitMissingPermissionPolicy`.
     open var missingPermissionPolicy: CallKitMissingPermissionPolicy = .none
 
-    /// Pending PushKit completions keyed by call CID.
-    let pushNotificationCompletionStorage =
-        PushNotificationCompletionStorage()
-
     /// The policy that decides whether CallKit-managed calls
     /// should leave automatically when participant state changes.
     ///
@@ -261,12 +211,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         }
     }
 
-    /// Reports an incoming call to CallKit.
-    ///
-    /// When the report originated from ``CallKitPushNotificationAdapter``, the
-    /// provider completion also completes the pending PushKit notification.
-    /// This ordering ensures the system observes the incoming call report
-    /// before the PushKit delegate finishes handling the VoIP push.
+    /// Report an incoming call to CallKit.
     open func reportIncomingCall(
         _ cid: String,
         localizedCallerName: String,
@@ -274,8 +219,6 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         hasVideo: Bool = false,
         completion: @Sendable @escaping (Error?) -> Void
     ) {
-        let pushNotificationCompletion =
-            pushNotificationCompletionStorage.pop(for: cid)
         let (callUUID, callUpdate) = buildCallUpdate(
             cid: cid,
             localizedCallerName: localizedCallerName,
@@ -286,10 +229,7 @@ open class CallKitService: NSObject, CXProviderDelegate, @unchecked Sendable {
         callProvider.reportNewIncomingCall(
             with: callUUID,
             update: callUpdate,
-            completion: { error in
-                completion(error)
-                pushNotificationCompletion?()
-            }
+            completion: completion
         )
 
         log.debug(

--- a/Sources/StreamVideo/Utils/UncheckedSendableBox.swift
+++ b/Sources/StreamVideo/Utils/UncheckedSendableBox.swift
@@ -1,0 +1,13 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+final class UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -156,20 +156,25 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         pushPayload.stubDictionaryPayload = payload
 
         let completionWasCalledExpectation = expectation(description: "Completion was called.")
+        var completionCallCount = 0
         subject.pushRegistry(
             subject.registry,
             didReceiveIncomingPushWith: pushPayload,
             for: pushPayload.type,
-            completion: { completionWasCalledExpectation.fulfill() }
+            completion: {
+                completionCallCount += 1
+                completionWasCalledExpectation.fulfill()
+            }
         )
 
-        await fulfillment(of: [completionWasCalledExpectation])
-
         guard contentType == .voIP else {
+            await fulfillment(of: [completionWasCalledExpectation])
+            XCTAssertEqual(completionCallCount, 1, file: file, line: line)
             return
         }
 
         await fulfillment { self.callKitService.reportIncomingCallWasCalled != nil }
+        XCTAssertEqual(completionCallCount, 0, file: file, line: line)
 
         if let content {
             XCTAssertEqual(
@@ -196,7 +201,6 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
                 file: file,
                 line: line
             )
-            callKitService.reportIncomingCallWasCalled?.completion(nil)
         } else {
             XCTAssertNil(
                 callKitService.reportIncomingCallWasCalled,
@@ -204,6 +208,10 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
                 line: line
             )
         }
+
+        callKitService.reportIncomingCallWasCalled?.completion(nil)
+        await fulfillment(of: [completionWasCalledExpectation])
+        XCTAssertEqual(completionCallCount, 1, file: file, line: line)
     }
 }
 

--- a/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
+++ b/StreamVideoTests/CallKit/CallKitPushNotificationAdapterTests.swift
@@ -10,7 +10,6 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
 
     private lazy var streamVideo: MockStreamVideo! = .init()
     private lazy var callKitService: MockCallKitService! = .init()
-    private lazy var callProvider: MockCXProvider! = .init()
     private lazy var subject: CallKitPushNotificationAdapter! = .init()
 
     // MARK: - Lifecycle
@@ -19,15 +18,11 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         super.setUp()
         _ = streamVideo
         InjectedValues[\.callKitService] = callKitService
-        callProvider.automaticallyCompletesReportNewIncomingCall = false
-        callKitService.callProvider = callProvider
-        callKitService.forwardsReportIncomingCallToSuper = true
     }
 
     override func tearDown() {
         streamVideo = nil
         callKitService = nil
-        callProvider = nil
         subject = nil
         super.tearDown()
     }
@@ -161,31 +156,20 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
         pushPayload.stubDictionaryPayload = payload
 
         let completionWasCalledExpectation = expectation(description: "Completion was called.")
-        var completionCallCount = 0
         subject.pushRegistry(
             subject.registry,
             didReceiveIncomingPushWith: pushPayload,
             for: pushPayload.type,
-            completion: {
-                completionCallCount += 1
-                completionWasCalledExpectation.fulfill()
-            }
+            completion: { completionWasCalledExpectation.fulfill() }
         )
 
+        await fulfillment(of: [completionWasCalledExpectation])
+
         guard contentType == .voIP else {
-            await fulfillment(of: [completionWasCalledExpectation])
-            XCTAssertEqual(completionCallCount, 1, file: file, line: line)
             return
         }
 
         await fulfillment { self.callKitService.reportIncomingCallWasCalled != nil }
-        XCTAssertEqual(completionCallCount, 0, file: file, line: line)
-
-        guard case let .reportNewIncomingCall(_, _, completion) = callProvider.invocations.first else {
-            return XCTFail(file: file, line: line)
-        }
-        completion(nil)
-        await fulfillment(of: [completionWasCalledExpectation])
 
         if let content {
             XCTAssertEqual(
@@ -212,6 +196,7 @@ final class CallKitPushNotificationAdapterTests: XCTestCase, @unchecked Sendable
                 file: file,
                 line: line
             )
+            callKitService.reportIncomingCallWasCalled?.completion(nil)
         } else {
             XCTAssertNil(
                 callKitService.reportIncomingCallWasCalled,

--- a/StreamVideoTests/CallKit/CallKitServiceTests.swift
+++ b/StreamVideoTests/CallKit/CallKitServiceTests.swift
@@ -210,55 +210,6 @@ final class CallKitServiceTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(update.remoteHandle?.value, callerId)
     }
 
-    func test_reportIncomingCall_pendingPushesCompleteWithOwnReports() throws {
-        var firstCallCount = 0
-        var secondCallCount = 0
-        let secondCid = "default:\(String.unique)"
-        callProvider.automaticallyCompletesReportNewIncomingCall = false
-        subject.pushNotificationCompletionStorage.append({
-            firstCallCount += 1
-        }, for: cid)
-        subject.pushNotificationCompletionStorage.append({
-            secondCallCount += 1
-        }, for: secondCid)
-
-        subject.reportIncomingCall(
-            cid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: false
-        ) { _ in }
-        subject.reportIncomingCall(
-            secondCid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: false
-        ) { _ in }
-
-        let reportCompletions: [(Error?) -> Void] = callProvider
-            .invocations
-            .compactMap {
-                guard case let .reportNewIncomingCall(_, _, completion) = $0 else {
-                    return nil
-                }
-                return completion
-            }
-
-        let firstReportCompletion = try XCTUnwrap(reportCompletions.first)
-        let secondReportCompletion = try XCTUnwrap(reportCompletions.last)
-        XCTAssertEqual(reportCompletions.count, 2)
-        XCTAssertEqual(firstCallCount, 0)
-        XCTAssertEqual(secondCallCount, 0)
-
-        secondReportCompletion(nil)
-        XCTAssertEqual(firstCallCount, 0)
-        XCTAssertEqual(secondCallCount, 1)
-
-        firstReportCompletion(nil)
-        XCTAssertEqual(firstCallCount, 1)
-        XCTAssertEqual(secondCallCount, 1)
-    }
-
     func test_reportIncomingCall_streamVideoIsNil_noCallWasCreatedAndNoActionIsBeingPerformed() async throws {
         try await assertWithoutRequestTransaction {
             subject.reportIncomingCall(

--- a/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCXProvider.swift
@@ -12,7 +12,6 @@ final class MockCXProvider: CXProvider {
     }
 
     private(set) var invocations: [Invocation] = []
-    var automaticallyCompletesReportNewIncomingCall = true
 
     convenience init() {
         self.init(configuration: .init(localizedName: "test"))
@@ -30,9 +29,7 @@ final class MockCXProvider: CXProvider {
                 completion: completion
             )
         )
-        if automaticallyCompletesReportNewIncomingCall {
-            completion(nil)
-        }
+        completion(nil)
     }
 
     override func reportCall(
@@ -51,6 +48,5 @@ final class MockCXProvider: CXProvider {
 
     func reset() {
         invocations = []
-        automaticallyCompletesReportNewIncomingCall = true
     }
 }

--- a/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
+++ b/StreamVideoTests/Utilities/Mocks/MockCallKitService.swift
@@ -7,8 +7,6 @@ import Foundation
 @testable import StreamVideo
 
 final class MockCallKitService: CallKitService, @unchecked Sendable {
-    var forwardsReportIncomingCallToSuper = false
-
     private(set) var reportIncomingCallWasCalled: (
         cid: String,
         callerName: String,
@@ -24,17 +22,9 @@ final class MockCallKitService: CallKitService, @unchecked Sendable {
         localizedCallerName: String,
         callerId: String,
         hasVideo: Bool?,
-        completion: @Sendable @escaping ((any Error)?) -> Void
+        completion: @escaping ((any Error)?) -> Void
     ) {
         reportIncomingCallWasCalled = (cid, localizedCallerName, callerId, hasVideo, completion)
-        guard forwardsReportIncomingCallToSuper else { return }
-        super.reportIncomingCall(
-            cid,
-            localizedCallerName: localizedCallerName,
-            callerId: callerId,
-            hasVideo: hasVideo ?? false,
-            completion: completion
-        )
     }
 
     func send(_ event: Event) {


### PR DESCRIPTION
 ### 🔗 Issue Links

  - [IOS-1943](https://linear.app/stream/issue/IOS-1943)
  - Follow-up to [#1219](https://github.com/GetStream/stream-video-swift/pull/1219)

  ### 🎯 Goal

  Preserve the PushKit crash fix from #1219 while simplifying completion handling and associating each callback directly with its CallKit report.

  ### 📝 Summary

  - Complete VoIP PushKit callbacks from the matching incoming-call report callback.
  - Remove CID-keyed completion storage and synchronization from `CallKitService`.
  - Keep the reusable `UncheckedSendableBox` internal to `StreamVideo`.
  - Cover deferred VoIP and immediate non-VoIP completion behavior.
  - Update the changelog for #1221.

  ### 🛠 Implementation

  `CallKitPushNotificationAdapter` wraps PushKit’s unannotated completion in an internal `UncheckedSendableBox` and invokes it from the existing `CallKitService.reportIncomingCall` completion.

  Because that completion is passed directly to `CXProvider.reportNewIncomingCall`, each PushKit callback remains tied to its exact CallKit report without additional storage, CID matching, or locking.

  There are no public API changes.

  ### 🎨 Showcase

  Not applicable — no UI changes.

  ### 🧪 Manual Testing Notes

  Physical-device QA was not run locally.

  1. Install the Demo App on a physical device with PushKit and CallKit configured.
  2. Background or terminate the app.
  3. Send an incoming VoIP call.
  4. Verify the CallKit incoming-call UI appears.
  5. Verify the process remains alive without the unhandled-VoIP-push assertion.

  ### ☑️ Contributor Checklist

  - [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
  - [x] This change follows zero ⚠️ policy (required)
  - [x] This change should receive manual QA
  - [x] Changelog is updated with client-facing changes
  - [x] New code is covered by unit tests
  - [ ] Comparison screenshots added for visual changes — not applicable
  - [x] Affected documentation updated (tutorial, CMS) — DocC updated; tutorial/CMS changes are not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of incoming VoIP call notifications by ensuring completion callbacks run after CallKit finishes reporting the call.
  * Ensured callbacks are invoked even when CallKit reports an error.
  * Fixed potential PushKit/CallKit crash scenarios involving incoming calls.

* **Documentation**
  * Updated the upcoming changelog with the corrected pull request reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->