### PR TITLE
Bump stream_actions plugin to 0.4.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.4.6)
+    fastlane-plugin-stream_actions (0.4.7)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -379,7 +379,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.4.6)
+  fastlane-plugin-stream_actions (= 0.4.7)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   json

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,3 +1,3 @@
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.4.6'
+gem 'fastlane-plugin-stream_actions', '0.4.7'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Resolve: https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Pick up `fastlane-plugin-stream_actions` [0.4.7](https://github.com/GetStream/fastlane-plugin-stream_actions), which strips invisible Unicode leftovers (`U+FE0E`/`U+FE0F`/`U+200D`) from the TestFlight changelog before handing it to pilot. Pilot removes emoji but leaves these companions behind, and App Store Connect rejects them — this silently failed every stream-chat-swift 5.8.0 and stream-chat-swiftui 5.7.0/5.8.0 demo deploy with `Text for whatsNew contains invalid characters:'[️]'`.

### 🛠 Implementation

- `fastlane-plugin-stream_actions` 0.4.6 → 0.4.7 (`Pluginfile` + lockfile). This repo's changelog is currently clean (its only variation selector is in an ancient section that never gets uploaded), so this is preventive.

Same bump applied across the iOS SDK repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Fastlane Stream Actions plugin to version 0.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
