### PR TITLE
[Fix] Isolate participant observation on the main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Prevent CallKit-driven joins from disconnecting and rejoining while waiting for audio-session activation. [#1218](https://github.com/GetStream/stream-video-swift/pull/1218)
 - Fixed a crash caused by completing a PushKit VoIP notification before CallKit finished reporting its incoming call. [#1221](https://github.com/GetStream/stream-video-swift/pull/1221)
+- Fixed a crash that could occur when setting up call participant observation from a background thread. [#1225](https://github.com/GetStream/stream-video-swift/pull/1225)
 
 ### 🔄 Changed
 

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -101,7 +101,7 @@ class CallController: @unchecked Sendable {
 
         _ = webRTCCoordinator
 
-        Task(disposableBag: disposableBag) { [weak self] in
+        Task(disposableBag: disposableBag) { @MainActor [weak self] in
             guard let self else { return }
             await handleParticipantCountUpdated()
             let participantsPublisher = await webRTCCoordinator.stateAdapter.$participants


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1949/bugconcurrency-issue-published-update-from-non-main-thread

### 🎯 Goal

Prevent a rare `EXC_BAD_ACCESS` inside Combine while `CallController` installs participant observation from a non-main executor.

### 📝 Summary

- Run the `CallController` observer initialization task on the main actor.
- Serialize participant observer creation and subscription with main-actor state handling.
- Document the crash fix in the changelog.
- No public API changes.

### 🛠 Implementation

Added `@MainActor` isolation to the existing initialization task in `CallController`. This ensures that `CollectionDelayedUpdateObserver` and its `$value` subscription are configured on the main actor instead of an arbitrary executor.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash when setting up call participant observation in the background.
  * Improved reliability by ensuring initialization completes on the main thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->