### PR TITLE
[Fix] Restore output route after media services reset

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
-        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.13.0"),
+        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.14.0"),
         .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.10.1")
     ],
     targets: [

--- a/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
+++ b/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
@@ -9,5 +9,5 @@ extension SystemEnvironment {
   /// A Stream Video version.
   public static let version: String = "1.51.0-SNAPSHOT"
   /// The WebRTC version.
-  public static let webRTCVersion: String = "145.13.0"
+  public static let webRTCVersion: String = "145.14.0"
 }

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Components/RTCAudioSessionPublisher.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Components/RTCAudioSessionPublisher.swift
@@ -16,6 +16,10 @@ final class RTCAudioSessionPublisher: NSObject, RTCAudioSessionDelegate, @unchec
 
         case didEndInterruption(shouldResumeSession: Bool)
 
+        /// Indicates that iOS restarted media services and the live audio
+        /// session may need to be restored.
+        case mediaServicesWereReset
+
         case didChangeRoute(
             reason: AVAudioSession.RouteChangeReason,
             from: AVAudioSessionRouteDescription,
@@ -29,6 +33,9 @@ final class RTCAudioSessionPublisher: NSObject, RTCAudioSessionDelegate, @unchec
 
             case (let .didEndInterruption(lhsValue), let .didEndInterruption(rhsValue)):
                 return lhsValue == rhsValue
+
+            case (.mediaServicesWereReset, .mediaServicesWereReset):
+                return true
 
             case (let .didChangeRoute(lReason, lFrom, lTo), let .didChangeRoute(rReason, rFrom, rTo)):
                 return lReason == rReason
@@ -71,6 +78,12 @@ final class RTCAudioSessionPublisher: NSObject, RTCAudioSessionDelegate, @unchec
         shouldResumeSession: Bool
     ) {
         subject.send(.didEndInterruption(shouldResumeSession: shouldResumeSession))
+    }
+
+    /// Publishes a reset event so store effects can restore SDK-owned audio
+    /// session state.
+    func audioSessionMediaServerReset(_ session: RTCAudioSession) {
+        subject.send(.mediaServicesWereReset)
     }
 
     /// Forwards route change notifications and includes the new route in the

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore+RouteChangeEffect.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore+RouteChangeEffect.swift
@@ -9,8 +9,16 @@ import StreamWebRTC
 
 extension RTCAudioStore {
 
-    /// Bridges `RTCAudioSession` route updates into store state so downstream
-    /// features can react to speaker/headset transitions.
+    /// Bridges `RTCAudioSession` route updates into store state and restores
+    /// SDK-owned route policy after a media-services reset.
+    ///
+    /// iOS emits the reset callback after its media-services process restarts.
+    /// The call can remain connected while its previously selected output route
+    /// is no longer applied, leaving playback on an unexpected output.
+    ///
+    /// WebRTC restores its audio-session configuration and engine. This effect
+    /// restores the output-port override maintained by `RTCAudioStore`, which
+    /// is not part of `RTCAudioSessionConfiguration`.
     final class RouteChangeEffect: StoreEffect<RTCAudioStore.Namespace>, @unchecked Sendable {
 
         private let audioSessionObserver: RTCAudioSessionPublisher
@@ -21,6 +29,12 @@ extension RTCAudioStore {
             self.init(.init(source))
         }
 
+        /// Starts observing route changes and media-services resets.
+        ///
+        /// Reset recovery uses a dedicated action because the cached route can
+        /// remain unchanged even though iOS discarded the live output override.
+        /// - Parameter audioSessionObserver: The publisher that bridges WebRTC
+        ///   audio-session delegate callbacks.
         init(_ audioSessionObserver: RTCAudioSessionPublisher) {
             self.audioSessionObserver = audioSessionObserver
             super.init()
@@ -43,6 +57,22 @@ extension RTCAudioStore {
                 .log(.debug, subsystems: .audioSession) { "AudioRoute updated \($1) → \($2) due to reason:\($0)." }
                 .map { $0.2 }
                 .sink { [weak self] in self?.dispatcher?.dispatch(.setCurrentRoute($0)) }
+                .store(in: disposableBag)
+
+            audioSessionObserver
+                .publisher
+                .filter {
+                    if case .mediaServicesWereReset = $0 {
+                        return true
+                    }
+                    return false
+                }
+                .receive(on: processingQueue)
+                .sink { [weak self] _ in
+                    self?.dispatcher?.dispatch(
+                        .avAudioSession(.restoreOutputAudioPortAfterMediaServicesReset)
+                    )
+                }
                 .store(in: disposableBag)
         }
     }

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore+Action.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore+Action.swift
@@ -72,6 +72,10 @@ extension RTCAudioStore {
             )
             case setOverrideOutputAudioPort(AVAudioSession.PortOverride)
 
+            /// Reapplies the cached output-port override after a media-services
+            /// reset without changing the session's activation state.
+            case restoreOutputAudioPortAfterMediaServicesReset
+
             var description: String {
                 switch self {
                 case .systemSetCategory(let category):
@@ -106,6 +110,9 @@ extension RTCAudioStore {
 
                 case .setOverrideOutputAudioPort(let portOverride):
                     return ".setOverrideOutputAudioPort(\(portOverride))"
+
+                case .restoreOutputAudioPortAfterMediaServicesReset:
+                    return ".restoreOutputAudioPortAfterMediaServicesReset"
                 }
             }
         }

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore+Coordinator.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore+Coordinator.swift
@@ -106,7 +106,10 @@ extension RTCAudioStore {
 
         // MARK: - Private Helpers
 
-        /// Determines if an AVAudioSession action would alter the configuration.
+        /// Determines if an AVAudioSession action should reach the reducer.
+        ///
+        /// Media-services recovery always executes because the system can lose
+        /// live route state without changing the cached configuration.
         private func shouldExecute(
             action: StoreAction.AVAudioSessionAction,
             state: StoreState.AVAudioSessionConfiguration
@@ -144,6 +147,9 @@ extension RTCAudioStore {
 
             case let .setOverrideOutputAudioPort(value):
                 return value != state.overrideOutputAudioPort
+
+            case .restoreOutputAudioPortAfterMediaServicesReset:
+                return true
             }
         }
 

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore+AVAudioSessionReducer.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore+AVAudioSessionReducer.swift
@@ -20,6 +20,9 @@ extension RTCAudioStore.Namespace {
 
         /// Handles `StoreAction.avAudioSession` cases by mutating the session and
         /// returning an updated state snapshot.
+        ///
+        /// Media-services recovery reapplies only the SDK-owned output override;
+        /// WebRTC owns restoration of its configuration and activation state.
         override func reduce(
             state: State,
             action: Action,
@@ -132,6 +135,20 @@ extension RTCAudioStore.Namespace {
                     updatedState = try await setDefaultToSpeaker(
                         state: state,
                         speakerOn: value == .speaker
+                    )
+                }
+
+            case .restoreOutputAudioPortAfterMediaServicesReset:
+                // WebRTC restores category options. Only play-and-record uses
+                // an explicit output override that is not part of its config.
+                guard state.audioSessionConfiguration.category == .playAndRecord else {
+                    return updatedState
+                }
+                // This changes route policy without activating the session, so
+                // a concurrent CallKit deactivation remains authoritative.
+                try source.perform {
+                    try $0.overrideOutputAudioPort(
+                        state.audioSessionConfiguration.overrideOutputAudioPort
                     )
                 }
             }

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3329,7 +3329,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-video-swift-webrtc.git";
 			requirement = {
 				kind = exactVersion;
-				version = 145.13.0;
+				version = 145.14.0;
 			};
 		};
 		40F445C32A9E1D91004BE3DA /* XCRemoteSwiftPackageReference "stream-chat-swift-test-helpers" */ = {

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Components/RTCAudioSessionPublisher_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Components/RTCAudioSessionPublisher_Tests.swift
@@ -39,6 +39,14 @@ final class RTCAudioSessionPublisher_Tests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - audioSessionMediaServerReset
+
+    func test_audioSessionMediaServerReset_publishedCorrectEvent() async {
+        await assertEvent(.mediaServicesWereReset) {
+            subject.audioSessionMediaServerReset(.sharedInstance())
+        }
+    }
+
     // MARK: - audioSessionDidChangeRoute
 
     func test_audioSessionDidChangeRoute_publishedCorrectEvent() async {

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore_RouteChangeEffectTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore_RouteChangeEffectTests.swift
@@ -65,6 +65,21 @@ final class RTCAudioStore_RouteChangeEffectTests: XCTestCase, @unchecked Sendabl
         XCTAssertEqual(route, expectedRoute)
     }
 
+    func test_mediaServicesReset_dispatchesRestoreOutputAudioPort() async {
+        dispatcherExpectation = expectation(description: "Dispatches route recovery")
+
+        publisher.audioSessionMediaServerReset(session)
+
+        await safeFulfillment(of: [dispatcherExpectation!], timeout: 1)
+
+        let actions = dispatchedActions.flatMap { $0.map(\.wrappedValue) }
+        guard
+            case .avAudioSession(.restoreOutputAudioPortAfterMediaServicesReset) = actions.first
+        else {
+            return XCTFail("Expected route recovery action.")
+        }
+    }
+
     func test_nonRouteEvents_doNotDispatch() async {
         let invertedExpectation = expectation(description: "No dispatch")
         invertedExpectation.isInverted = true

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore_CoordinatorTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/RTCAudioStore_CoordinatorTests.swift
@@ -252,6 +252,21 @@ final class RTCAudioStore_CoordinatorTests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    func test_avAudioSession_restoreOutputAfterMediaServicesReset_returnsTrue() {
+        let configuration = makeAVAudioSessionConfiguration(
+            category: .playAndRecord,
+            overrideOutputAudioPort: .speaker
+        )
+        let state = makeState(audioSessionConfiguration: configuration)
+
+        XCTAssertTrue(
+            subject.shouldExecute(
+                action: .avAudioSession(.restoreOutputAudioPortAfterMediaServicesReset),
+                state: state
+            )
+        )
+    }
+
     func test_webRTCAudioSession_setAudioEnabled_sameValue_returnsFalse() {
         let configuration = makeWebRTCAudioSessionConfiguration(isAudioEnabled: true)
         let state = makeState(webRTCAudioSessionConfiguration: configuration)

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore_AVAudioSessionReducerTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore_AVAudioSessionReducerTests.swift
@@ -193,6 +193,50 @@ final class RTCAudioStore_AVAudioSessionReducerTests: XCTestCase, @unchecked Sen
         XCTAssertEqual(session.timesCalled(.setConfiguration), 1)
     }
 
+    func test_reduce_restoreOutputAfterMediaServicesReset_reappliesCachedOverride() async throws {
+        let state = makeState(
+            category: .playAndRecord,
+            mode: .voiceChat,
+            options: [],
+            overrideOutput: .speaker
+        )
+
+        let result = try await subject.reduce(
+            state: state,
+            action: .avAudioSession(.restoreOutputAudioPortAfterMediaServicesReset),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertEqual(result, state)
+        let recorded = session.recordedInputPayload(
+            AVAudioSession.PortOverride.self,
+            for: .overrideOutputAudioPort
+        ) ?? []
+        XCTAssertEqual(recorded, [.speaker])
+    }
+
+    func test_reduce_restoreOutputAfterMediaServicesReset_nonPlayAndRecord_skipsOverride() async throws {
+        let state = makeState(
+            category: .playback,
+            mode: .default,
+            options: [.defaultToSpeaker],
+            overrideOutput: .speaker
+        )
+
+        let result = try await subject.reduce(
+            state: state,
+            action: .avAudioSession(.restoreOutputAudioPortAfterMediaServicesReset),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertEqual(result, state)
+        XCTAssertEqual(session.timesCalled(.overrideOutputAudioPort), 0)
+    }
+
     func test_reduce_systemSetCategory_updatesStateWithoutCallingSession() async throws {
         let state = makeState(
             category: .playback,


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1961](https://linear.app/stream/issue/IOS-1961/bugmediaservices-teardown-issue)

### 🎯 Goal

Restore the SDK-selected audio output route after iOS restarts media services, without reactivating a session that CallKit or the app has already deactivated.

### 📝 Summary

- Publish WebRTC media-services reset callbacks through `RTCAudioSessionPublisher`.
- Dispatch route recovery through the existing audio-store pipeline.
- Reapply the cached output-port override for play-and-record sessions.
- Add unit coverage for the publisher, effect, coordinator, and reducer behavior.

### 🛠 Implementation

`RTCAudioSessionPublisher` converts `audioSessionMediaServerReset` delegate callbacks into a store event. `RouteChangeEffect` receives the event on its processing queue and dispatches a dedicated recovery action.

The coordinator always executes this action because the stored route configuration may be unchanged while the media-services restart has discarded the corresponding system state.

The reducer reapplies the cached `overrideOutputAudioPort` value only for `.playAndRecord` sessions. It does not activate the audio session, ensuring that a concurrent CallKit or application deactivation remains authoritative.

This restores the route state owned by the Swift SDK. Full bidirectional audio recovery also depends on the companion WebRTC change that restores `AVAudioSession` configuration and rebuilds the invalidated audio engine. This branch does not update the StreamWebRTC dependency.

### 🎨 Showcase

Not applicable — no UI changes.

### 🧪 Manual Testing Notes

Suggested physical-device scenario:

1. Integrate a StreamWebRTC build containing the companion media-services recovery.
2. Join a call and select speaker output.
3. Trigger a media-services reset while the call remains connected.
4. Verify the speaker override is restored and bidirectional audio resumes.
5. Repeat while leaving the call or deactivating through CallKit.
6. Verify the session remains inactive and audio is not restarted unexpectedly.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-session recovery after media services reset.
  * Restores the configured speaker output for active play-and-record sessions without unnecessarily reactivating the audio session.
  * Helps maintain expected audio routing when iOS media services restart.

* **Compatibility**
  * Updated the underlying WebRTC integration to improve media-session reset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->