### PR TITLE
[Fix] Complete audio recovery after media services reset

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
-        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.14.0"),
+        .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.15.0"),
         .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.10.1")
     ],
     targets: [

--- a/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
+++ b/Sources/StreamVideo/Generated/SystemEnvironment+Version.swift
@@ -9,5 +9,5 @@ extension SystemEnvironment {
   /// A Stream Video version.
   public static let version: String = "1.51.0-SNAPSHOT"
   /// The WebRTC version.
-  public static let webRTCVersion: String = "145.14.0"
+  public static let webRTCVersion: String = "145.15.0"
 }

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore+AVAudioSessionReducer.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore+AVAudioSessionReducer.swift
@@ -32,7 +32,8 @@ extension RTCAudioStore.Namespace {
         ) async throws -> State {
             var updatedState = state
 
-            if case let .setCurrentRoute(value) = action {
+            if case let .setCurrentRoute(value) = action,
+               value.reason.isValidRouteChange {
                 updatedState.audioSessionConfiguration.overrideOutputAudioPort = value.isSpeaker ? .speaker : .none
             }
 
@@ -141,7 +142,9 @@ extension RTCAudioStore.Namespace {
             case .restoreOutputAudioPortAfterMediaServicesReset:
                 // WebRTC restores category options. Only play-and-record uses
                 // an explicit output override that is not part of its config.
-                guard state.audioSessionConfiguration.category == .playAndRecord else {
+                // Read the live category because the mirrored store snapshot
+                // can still contain pre-reset values at this callback boundary.
+                guard source.category == AVAudioSession.Category.playAndRecord.rawValue else {
                     return updatedState
                 }
                 // This changes route policy without activating the session, so

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3329,7 +3329,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-video-swift-webrtc.git";
 			requirement = {
 				kind = exactVersion;
-				version = 145.14.0;
+				version = 145.15.0;
 			};
 		};
 		40F445C32A9E1D91004BE3DA /* XCRemoteSwiftPackageReference "stream-chat-swift-test-helpers" */ = {

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore_AVAudioSessionReducerTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Reducers/RTCAudioStore_AVAudioSessionReducerTests.swift
@@ -193,13 +193,14 @@ final class RTCAudioStore_AVAudioSessionReducerTests: XCTestCase, @unchecked Sen
         XCTAssertEqual(session.timesCalled(.setConfiguration), 1)
     }
 
-    func test_reduce_restoreOutputAfterMediaServicesReset_reappliesCachedOverride() async throws {
+    func test_reduce_restoreOutputAfterMediaServicesReset_livePlayAndRecord_reappliesCachedOverride() async throws {
         let state = makeState(
-            category: .playAndRecord,
-            mode: .voiceChat,
+            category: .init(rawValue: ""),
+            mode: .init(rawValue: ""),
             options: [],
             overrideOutput: .speaker
         )
+        session.category = AVAudioSession.Category.playAndRecord.rawValue
 
         let result = try await subject.reduce(
             state: state,
@@ -219,11 +220,12 @@ final class RTCAudioStore_AVAudioSessionReducerTests: XCTestCase, @unchecked Sen
 
     func test_reduce_restoreOutputAfterMediaServicesReset_nonPlayAndRecord_skipsOverride() async throws {
         let state = makeState(
-            category: .playback,
-            mode: .default,
+            category: .playAndRecord,
+            mode: .voiceChat,
             options: [.defaultToSpeaker],
             overrideOutput: .speaker
         )
+        session.category = AVAudioSession.Category.playback.rawValue
 
         let result = try await subject.reduce(
             state: state,
@@ -276,6 +278,24 @@ final class RTCAudioStore_AVAudioSessionReducerTests: XCTestCase, @unchecked Sen
         let result = try await subject.reduce(
             state: state,
             action: .setCurrentRoute(speakerRoute),
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        XCTAssertEqual(result.audioSessionConfiguration.overrideOutputAudioPort, .speaker)
+    }
+
+    func test_reduce_setCurrentRoute_categoryChange_preservesOverridePort() async throws {
+        let state = makeState(overrideOutput: .speaker)
+        let receiverRoute = RTCAudioStore.StoreState.AudioRoute.dummy(
+            outputs: [.dummy(isReceiver: true)],
+            reason: .categoryChange
+        )
+
+        let result = try await subject.reduce(
+            state: state,
+            action: .setCurrentRoute(receiverRoute),
             file: #file,
             function: #function,
             line: #line


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1961](https://linear.app/stream/issue/IOS-1961/bugmediaservices-teardown-issue)
- Follow-up to [#1232](https://github.com/GetStream/stream-video-swift/pull/1232)
- Companion WebRTC fix: [GetStream/webrtc#108](https://github.com/GetStream/webrtc/pull/108)

### 🎯 Goal

Complete iOS audio recovery after a media-services reset.

The initial SDK recovery could still lose the cached speaker override when iOS emitted a filtered route callback such as `.categoryChange`. It also checked the mirrored store category, which may be stale when the reset callback arrives.

### 📝 Summary

- Upgrade StreamWebRTC from `145.14.0` to `145.15.0`.
- Preserve the selected output override during filtered route callbacks.
- Determine reset-recovery eligibility from the live `AVAudioSession` category.
- Add reducer coverage for stale store state and category-change callbacks.

### 🛠 Implementation

StreamWebRTC `145.15.0` includes the post-reset CallKit reconfiguration fix from GetStream/webrtc#108. WebRTC remains responsible for rebuilding the invalidated audio graph, while the Swift SDK remains responsible for restoring the explicit output-port override.

The route reducer now updates its cached output override only for valid route changes. Callbacks such as `.categoryChange` and `.routeConfigurationChange` no longer erase the user's stored speaker selection.

When restoring the output after a media-services reset, the reducer reads the live `AVAudioSession.category` instead of its mirrored store snapshot. The override is applied only when the live category is `.playAndRecord`, and the recovery does not activate the session.

There are no public API or migration changes.

### 🎨 Showcase

Not applicable - no UI changes.

### 🧪 Manual Testing Notes

Automated coverage was added for:

- Reapplying the cached override when the live category is `.playAndRecord`, even if the store snapshot is stale.
- Skipping the override when the live category is not `.playAndRecord`.
- Preserving the cached speaker override during `.categoryChange`.

The focused tests have not been run as part of this PR draft. `git diff --cached --check` passes.

Physical-device QA is pending:

1. Build the app with this branch and StreamWebRTC `145.15.0`.
2. Join a call and select speaker output.
3. Lock the device until the background task expires.
4. Receive and answer a CallKit call, wait briefly, unlock, and return to the app.
5. Background the app and enter Picture in Picture.
6. Trigger a media-services reset.
7. Return to the foreground.
8. Verify bidirectional audio recovers and the selected output route remains active.
9. Repeat while intentionally deactivating through CallKit or the app and verify recovery does not reactivate the session unexpectedly.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio routing when changing output devices.
  * Preserved speaker preferences during valid route changes.
  * Enhanced recovery after audio-service interruptions by checking the active audio configuration.

* **Chores**
  * Updated the WebRTC component to version 145.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->