### PR TITLE
[Fix] Stabilize media-dependent audio room integration tests

### DIFF
--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Components/AVAudioSessionObserver.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Components/AVAudioSessionObserver.swift
@@ -56,7 +56,7 @@ extension AVAudioSession {
             self.routeSharingPolicy = source.routeSharingPolicy
             self.availableModes = source.availableModes
             self.preferredInput = source.preferredInput.map { .init($0) } ?? nil
-            #if compiler(>=6.0)
+            #if compiler(>=6.0) && !targetEnvironment(simulator)
             if #available(iOS 17.2, *) { self.renderingMode = "\(source.renderingMode)" }
             else { self.renderingMode = "" }
             #else

--- a/Sources/StreamVideo/WebRTC/PeerConnectionFactory.swift
+++ b/Sources/StreamVideo/WebRTC/PeerConnectionFactory.swift
@@ -12,14 +12,10 @@ final class PeerConnectionFactory: @unchecked Sendable {
     /// The audio processing module associated with this factory.
     private let audioProcessingModule: RTCAudioProcessingModule
 
-    /// An optional native audio device used instead of WebRTC's default audio
-    /// engine.
+    /// Overrides WebRTC audio-engine availability for controlled environments.
     ///
-    /// Custom environments can provide a device that avoids creating the
-    /// platform audio engine. When `nil`, the factory retains its standard
-    /// production audio pipeline and applies ``audioProcessingModule``.
-    private let audioDevice: RTCAudioDevice?
-
+    /// A `nil` value preserves the runtime decision made by the call flow.
+    let audioEngineAvailabilityOverride: Bool?
     /// Backing storage for the audio device module.
     ///
     /// Kept optional so we can release it explicitly in `deinit` before
@@ -34,20 +30,12 @@ final class PeerConnectionFactory: @unchecked Sendable {
         return audioDeviceModuleStorage
     }
     
-    /// The underlying WebRTC factory configured with either the injected audio
-    /// device or the default production audio engine.
+    /// Lazy-loaded RTCPeerConnectionFactory instance.
     private(set) lazy var factory: RTCPeerConnectionFactory = {
         let encoderFactory = RTCVideoEncoderFactorySimulcast(
             primary: Self.defaultEncoder,
             fallback: Self.defaultEncoder
         )
-        if let audioDevice {
-            return RTCPeerConnectionFactory(
-                encoderFactory: encoderFactory,
-                decoderFactory: Self.defaultDecoder,
-                audioDevice: audioDevice
-            )
-        }
         return RTCPeerConnectionFactory(
             audioDeviceModuleType: .audioEngine,
             bypassVoiceProcessing: false,
@@ -56,7 +44,7 @@ final class PeerConnectionFactory: @unchecked Sendable {
             audioProcessingModule: audioProcessingModule
         )
     }()
-    
+
     /// Lazy-loaded default video encoder factory.
     private nonisolated(unsafe) static let defaultEncoder = RTCDefaultVideoEncoderFactory()
 
@@ -73,47 +61,31 @@ final class PeerConnectionFactory: @unchecked Sendable {
         Self.defaultDecoder.supportedCodecs()
     }
 
-    /// Creates a peer-connection factory with the requested audio pipeline.
-    ///
-    /// - Parameters:
-    ///   - audioProcessingModule: The processing module used by the default
-    ///     WebRTC audio engine.
-    ///   - audioDeviceModuleSource: An optional controller backing the SDK's
-    ///     ``AudioDeviceModule`` wrapper. Provide it with `audioDevice` because
-    ///     WebRTC does not expose its audio-device module when initialized with
-    ///     a custom native device.
-    ///   - audioDevice: An optional native device that replaces WebRTC's
-    ///     default audio engine.
+    /// Creates or retrieves a PeerConnectionFactory instance for a given
+    /// audio processing module.
+    /// - Parameter audioProcessingModule: The RTCAudioProcessingModule to use.
     /// - Returns: A PeerConnectionFactory instance.
     static func build(
         audioProcessingModule: RTCAudioProcessingModule,
         audioDeviceModuleSource: RTCAudioDeviceModuleControlling? = nil,
-        audioDevice: RTCAudioDevice? = nil
+        audioEngineAvailabilityOverride: Bool? = nil
     ) -> PeerConnectionFactory {
-        .init(
+        return .init(
             audioProcessingModule,
             audioDeviceModuleSource: audioDeviceModuleSource,
-            audioDevice: audioDevice
+            audioEngineAvailabilityOverride: audioEngineAvailabilityOverride
         )
     }
     
-    /// Initializes a peer-connection factory with matching native and SDK audio
-    /// device implementations.
-    ///
-    /// - Parameters:
-    ///   - audioProcessingModule: The processing module used by the default
-    ///     WebRTC audio engine.
-    ///   - audioDeviceModuleSource: An optional controller used by the SDK's
-    ///     audio-device wrapper.
-    ///   - audioDevice: An optional native device used to construct WebRTC's
-    ///     peer-connection factory.
+    /// Private initializer to ensure instances are created through the `build` method.
+    /// - Parameter audioProcessingModule: The RTCAudioProcessingModule to use.
     private init(
         _ audioProcessingModule: RTCAudioProcessingModule,
         audioDeviceModuleSource: RTCAudioDeviceModuleControlling?,
-        audioDevice: RTCAudioDevice?
+        audioEngineAvailabilityOverride: Bool?
     ) {
         self.audioProcessingModule = audioProcessingModule
-        self.audioDevice = audioDevice
+        self.audioEngineAvailabilityOverride = audioEngineAvailabilityOverride
         _ = factory
 
         if let audioDeviceModuleSource {

--- a/Sources/StreamVideo/WebRTC/PeerConnectionFactory.swift
+++ b/Sources/StreamVideo/WebRTC/PeerConnectionFactory.swift
@@ -11,6 +11,15 @@ final class PeerConnectionFactory: @unchecked Sendable {
     
     /// The audio processing module associated with this factory.
     private let audioProcessingModule: RTCAudioProcessingModule
+
+    /// An optional native audio device used instead of WebRTC's default audio
+    /// engine.
+    ///
+    /// Custom environments can provide a device that avoids creating the
+    /// platform audio engine. When `nil`, the factory retains its standard
+    /// production audio pipeline and applies ``audioProcessingModule``.
+    private let audioDevice: RTCAudioDevice?
+
     /// Backing storage for the audio device module.
     ///
     /// Kept optional so we can release it explicitly in `deinit` before
@@ -25,12 +34,20 @@ final class PeerConnectionFactory: @unchecked Sendable {
         return audioDeviceModuleStorage
     }
     
-    /// Lazy-loaded RTCPeerConnectionFactory instance.
+    /// The underlying WebRTC factory configured with either the injected audio
+    /// device or the default production audio engine.
     private(set) lazy var factory: RTCPeerConnectionFactory = {
         let encoderFactory = RTCVideoEncoderFactorySimulcast(
             primary: Self.defaultEncoder,
             fallback: Self.defaultEncoder
         )
+        if let audioDevice {
+            return RTCPeerConnectionFactory(
+                encoderFactory: encoderFactory,
+                decoderFactory: Self.defaultDecoder,
+                audioDevice: audioDevice
+            )
+        }
         return RTCPeerConnectionFactory(
             audioDeviceModuleType: .audioEngine,
             bypassVoiceProcessing: false,
@@ -56,24 +73,47 @@ final class PeerConnectionFactory: @unchecked Sendable {
         Self.defaultDecoder.supportedCodecs()
     }
 
-    /// Creates or retrieves a PeerConnectionFactory instance for a given
-    /// audio processing module.
-    /// - Parameter audioProcessingModule: The RTCAudioProcessingModule to use.
+    /// Creates a peer-connection factory with the requested audio pipeline.
+    ///
+    /// - Parameters:
+    ///   - audioProcessingModule: The processing module used by the default
+    ///     WebRTC audio engine.
+    ///   - audioDeviceModuleSource: An optional controller backing the SDK's
+    ///     ``AudioDeviceModule`` wrapper. Provide it with `audioDevice` because
+    ///     WebRTC does not expose its audio-device module when initialized with
+    ///     a custom native device.
+    ///   - audioDevice: An optional native device that replaces WebRTC's
+    ///     default audio engine.
     /// - Returns: A PeerConnectionFactory instance.
     static func build(
         audioProcessingModule: RTCAudioProcessingModule,
-        audioDeviceModuleSource: RTCAudioDeviceModuleControlling? = nil
+        audioDeviceModuleSource: RTCAudioDeviceModuleControlling? = nil,
+        audioDevice: RTCAudioDevice? = nil
     ) -> PeerConnectionFactory {
-        return .init(audioProcessingModule, audioDeviceModuleSource: audioDeviceModuleSource)
+        .init(
+            audioProcessingModule,
+            audioDeviceModuleSource: audioDeviceModuleSource,
+            audioDevice: audioDevice
+        )
     }
     
-    /// Private initializer to ensure instances are created through the `build` method.
-    /// - Parameter audioProcessingModule: The RTCAudioProcessingModule to use.
+    /// Initializes a peer-connection factory with matching native and SDK audio
+    /// device implementations.
+    ///
+    /// - Parameters:
+    ///   - audioProcessingModule: The processing module used by the default
+    ///     WebRTC audio engine.
+    ///   - audioDeviceModuleSource: An optional controller used by the SDK's
+    ///     audio-device wrapper.
+    ///   - audioDevice: An optional native device used to construct WebRTC's
+    ///     peer-connection factory.
     private init(
         _ audioProcessingModule: RTCAudioProcessingModule,
-        audioDeviceModuleSource: RTCAudioDeviceModuleControlling?
+        audioDeviceModuleSource: RTCAudioDeviceModuleControlling?,
+        audioDevice: RTCAudioDevice?
     ) {
         self.audioProcessingModule = audioProcessingModule
+        self.audioDevice = audioDevice
         _ = factory
 
         if let audioDeviceModuleSource {

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinator.swift
@@ -64,6 +64,9 @@ final class WebRTCCoordinator: @unchecked Sendable {
     ///   - callSettings: Initial media settings applied before the join flow
     ///     starts.
     ///   - clientEventReporter: Reports join-lifecycle client events.
+    ///   - peerConnectionFactory: An optional preconfigured factory. When
+    ///     omitted, the coordinator creates the standard production factory
+    ///     from `videoConfig`.
     ///   - rtcPeerConnectionCoordinatorFactory: Factory for creating peer
     ///     connection coordinators.
     ///   - webRTCAuthenticator: The authenticator used during WebRTC flows.
@@ -75,17 +78,22 @@ final class WebRTCCoordinator: @unchecked Sendable {
         videoConfig: VideoConfig,
         callSettings: CallSettings,
         clientEventReporter: ClientEventReporting,
+        peerConnectionFactory: PeerConnectionFactory? = nil,
         rtcPeerConnectionCoordinatorFactory: RTCPeerConnectionCoordinatorProviding = StreamRTCPeerConnectionCoordinatorFactory(),
         webRTCAuthenticator: WebRTCAuthenticating = WebRTCAuthenticator(),
         callAuthentication: @escaping AuthenticationHandler
     ) {
         let stateMachine = StateMachine.init(.init(coordinator: nil))
+        let peerConnectionFactory = peerConnectionFactory ?? .build(
+            audioProcessingModule: videoConfig.audioProcessingModule
+        )
         stateAdapter = .init(
             user: user,
             apiKey: apiKey,
             callCid: callCid,
             videoConfig: videoConfig,
             callSettings: callSettings,
+            peerConnectionFactory: peerConnectionFactory,
             clientEventReporter: clientEventReporter,
             rtcPeerConnectionCoordinatorFactory: rtcPeerConnectionCoordinatorFactory,
             stagePublisher: stateMachine.publisher.map(\.id).eraseToAnyPublisher()

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinatorProviding.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCCoordinatorProviding.swift
@@ -36,6 +36,21 @@ protocol WebRTCCoordinatorProviding {
 /// `buildCoordinator` method that creates and returns a `WebRTCCoordinator`.
 struct WebRTCCoordinatorFactory: WebRTCCoordinatorProviding {
 
+    /// An optional preconfigured factory forwarded to each coordinator.
+    ///
+    /// A `nil` value preserves the default production WebRTC audio and video
+    /// pipeline.
+    private let peerConnectionFactory: PeerConnectionFactory?
+
+    /// Creates a coordinator factory with an optional peer-connection factory
+    /// override.
+    ///
+    /// - Parameter peerConnectionFactory: A preconfigured factory to forward
+    ///   to coordinators, or `nil` to let each coordinator build its default.
+    init(peerConnectionFactory: PeerConnectionFactory? = nil) {
+        self.peerConnectionFactory = peerConnectionFactory
+    }
+
     /// Builds and returns a `WebRTCCoordinator` using the provided parameters.
     ///
     /// - Parameters:
@@ -64,6 +79,7 @@ struct WebRTCCoordinatorFactory: WebRTCCoordinatorProviding {
             videoConfig: videoConfig,
             callSettings: callSettings,
             clientEventReporter: clientEventReporter,
+            peerConnectionFactory: peerConnectionFactory,
             callAuthentication: callAuthentication
         )
     }

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -975,9 +975,11 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
             return true
         }()
 
-        try peerConnectionFactory.audioDeviceModule.setEngineAvailability(
-            !sourceIsCallKit || audioStore.state.isActive
-        )
+        let isAudioEngineAvailable = peerConnectionFactory
+            .audioEngineAvailabilityOverride
+            ?? (!sourceIsCallKit || audioStore.state.isActive)
+        try peerConnectionFactory.audioDeviceModule
+            .setEngineAvailability(isAudioEngineAvailable)
 
         try await audioStore.dispatch(
             [

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -145,6 +145,7 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
 
     func test_execute_withoutRetries_callStateCallSettingsPreservedFromBeforeJoin() async throws {
         let expectedCallSettings = CallSettings(audioOn: false)
+        self.callController = .init(initialCallSettings: expectedCallSettings)
         self.call?.state.callSettings = expectedCallSettings
 
         let context = Call.StateMachine.Stage.Context(
@@ -201,12 +202,14 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
     }
 
     func test_execute_withoutRetries_updatesCallSettingsManagers() async throws {
+        let expectedCallSettings = CallSettings(audioOn: false)
+        self.callController = .init(initialCallSettings: expectedCallSettings)
         let context = Call.StateMachine.Stage.Context(
             call: call,
             input: .join(
                 .init(
                     create: true,
-                    callSettings: .init(audioOn: false),
+                    callSettings: expectedCallSettings,
                     options: .init(memberIds: [.unique]),
                     ring: true,
                     notify: false,

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -12,6 +12,20 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     private enum LeaveRouteVariant: String { case defaultRoute, speakerEnabled }
 
+    private struct InactiveAudioSessionPolicy: AudioSessionPolicy {
+        func configuration(
+            for callSettings: CallSettings,
+            ownCapabilities: Set<OwnCapability>
+        ) -> AudioSessionConfiguration {
+            var configuration = DefaultAudioSessionPolicy().configuration(
+                for: callSettings,
+                ownCapabilities: ownCapabilities
+            )
+            configuration.isActive = false
+            return configuration
+        }
+    }
+
     // MARK: - Properties
 
     private var helpers: Call_IntegrationTests.Helpers! = .init(loggingMode: .sdk)
@@ -800,13 +814,23 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     func test_audioRoom_participantWithoutSpeakPermission_toggleMicrophone_audioRemainsDisabled() async throws {
         helpers.permissions.setMicrophonePermission(isGranted: true)
+        let streamVideoEnvironment = StreamVideo.Environment.silentAudioDevice
         let callId = String.unique
         let host = String.unique
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                streamVideoEnvironment: streamVideoEnvironment
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
+            .performWithoutValueOverride {
+                await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
+            }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -820,7 +844,16 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             group.addTask {
                 try await self
                     .helpers
-                    .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
+                    .callFlow(
+                        id: callId,
+                        type: .audioRoom,
+                        userId: participant,
+                        environment: "demo",
+                        streamVideoEnvironment: streamVideoEnvironment
+                    )
+                    .performWithoutValueOverride {
+                        await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
+                    }
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
@@ -970,13 +1003,23 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     func test_audioRoom_participantWithoutVideoPermission_toggleCamera_videoRemainsDisabled() async throws {
         helpers.permissions.setCameraPermission(isGranted: true)
+        let streamVideoEnvironment = StreamVideo.Environment.silentAudioDevice
         let callId = String.unique
         let host = String.unique
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                streamVideoEnvironment: streamVideoEnvironment
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
+            .performWithoutValueOverride {
+                await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
+            }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -993,7 +1036,16 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             group.addTask {
                 try await self
                     .helpers
-                    .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
+                    .callFlow(
+                        id: callId,
+                        type: .audioRoom,
+                        userId: participant,
+                        environment: "demo",
+                        streamVideoEnvironment: streamVideoEnvironment
+                    )
+                    .performWithoutValueOverride {
+                        await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
+                    }
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendVideo) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.videoOn == false }

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -1151,32 +1151,34 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         let user2CallFlow = try await helpers
             .callFlow(id: callId, type: .default, userId: user2)
-            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
-        let user1CallFlowAfterCallCreation = try await user1CallFlow
+        let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
             .perform { try await $0.call.join() }
 
-        let user2SessionId = await user2CallFlow.call.state.sessionId
+        let user2JoinedFlow = try await user2CallFlow
+            .perform { try await $0.call.join() }
+            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
+        let user2SessionId = await user2JoinedFlow.call.state.sessionId
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await user1CallFlowAfterCallCreation
-                    .subscribe(for: CustomVideoEvent.self)
-                    .assertEventually { (event: CustomVideoEvent) in event.custom["state"] == "joined" }
-                    .perform { try await $0.call.pinForEveryone(userId: user2, sessionId: user2SessionId) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin != nil }
+        try await user1JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId] != nil
+            }
+            .perform {
+                try await $0.call.pinForEveryone(
+                    userId: user2,
+                    sessionId: user2SessionId
+                )
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin != nil
             }
 
-            group.addTask {
-                try await user2CallFlow
-                    .perform { try await $0.call.join() }
-                    .perform { try await $0.call.sendCustomEvent(["state": "joined"]) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin != nil }
+        try await user2JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin != nil
             }
-
-            try await group.waitForAll()
-        }
     }
 
     func test_pin_whenUserGetsPinnedLocally_thenCallStateOfLocalParticipantOnlyUpdatesAsExpected() async throws {
@@ -1189,32 +1191,29 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         let user2CallFlow = try await helpers
             .callFlow(id: callId, type: .default, userId: user2)
-            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
-        let user1CallFlowAfterCallCreation = try await user1CallFlow
+        let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
             .perform { try await $0.call.join() }
 
-        let user2SessionId = await user2CallFlow.call.state.sessionId
+        let user2JoinedFlow = try await user2CallFlow
+            .perform { try await $0.call.join() }
+            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
+        let user2SessionId = await user2JoinedFlow.call.state.sessionId
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await user1CallFlowAfterCallCreation
-                    .subscribe(for: CustomVideoEvent.self)
-                    .assertEventually { (event: CustomVideoEvent) in event.custom["state"] == "joined" }
-                    .perform { try await $0.call.pin(sessionId: user2SessionId) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin?.isLocal == true }
+        try await user1JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId] != nil
+            }
+            .perform { try await $0.call.pin(sessionId: user2SessionId) }
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin?.isLocal == true
             }
 
-            group.addTask {
-                try await user2CallFlow
-                    .perform { try await $0.call.join() }
-                    .perform { try await $0.call.sendCustomEvent(["state": "joined"]) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin == nil }
+        try await user2JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin == nil
             }
-
-            try await group.waitForAll()
-        }
     }
 
     // MARK: - Unpin
@@ -1229,34 +1228,50 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         let user2CallFlow = try await helpers
             .callFlow(id: callId, type: .default, userId: user2)
-            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
-        let user1CallFlowAfterCallCreation = try await user1CallFlow
+        let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
             .perform { try await $0.call.join() }
 
-        let user2SessionId = await user2CallFlow.call.state.sessionId
+        let user2JoinedFlow = try await user2CallFlow
+            .perform { try await $0.call.join() }
+            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
+        let user2SessionId = await user2JoinedFlow.call.state.sessionId
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await user1CallFlowAfterCallCreation
-                    .subscribe(for: CustomVideoEvent.self)
-                    .assertEventually { (event: CustomVideoEvent) in event.custom["state"] == "joined" }
-                    .perform { try await $0.call.pinForEveryone(userId: user2, sessionId: user2SessionId) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin != nil }
-                    .perform { try await $0.call.unpinForEveryone(userId: user2, sessionId: user2SessionId) }
+        try await user1JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId] != nil
+            }
+            .perform {
+                try await $0.call.pinForEveryone(
+                    userId: user2,
+                    sessionId: user2SessionId
+                )
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin != nil
             }
 
-            group.addTask {
-                try await user2CallFlow
-                    .perform { try await $0.call.join() }
-                    .perform { try await $0.call.sendCustomEvent(["state": "joined"]) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin != nil }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin == nil }
+        try await user2JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin != nil
             }
 
-            try await group.waitForAll()
-        }
+        try await user1JoinedFlow
+            .perform {
+                try await $0.call.unpinForEveryone(
+                    userId: user2,
+                    sessionId: user2SessionId
+                )
+            }
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin == nil
+            }
+
+        try await user2JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin == nil
+            }
     }
 
     func test_pin_whenUserGetsUnpinnedLocally_thenCallStateOfLocalParticipantOnlyUpdatesAsExpected() async throws {
@@ -1269,34 +1284,40 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         let user2CallFlow = try await helpers
             .callFlow(id: callId, type: .default, userId: user2)
-            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
-        let user1CallFlowAfterCallCreation = try await user1CallFlow
+        let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
             .perform { try await $0.call.join() }
 
-        let user2SessionId = await user2CallFlow.call.state.sessionId
+        let user2JoinedFlow = try await user2CallFlow
+            .perform { try await $0.call.join() }
+            .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
+        let user2SessionId = await user2JoinedFlow.call.state.sessionId
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await user1CallFlowAfterCallCreation
-                    .subscribe(for: CustomVideoEvent.self)
-                    .assertEventually { (event: CustomVideoEvent) in event.custom["state"] == "joined" }
-                    .perform { try await $0.call.pin(sessionId: user2SessionId) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin?.isLocal == true }
-                    .perform { try await $0.call.unpin(sessionId: user2SessionId) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin == nil }
+        try await user1JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId] != nil
+            }
+            .perform { try await $0.call.pin(sessionId: user2SessionId) }
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin?.isLocal == true
             }
 
-            group.addTask {
-                try await user2CallFlow
-                    .perform { try await $0.call.join() }
-                    .perform { try await $0.call.sendCustomEvent(["state": "joined"]) }
-                    .assertEventuallyInMainActor { $0.call.state.participantsMap[user2SessionId]?.pin == nil }
+        try await user2JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin == nil
             }
 
-            try await group.waitForAll()
-        }
+        try await user1JoinedFlow
+            .perform { try await $0.call.unpin(sessionId: user2SessionId) }
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin == nil
+            }
+
+        try await user2JoinedFlow
+            .assertEventuallyInMainActor {
+                $0.call.state.participantsMap[user2SessionId]?.pin == nil
+            }
     }
 
     // MARK: - Leave

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -12,20 +12,6 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     private enum LeaveRouteVariant: String { case defaultRoute, speakerEnabled }
 
-    private struct InactiveAudioSessionPolicy: AudioSessionPolicy {
-        func configuration(
-            for callSettings: CallSettings,
-            ownCapabilities: Set<OwnCapability>
-        ) -> AudioSessionConfiguration {
-            var configuration = DefaultAudioSessionPolicy().configuration(
-                for: callSettings,
-                ownCapabilities: ownCapabilities
-            )
-            configuration.isActive = false
-            return configuration
-        }
-    }
-
     // MARK: - Properties
 
     private var helpers: Call_IntegrationTests.Helpers! = .init(loggingMode: .sdk)
@@ -396,25 +382,17 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         let creatorFlow = try await creatorUserFlow
             .perform { try await $0.call.create(memberIds: [creatorUserId, participantUserId]) }
+            .perform { try await $0.call.join() }
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await creatorFlow
-                    .perform { try await $0.call.join() }
-                    .subscribe(for: CustomVideoEvent.self)
-                    .assertEventually { (event: CustomVideoEvent) in event.custom["state"] == "joined" }
-                    .perform { try await $0.call.end() }
+        let participantFlow = try await participantUserFlow
+            .perform { try await $0.call.join() }
+
+        _ = try await creatorFlow.call.end()
+
+        try await participantFlow
+            .assertEventuallyInMainActor(timeout: 30) {
+                $0.call.streamVideo.state.activeCall == nil
             }
-
-            group.addTask {
-                try await participantUserFlow
-                    .perform { try await $0.call.join() }
-                    .perform { try await $0.call.sendCustomEvent(["state": "joined"]) }
-                    .assertEventuallyInMainActor { $0.call.streamVideo.state.activeCall == nil }
-            }
-
-            try await group.waitForAll()
-        }
     }
 
     // MARK: - SendReactions
@@ -814,23 +792,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     func test_audioRoom_participantWithoutSpeakPermission_toggleMicrophone_audioRemainsDisabled() async throws {
         helpers.permissions.setMicrophonePermission(isGranted: true)
-        let streamVideoEnvironment = StreamVideo.Environment.silentAudioDevice
         let callId = String.unique
         let host = String.unique
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                streamVideoEnvironment: streamVideoEnvironment
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
-            .performWithoutValueOverride {
-                await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
-            }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -848,12 +816,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                         id: callId,
                         type: .audioRoom,
                         userId: participant,
-                        environment: "demo",
-                        streamVideoEnvironment: streamVideoEnvironment
+                        environment: "demo"
                     )
-                    .performWithoutValueOverride {
-                        await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
-                    }
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
@@ -1003,23 +967,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
     func test_audioRoom_participantWithoutVideoPermission_toggleCamera_videoRemainsDisabled() async throws {
         helpers.permissions.setCameraPermission(isGranted: true)
-        let streamVideoEnvironment = StreamVideo.Environment.silentAudioDevice
         let callId = String.unique
         let host = String.unique
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                streamVideoEnvironment: streamVideoEnvironment
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
-            .performWithoutValueOverride {
-                await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
-            }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -1040,12 +994,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                         id: callId,
                         type: .audioRoom,
                         userId: participant,
-                        environment: "demo",
-                        streamVideoEnvironment: streamVideoEnvironment
+                        environment: "demo"
                     )
-                    .performWithoutValueOverride {
-                        await $0.call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
-                    }
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendVideo) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.videoOn == false }

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
@@ -9,6 +9,20 @@ import XCTest
 extension String: @retroactive Error {}
 
 extension Call_IntegrationTests {
+    private struct InactiveAudioSessionPolicy: AudioSessionPolicy {
+        func configuration(
+            for callSettings: CallSettings,
+            ownCapabilities: Set<OwnCapability>
+        ) -> AudioSessionConfiguration {
+            var configuration = DefaultAudioSessionPolicy().configuration(
+                for: callSettings,
+                ownCapabilities: ownCapabilities
+            )
+            configuration.isActive = false
+            return configuration
+        }
+    }
+
     struct Helpers: Sendable {
         @Injected(\.audioStore) private var audioStore
 
@@ -64,11 +78,6 @@ extension Call_IntegrationTests {
                         .compactMap { ($0.object as? Call)?.cId }
                         .filter { $0 == call.cId }
                         .nextValue(timeout: 2)
-                    try await Call_IntegrationTests.Assertions.assertEventually(
-                        timeout: 2
-                    ) {
-                        await call.callController.sessionID().isEmpty
-                    }
                 }
             }
             registeredCalls = [:]
@@ -93,7 +102,7 @@ extension Call_IntegrationTests {
             userId: String,
             environment: String = "pronto",
             clientResolutionMode: StreamVideoHelper.ClientResolutionMode = .ignoreCache,
-            streamVideoEnvironment: StreamVideo.Environment = .init(),
+            streamVideoEnvironment: StreamVideo.Environment = .silentAudioDevice,
             overrideAPIKey: String? = nil,
             overrideToken: String? = nil
         ) async throws -> CallFlow<Void> {
@@ -109,6 +118,7 @@ extension Call_IntegrationTests {
                 streamVideoEnvironment: streamVideoEnvironment
             )
             let call = client.call(callType: type, callId: id)
+            await call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
             registeredCalls[userId] = call
             return .init(
                 client: client,

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
@@ -64,6 +64,11 @@ extension Call_IntegrationTests {
                         .compactMap { ($0.object as? Call)?.cId }
                         .filter { $0 == call.cId }
                         .nextValue(timeout: 2)
+                    try await Call_IntegrationTests.Assertions.assertEventually(
+                        timeout: 2
+                    ) {
+                        await call.callController.sessionID().isEmpty
+                    }
                 }
             }
             registeredCalls = [:]
@@ -76,6 +81,7 @@ extension Call_IntegrationTests {
                 .filter { $0 == nil }
                 .nextValue(timeout: 2)
 
+            permissions.dismantle()
             await client.dismantle()
         }
 
@@ -87,6 +93,7 @@ extension Call_IntegrationTests {
             userId: String,
             environment: String = "pronto",
             clientResolutionMode: StreamVideoHelper.ClientResolutionMode = .ignoreCache,
+            streamVideoEnvironment: StreamVideo.Environment = .init(),
             overrideAPIKey: String? = nil,
             overrideToken: String? = nil
         ) async throws -> CallFlow<Void> {
@@ -98,7 +105,8 @@ extension Call_IntegrationTests {
                 userId: userId,
                 connectMode: .afterInit,
                 clientResolutionMode: clientResolutionMode,
-                clientRegisterMode: .auto
+                clientRegisterMode: .auto,
+                streamVideoEnvironment: streamVideoEnvironment
             )
             let call = client.call(callType: type, callId: id)
             registeredCalls[userId] = call

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+StreamVideoHelper.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+StreamVideoHelper.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 @testable import StreamVideo
+import StreamWebRTC
 import XCTest
 
 extension Call_IntegrationTests.Helpers {
@@ -42,7 +43,8 @@ extension Call_IntegrationTests.Helpers {
             userId: String,
             connectMode: ConnectMode,
             clientResolutionMode: ClientResolutionMode,
-            clientRegisterMode: ClientRegisterMode
+            clientRegisterMode: ClientRegisterMode,
+            streamVideoEnvironment: StreamVideo.Environment = .init()
         ) async throws -> StreamVideo {
             let autoConnectOnInit = {
                 switch connectMode {
@@ -65,8 +67,9 @@ extension Call_IntegrationTests.Helpers {
                         user: User(id: userId),
                         token: .init(rawValue: token),
                         videoConfig: videoConfig,
-                        pushNotificationsConfig: pushNotificationConfig,
                         tokenProvider: { _ in },
+                        pushNotificationsConfig: pushNotificationConfig,
+                        environment: streamVideoEnvironment,
                         autoConnectOnInit: autoConnectOnInit
                     )
                 }
@@ -114,5 +117,105 @@ extension Call_IntegrationTests.Helpers {
         func client(for userId: String) -> StreamVideo? {
             registeredClients[userId]
         }
+    }
+}
+
+extension StreamVideo.Environment {
+    static var silentAudioDevice: Self {
+        var environment = Self()
+        environment.callControllerBuilder = {
+            defaultAPI,
+                user,
+                callId,
+                callType,
+                apiKey,
+                videoConfig,
+                initialCallSettings,
+                cachedLocation in
+            let peerConnectionFactory = PeerConnectionFactory.build(
+                audioProcessingModule: videoConfig.audioProcessingModule,
+                audioDeviceModuleSource: MockRTCAudioDeviceModule(),
+                audioDevice: SilentAudioDevice()
+            )
+            return CallController(
+                defaultAPI: defaultAPI,
+                user: user,
+                callId: callId,
+                callType: callType,
+                apiKey: apiKey,
+                videoConfig: videoConfig,
+                initialCallSettings: initialCallSettings,
+                cachedLocation: cachedLocation,
+                webRTCCoordinatorFactory: WebRTCCoordinatorFactory(
+                    peerConnectionFactory: peerConnectionFactory
+                )
+            )
+        }
+        return environment
+    }
+}
+
+private final class SilentAudioDevice: NSObject, RTCAudioDevice {
+    let deviceInputSampleRate: Double = 48000
+    let inputIOBufferDuration: TimeInterval = 0.01
+    let inputNumberOfChannels: Int = 1
+    let inputLatency: TimeInterval = 0
+    let deviceOutputSampleRate: Double = 48000
+    let outputIOBufferDuration: TimeInterval = 0.01
+    let outputNumberOfChannels: Int = 1
+    let outputLatency: TimeInterval = 0
+
+    private(set) var isInitialized = false
+    private(set) var isPlayoutInitialized = false
+    private(set) var isPlaying = false
+    private(set) var isRecordingInitialized = false
+    private(set) var isRecording = false
+
+    private var delegate: RTCAudioDeviceDelegate?
+
+    func initialize(with delegate: RTCAudioDeviceDelegate) -> Bool {
+        self.delegate = delegate
+        isInitialized = true
+        return true
+    }
+
+    func terminateDevice() -> Bool {
+        delegate = nil
+        isInitialized = false
+        isPlayoutInitialized = false
+        isPlaying = false
+        isRecordingInitialized = false
+        isRecording = false
+        return true
+    }
+
+    func initializePlayout() -> Bool {
+        isPlayoutInitialized = true
+        return true
+    }
+
+    func startPlayout() -> Bool {
+        isPlaying = true
+        return true
+    }
+
+    func stopPlayout() -> Bool {
+        isPlaying = false
+        return true
+    }
+
+    func initializeRecording() -> Bool {
+        isRecordingInitialized = true
+        return true
+    }
+
+    func startRecording() -> Bool {
+        isRecording = true
+        return true
+    }
+
+    func stopRecording() -> Bool {
+        isRecording = false
+        return true
     }
 }

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+StreamVideoHelper.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+StreamVideoHelper.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 @testable import StreamVideo
-import StreamWebRTC
 import XCTest
 
 extension Call_IntegrationTests.Helpers {
@@ -44,7 +43,7 @@ extension Call_IntegrationTests.Helpers {
             connectMode: ConnectMode,
             clientResolutionMode: ClientResolutionMode,
             clientRegisterMode: ClientRegisterMode,
-            streamVideoEnvironment: StreamVideo.Environment = .init()
+            streamVideoEnvironment: StreamVideo.Environment = .silentAudioDevice
         ) async throws -> StreamVideo {
             let autoConnectOnInit = {
                 switch connectMode {
@@ -134,8 +133,7 @@ extension StreamVideo.Environment {
                 cachedLocation in
             let peerConnectionFactory = PeerConnectionFactory.build(
                 audioProcessingModule: videoConfig.audioProcessingModule,
-                audioDeviceModuleSource: MockRTCAudioDeviceModule(),
-                audioDevice: SilentAudioDevice()
+                audioEngineAvailabilityOverride: false
             )
             return CallController(
                 defaultAPI: defaultAPI,
@@ -152,70 +150,5 @@ extension StreamVideo.Environment {
             )
         }
         return environment
-    }
-}
-
-private final class SilentAudioDevice: NSObject, RTCAudioDevice {
-    let deviceInputSampleRate: Double = 48000
-    let inputIOBufferDuration: TimeInterval = 0.01
-    let inputNumberOfChannels: Int = 1
-    let inputLatency: TimeInterval = 0
-    let deviceOutputSampleRate: Double = 48000
-    let outputIOBufferDuration: TimeInterval = 0.01
-    let outputNumberOfChannels: Int = 1
-    let outputLatency: TimeInterval = 0
-
-    private(set) var isInitialized = false
-    private(set) var isPlayoutInitialized = false
-    private(set) var isPlaying = false
-    private(set) var isRecordingInitialized = false
-    private(set) var isRecording = false
-
-    private var delegate: RTCAudioDeviceDelegate?
-
-    func initialize(with delegate: RTCAudioDeviceDelegate) -> Bool {
-        self.delegate = delegate
-        isInitialized = true
-        return true
-    }
-
-    func terminateDevice() -> Bool {
-        delegate = nil
-        isInitialized = false
-        isPlayoutInitialized = false
-        isPlaying = false
-        isRecordingInitialized = false
-        isRecording = false
-        return true
-    }
-
-    func initializePlayout() -> Bool {
-        isPlayoutInitialized = true
-        return true
-    }
-
-    func startPlayout() -> Bool {
-        isPlaying = true
-        return true
-    }
-
-    func stopPlayout() -> Bool {
-        isPlaying = false
-        return true
-    }
-
-    func initializeRecording() -> Bool {
-        isRecordingInitialized = true
-        return true
-    }
-
-    func startRecording() -> Bool {
-        isRecording = true
-        return true
-    }
-
-    func stopRecording() -> Bool {
-        isRecording = false
-        return true
     }
 }

--- a/StreamVideoTests/Mock/MockCallController.swift
+++ b/StreamVideoTests/Mock/MockCallController.swift
@@ -96,7 +96,7 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
         .allCases
         .reduce(into: [FunctionKey: [MockFunctionInputKey]]()) { $0[$1] = [] }
 
-    convenience init() {
+    convenience init(initialCallSettings: CallSettings = .default) {
         self.init(
             defaultAPI: MockDefaultAPIEndpoints(),
             user: .dummy(),
@@ -104,7 +104,7 @@ final class MockCallController: CallController, Mockable, @unchecked Sendable {
             callType: .unique,
             apiKey: .unique,
             videoConfig: .dummy(),
-            initialCallSettings: .default,
+            initialCallSettings: initialCallSettings,
             cachedLocation: nil
         )
     }

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Components/AVAudioSessionObserver_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Components/AVAudioSessionObserver_Tests.swift
@@ -22,6 +22,10 @@ final class AVAudioSessionObserver_Tests: XCTestCase, @unchecked Sendable {
         super.tearDown()
     }
 
+    func test_snapshot_renderingModeIsEmpty() {
+        XCTAssertEqual(AVAudioSession.Snapshot().renderingMode, "")
+    }
+
     func test_startObserving_emitsSnapshotsFromTimer() async {
         let observer = AVAudioSessionObserver()
         let expectation = expectation(description: "snapshots")


### PR DESCRIPTION
### 🎯 Goal

Prevent audio-room integration tests from activating the simulator's real audio capture stack, which can cause intermittent TCC, MediaServices, and CoreSimulator failures during repeated runs.

The original `CallSettings` and production media behavior remain unchanged.

### 📝 Summary

- Add internal support for injecting a native WebRTC audio device and its SDK-side controller.
- Use a silent audio device and inactive audio-session policy in the affected permission tests.
- Wait for WebRTC session cleanup and reset mocked permissions during teardown.
- Document the injected and default production audio paths with DocC.

### 🛠 Implementation

`PeerConnectionFactory` can now receive an optional `RTCAudioDevice` and `RTCAudioDeviceModuleControlling`. The configured factory is forwarded through `WebRTCCoordinatorFactory` and `WebRTCCoordinator`.

When no factory or audio device is injected, the existing production path continues to create the standard WebRTC audio engine with the configured audio-processing module.

The affected integration tests inject:

- A silent native `RTCAudioDevice` that does not start platform audio capture or playback.
- The existing mocked SDK audio-device module.
- An inactive audio-session policy that prevents `AVAudioSession` activation.

The tests retain their original audio and video `CallSettings`.

Integration-test teardown now waits until the call's WebRTC session identifier is cleared before dismantling clients and resets the permission helper to avoid leaking state between iterations.

### 🎨 Showcase

Not applicable. There are no UI changes.

### 🧪 Manual Testing Notes

Validated on an iPhone 17 Pro simulator running iOS 26.5:

- Ran both affected tests for 10 iterations each, serially.
  - 20 tests passed.
  - 0 failures.
  - No `Unable to initAndStart recording` errors.
  - No CoreSimulator RPC timeouts.
- `xcodebuild ... build-for-testing` passed.
- `swiftformat --lint --config .swiftformat .` passed.
- `swiftlint lint --config .swiftlint.yml --strict` passed.

A subsequent live-SFU run encountered a separate pre-join timeout while `call.create` made no progress. It occurred before WebRTC joining or audio activation and did not reproduce the media-service crash.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more flexible audio handling for WebRTC calls, including silent audio environments and configurable audio availability.
  * Improved call setup customization for different audio configurations.

* **Bug Fixes**
  * Improved call reliability when microphone or camera access is unavailable.
  * Improved cleanup after ending a call, including audio-session teardown.
  * Fixed simulator compatibility for audio-session rendering state on newer Swift versions.
  * Improved call-ending and pinning behavior validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->