### PR TITLE
[Fix] Avoid rejoining on transient peer connection disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent CallKit-driven joins from disconnecting and rejoining while waiting for audio-session activation. [#1218](https://github.com/GetStream/stream-video-swift/pull/1218)
 - Fixed a crash caused by completing a PushKit VoIP notification before CallKit finished reporting its incoming call. [#1221](https://github.com/GetStream/stream-video-swift/pull/1221)
 - Fixed a crash that could occur when setting up call participant observation from a background thread. [#1225](https://github.com/GetStream/stream-video-swift/pull/1225)
+- Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 
 ### 🔄 Changed
 

--- a/Sources/StreamVideo/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator.swift
+++ b/Sources/StreamVideo/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator.swift
@@ -85,7 +85,7 @@ class RTCPeerConnectionCoordinator: @unchecked Sendable {
     var disconnectedPublisher: AnyPublisher<Void, Never> {
         peerConnection
             .publisher(eventType: StreamRTCPeerConnection.DidChangeConnectionStateEvent.self)
-            .filter { $0.state == .disconnected || $0.state == .failed }
+            .filter { $0.state == .failed }
             .map { _ in () }
             .eraseToAnyPublisher()
     }

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
@@ -92,6 +92,30 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         XCTAssertTrue(iceConnectionStateAdapter.peerConnectionCoordinator === subject)
     }
 
+    func test_disconnectedPublisher_peerConnectionDisconnected_doesNotPublish() {
+        var receivedEvents = 0
+        let cancellable = subject.disconnectedPublisher.sink { receivedEvents += 1 }
+
+        mockPeerConnection.subject.send(
+            StreamRTCPeerConnection.DidChangeConnectionStateEvent(state: .disconnected)
+        )
+
+        XCTAssertEqual(receivedEvents, 0)
+        cancellable.cancel()
+    }
+
+    func test_disconnectedPublisher_peerConnectionFailed_publishes() {
+        var receivedEvents = 0
+        let cancellable = subject.disconnectedPublisher.sink { receivedEvents += 1 }
+
+        mockPeerConnection.subject.send(
+            StreamRTCPeerConnection.DidChangeConnectionStateEvent(state: .failed)
+        )
+
+        XCTAssertEqual(receivedEvents, 1)
+        cancellable.cancel()
+    }
+
     // MARK: - isHealthy
 
     func test_isHealthy_ICEConnectionFailed_ConnectionStateHealthy_returnsFalse() {


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1959 – Reconnection policy misalignment](https://linear.app/stream/issue/IOS-1959/bugreconnection-policy-misalignment)

### 🎯 Goal

Allow transient WebRTC disconnections to recover through the existing ICE restart flow instead of immediately creating a new session. A full rejoin remains the fallback when the peer connection reaches `.failed`.

### 📝 Summary

- Ignore `.disconnected` as a full-rejoin trigger.
- Continue triggering a rejoin for `.failed`.
- Add regression coverage for both connection states.

### 🛠 Implementation

Narrowed `RTCPeerConnectionCoordinator.disconnectedPublisher` to emit only when the peer connection reaches `.failed`. The existing `ICEConnectionStateAdapter` remains responsible for recovering transient disconnections through ICE restart.

This change does not modify public APIs.

### 🎨 Showcase

Not applicable; there are no UI changes.

### 🧪 Manual Testing Notes

Suggested verification:

- Briefly interrupt an active call and verify it recovers without creating a new session.
- Verify a peer connection reaching `.failed` still triggers a full rejoin.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ x This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x]Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

Not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved peer connection recovery by ignoring transient disconnections.
  - Failure notifications now occur only when a peer connection enters a failed state, supporting ICE restart recovery.

- **Tests**
  - Added coverage confirming disconnected states are ignored and failed states generate exactly one notification.

- **Documentation**
  - Updated the upcoming changelog with the disconnection and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->