### PR TITLE
Keep Float in generated OpenAPI models

### DIFF
--- a/Scripts/generate.sh
+++ b/Scripts/generate.sh
@@ -19,7 +19,10 @@ rm -rf "$PROJECT_ROOT/Sources/StreamVideo/OpenApi/generated/Models/"*
 (
   cd "$SOURCE_PATH/projects/chat-manager" &&
   go run . openapi generate-spec -products video -version v2 -clientside -output "$SOURCE_PATH/releases/v2/video-openapi-clientside" -renamed-models "$SCRIPT_DIR/renamed-models.json" &&
-  go run . openapi generate-client --language swift --spec "$SOURCE_PATH/releases/v2/video-openapi-clientside.yaml" --output "$PROJECT_ROOT/Sources/StreamVideo/OpenApi/generated/"
+  # number_as_float keeps JSON numbers as Float. The generator defaults to Double
+  # since Float truncates float64s, but our generated models are public, so
+  # widening them would be a source and binary break.
+  go run . openapi generate-client --language swift --spec "$SOURCE_PATH/releases/v2/video-openapi-clientside.yaml" --opt number_as_float=true --output "$PROJECT_ROOT/Sources/StreamVideo/OpenApi/generated/"
 )
 
 # Shared OpenAPI types are provided by StreamCore.


### PR DESCRIPTION
### 🔗 Issue Links

- [CHA-4672](https://linear.app/stream/issue/CHA-4672/generated-sdk-models-narrow-float64-fields-to-32-bit-float)
- Depends on GetStream/chat#15645

### 🎯 Goal

The chat OpenAPI Swift generator now maps JSON numbers to `Double` instead of `Float`, since `Float` truncates the `float64` values the backend sends.

Our generated models are `public`, so widening them would be a source and binary break. Our number fields are also response-only, so nothing is sent back narrowed and the extra precision isn't consumed anywhere — `EdgeResponse` coordinates pick a datacenter, and `Float` is already sub-metre there.

### 📝 Summary

- Pass `number_as_float=true` in `Scripts/generate.sh` to keep the current types.
- No generated code changes: this offsets the new generator default exactly.
- The opt should be dropped at the next major to adopt `Double`.

### 🛠 Implementation

The width is a generator opt rather than a hardcoded exclusion, so adopting `Double` later is a one-line deletion here instead of a change in the chat repo. The generator rejects unknown opts, so a typo fails the generation run rather than silently widening.

### 🧪 Manual Testing Notes

Ran `Scripts/generate.sh` against the chat branch and diffed `Sources/StreamVideo/OpenApi/generated/` against a run on chat `master` without the opt: byte identical, 337 files.

Note that GetStream/chat#15645 must merge first — the opt does not exist before it.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Swift client generation so JSON numbers are represented as `Float` values instead of `Double`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->