### PR TITLE
[Fix] Preserve microphone state and prevent renderer UI stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent CallKit-driven joins from disconnecting and rejoining while waiting for audio-session activation. [#1218](https://github.com/GetStream/stream-video-swift/pull/1218)
 - Fixed a crash caused by completing a PushKit VoIP notification before CallKit finished reporting its incoming call. [#1221](https://github.com/GetStream/stream-video-swift/pull/1221)
 - Fixed a crash that could occur when setting up call participant observation from a background thread. [#1225](https://github.com/GetStream/stream-video-swift/pull/1225)
+- Fixed microphone state restoration after joining or resuming a call, and prevented participant video rendering from blocking the main thread while querying WebRTC track state. [#1237](https://github.com/GetStream/stream-video-swift/pull/1237)
 
 ### 🔄 Changed
 

--- a/Sources/StreamVideo/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule.swift
@@ -361,15 +361,30 @@ final class AudioDeviceModule: NSObject, RTCAudioDeviceModuleDelegate, Encodable
         }
     }
 
-    /// Enables or disables recording on the wrapped audio device module.
+    /// Starts or stops capture while keeping published state synchronized with
+    /// the wrapped audio device module.
+    ///
+    /// Enabling snapshots the requested mute state before native recording
+    /// starts because WebRTC may reset that state while rebuilding its input
+    /// path. The mute state is restored before recording is published so
+    /// observers never receive an active state while restoration is pending.
+    ///
+    /// If mute restoration fails, the native start is rolled back before the
+    /// restoration error is returned. If rollback also fails, the cached
+    /// recording and mute values are refreshed from the native module before
+    /// the rollback error is returned.
+    ///
     /// - Parameter isEnabled: When `true` recording starts, otherwise stops.
-    /// - Throws: `ClientError` when the underlying module reports a failure.
-    /// - Note: Serialized on ``engineQueue`` with other engine mutations.
+    /// - Throws: `ClientError` when start, stop, mute restoration, or rollback
+    ///   fails in the underlying module.
+    /// - Important: Native mutations and publisher updates are serialized on
+    ///   ``engineQueue`` with the other audio-engine operations.
     func setRecording(_ isEnabled: Bool) throws {
         try engineQueue.sync {
             guard isEnabled != isRecording else {
                 return
             }
+            let isMicrophoneMuted = self.isMicrophoneMuted
             if isEnabled {
                 if source.isRecordingInitialized {
                     try throwingExecution("Unable to start recording") {
@@ -386,30 +401,47 @@ final class AudioDeviceModule: NSObject, RTCAudioDeviceModuleDelegate, Encodable
                 }
             }
 
+            if isEnabled {
+                do {
+                    try setMuted(
+                        isMicrophoneMuted,
+                        startRecordingIfNeeded: false
+                    )
+                } catch let restorationError {
+                    do {
+                        try throwingExecution(
+                            "Unable to stop recording after mute restoration failed"
+                        ) {
+                            source.stopRecording()
+                        }
+                    } catch {
+                        isRecordingSubject.send(source.isRecording)
+                        if source.isMicrophoneMuted != self.isMicrophoneMuted {
+                            isMicrophoneMutedSubject.send(source.isMicrophoneMuted)
+                        }
+                        throw error
+                    }
+                    throw restorationError
+                }
+            }
             isRecordingSubject.send(isEnabled)
         }
     }
 
-    /// Updates the muted state of the microphone for the wrapped module.
+    /// Updates both native and published microphone mute state.
+    ///
+    /// Unmuting starts recording first when capture is stopped. When the native
+    /// state already matches the request, the cached publisher is still
+    /// reconciled because native recording transitions may have changed state
+    /// without updating the wrapper.
+    ///
     /// - Parameter isMuted: `true` to mute the microphone, `false` to unmute.
     /// - Throws: `ClientError` when the underlying module reports a failure.
-    /// - Note: Serialized on ``engineQueue``; re-enters it when it needs to
-    ///   start recording before unmuting.
+    /// - Important: The operation is serialized on ``engineQueue`` and may
+    ///   re-enter it to start recording before an unmute request is applied.
     func setMuted(_ isMuted: Bool) throws {
         try engineQueue.sync {
-            guard isMuted != source.isMicrophoneMuted else {
-                return
-            }
-
-            if !isMuted, !isRecording {
-                try setRecording(true)
-            }
-
-            try throwingExecution("Unable to setMicrophoneMuted:\(isMuted)") {
-                source.setMicrophoneMuted(isMuted)
-            }
-
-            isMicrophoneMutedSubject.send(isMuted)
+            try setMuted(isMuted, startRecordingIfNeeded: true)
         }
     }
 
@@ -417,6 +449,39 @@ final class AudioDeviceModule: NSObject, RTCAudioDeviceModuleDelegate, Encodable
     /// - Note: Serialized on ``engineQueue`` with other engine mutations.
     func refreshStereoPlayoutState() {
         engineQueue.sync { source.refreshStereoPlayoutState() }
+    }
+
+    /// Applies mute state with explicit control over recording activation.
+    ///
+    /// Normal mute requests may start recording before unmuting. Recording
+    /// recovery disables that behavior because native recording has already
+    /// started while the published recording state is intentionally pending.
+    ///
+    /// - Parameters:
+    ///   - isMuted: The mute state to apply and publish.
+    ///   - startRecordingIfNeeded: Whether an unmute request may start capture.
+    /// - Throws: `ClientError` when recording activation or the native mute
+    ///   operation fails.
+    private func setMuted(
+        _ isMuted: Bool,
+        startRecordingIfNeeded: Bool
+    ) throws {
+        guard isMuted != source.isMicrophoneMuted else {
+            if isMuted != isMicrophoneMuted {
+                isMicrophoneMutedSubject.send(isMuted)
+            }
+            return
+        }
+
+        if !isMuted, startRecordingIfNeeded, !isRecording {
+            try setRecording(true)
+        }
+
+        try throwingExecution("Unable to setMicrophoneMuted:\(isMuted)") {
+            source.setMicrophoneMuted(isMuted)
+        }
+
+        isMicrophoneMutedSubject.send(isMuted)
     }
 
     // MARK: - Audio Buffer injection

--- a/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore+InterruptionsEffect.swift
+++ b/Sources/StreamVideo/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore+InterruptionsEffect.swift
@@ -8,8 +8,18 @@ import StreamWebRTC
 
 extension RTCAudioStore {
 
-    /// Converts audio session interruption callbacks into store actions so the
-    /// audio pipeline can gracefully pause and resume.
+    /// Converts audio-session interruptions into ordered recovery actions.
+    ///
+    /// Interruption start marks the store as interrupted. A resumable end clears
+    /// that state and restarts recording when it was active before the event.
+    /// Muted-speech detection is temporarily disabled around the restart so
+    /// WebRTC rebuilds the input graph instead of treating recovery as a mute
+    /// toggle.
+    ///
+    /// Microphone mute restoration belongs to
+    /// `AudioDeviceModule.setRecording(_:)`, after native recording starts. The
+    /// effect intentionally does not replay a mute snapshot that could be stale
+    /// by the time its queued actions execute.
     final class InterruptionsEffect: StoreEffect<RTCAudioStore.Namespace>, @unchecked Sendable {
 
         private let audioSessionObserver: RTCAudioSessionPublisher
@@ -31,8 +41,14 @@ extension RTCAudioStore {
 
         // MARK: - Private Helpers
 
-        /// Handles the underlying audio session events and dispatches the
-        /// appropriate store actions.
+        /// Builds and dispatches the action sequence for an audio-session event.
+        ///
+        /// A resumable interruption restarts recording only when the store was
+        /// interrupted and recording was previously active. Persistent muted
+        /// speech detection is restored after that restart. Mute state is not
+        /// appended here because recording recovery owns post-start restoration.
+        ///
+        /// - Parameter event: The WebRTC audio-session event to process.
         private func handle(
             _ event: RTCAudioSessionPublisher.Event
         ) {
@@ -56,7 +72,6 @@ extension RTCAudioStore {
                     let state = stateProvider?(),
                     state.audioDeviceModule != nil {
                     let isRecording = state.isRecording
-                    let isMicrophoneMuted = state.isMicrophoneMuted
                     let isMutedSpeechDetectionEnabled = state.isMutedSpeechDetectionEnabled
 
                     if isRecording {
@@ -77,8 +92,6 @@ extension RTCAudioStore {
                             actions.append(.setMutedSpeechDetectionEnabled(true))
                         }
                     }
-
-                    actions.append(.setMicrophoneMuted(isMicrophoneMuted))
                 }
                 dispatcher?.dispatch(actions.map(\.box))
             default:

--- a/Sources/StreamVideoSwiftUI/CallView/VideoRenderer/VideoRenderer.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/VideoRenderer/VideoRenderer.swift
@@ -134,17 +134,27 @@ public class VideoRenderer: RTCVideoRenderingView, @unchecked Sendable {
 
 extension VideoRenderer {
 
-    /// Handles rendering view updates for a specified participant's video track.
+    /// Attaches a participant's current video track and propagates size updates.
+    ///
+    /// When a track exists, the renderer retains the participant, attaches the
+    /// track, and reports a changed rendered size asynchronously. Diagnostic
+    /// logging is restricted to immutable track metadata so rendering does not
+    /// wait for synchronized WebRTC state during a SwiftUI view update.
+    ///
     /// - Parameters:
-    ///   - participant: The participant whose video track is being handled.
-    ///   - onTrackSizeUpdate: A closure to be called when the track size is updated.
+    ///   - participant: The participant whose current track should be rendered.
+    ///   - onTrackSizeUpdate: Called when the rendered size differs from the
+    ///     participant's stored track size.
+    /// - Important: This method can run on the main thread during SwiftUI
+    ///   updates. Reading `RTCVideoTrack.isEnabled` here is unsafe because its
+    ///   proxy may wait for WebRTC's signaling thread and block UI updates.
     public func handleViewRendering(
         for participant: CallParticipant,
         onTrackSizeUpdate: @escaping @Sendable (CGSize, CallParticipant) -> Void
     ) {
         if let track = participant.track {
             log.info(
-                "Found \(track.kind) track:\(track.trackId) for \(participant.name) and will add on \(type(of: self)):\(identifier)) isMuted:\(!track.isEnabled)",
+                "Found \(track.kind) track:\(track.trackId) for \(participant.name) and will add on \(type(of: self)):\(identifier)",
                 subsystems: .other
             )
             self.participant = participant

--- a/StreamVideoSwiftUITests/CallView/VideoRenderer_Tests.swift
+++ b/StreamVideoSwiftUITests/CallView/VideoRenderer_Tests.swift
@@ -3,9 +3,11 @@
 //
 
 import Combine
+import ObjectiveC
 import StreamSwiftTestHelpers
 @testable import StreamVideo
 @testable import StreamVideoSwiftUI
+import StreamWebRTC
 import XCTest
 
 @MainActor
@@ -53,6 +55,40 @@ final class VideoRenderer_Tests: XCTestCase, @unchecked Sendable {
             thermalState: .critical,
             expected: Double(maximumFramesPerSecond) * 0.4
         )
+    }
+
+    func test_handleViewRendering_trackEnabledStateWasNotRead() throws {
+        let originalLogLevel = LogConfig.level
+        LogConfig.level = .info
+        defer { LogConfig.level = originalLogLevel }
+
+        let factory = PeerConnectionFactory.build(
+            audioProcessingModule: MockAudioProcessingModule.shared
+        )
+        let track = factory.makeVideoTrack(
+            source: factory.makeVideoSource(forScreenShare: false)
+        )
+        let participant = CallParticipant.dummy(track: track)
+        let selector = #selector(getter: RTCMediaStreamTrack.isEnabled)
+        let method = try XCTUnwrap(
+            class_getInstanceMethod(RTCMediaStreamTrack.self, selector)
+        )
+        let originalImplementation = method_getImplementation(method)
+        var wasRead = false
+        let replacement: @convention(block) (RTCMediaStreamTrack) -> Bool = { _ in
+            wasRead = true
+            return true
+        }
+        let replacementImplementation = imp_implementationWithBlock(replacement)
+        method_setImplementation(method, replacementImplementation)
+        defer {
+            method_setImplementation(method, originalImplementation)
+            imp_removeBlock(replacementImplementation)
+        }
+
+        subject.handleViewRendering(for: participant) { _, _ in }
+
+        XCTAssertFalse(wasRead)
     }
 
     // MARK: - Private helpers

--- a/StreamVideoTests/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule_Tests.swift
+++ b/StreamVideoTests/Utils/AudioSession/AudioDeviceModule/AudioDeviceModule_Tests.swift
@@ -130,6 +130,67 @@ final class AudioDeviceModule_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(source.timesCalled(.startRecording), 0)
     }
 
+    func test_setRecording_whenNativeStartUnmutes_restoresMuteBeforePublishingRecording() throws {
+        source.stub(for: \.isMicrophoneMuted, with: true)
+        source.stub(for: \.isRecordingInitialized, with: true)
+        makeSubject()
+        var muteCallCountWhenRecordingWasPublished: Int?
+        subject.isRecordingPublisher
+            .dropFirst()
+            .sink { [weak source] isRecording in
+                guard isRecording else { return }
+                muteCallCountWhenRecordingWasPublished =
+                    source?.timesCalled(.setMicrophoneMuted)
+            }
+            .store(in: &cancellables)
+        source.onInvoke = { [weak source] function in
+            guard function == .startRecording else { return }
+            source?.stub(for: \.isMicrophoneMuted, with: false)
+        }
+
+        try subject.setRecording(true)
+
+        XCTAssertEqual(
+            source.recordedInputPayload(Bool.self, for: .setMicrophoneMuted),
+            [true]
+        )
+        XCTAssertEqual(muteCallCountWhenRecordingWasPublished, 1)
+        XCTAssertTrue(subject.isMicrophoneMuted)
+    }
+
+    func test_setRecording_whenMuteRestorationFails_stopsRecording() {
+        source.stub(for: \.isMicrophoneMuted, with: true)
+        source.stub(for: \.isRecordingInitialized, with: true)
+        source.stub(for: .setMicrophoneMuted, with: -1)
+        makeSubject()
+        source.onInvoke = { [weak source] function in
+            guard function == .startRecording else { return }
+            source?.stub(for: \.isMicrophoneMuted, with: false)
+        }
+
+        XCTAssertThrowsError(try subject.setRecording(true))
+
+        XCTAssertEqual(source.timesCalled(.stopRecording), 1)
+        XCTAssertFalse(subject.isRecording)
+    }
+
+    func test_setRecording_whenMuteRestorationAndRollbackFail_reconcilesState() {
+        source.stub(for: \.isMicrophoneMuted, with: true)
+        source.stub(for: \.isRecordingInitialized, with: true)
+        source.stub(for: .setMicrophoneMuted, with: -1)
+        source.stub(for: .stopRecording, with: -1)
+        makeSubject()
+        source.onInvoke = { [weak source] function in
+            guard function == .startRecording else { return }
+            source?.stub(for: \.isMicrophoneMuted, with: false)
+        }
+
+        XCTAssertThrowsError(try subject.setRecording(true))
+
+        XCTAssertFalse(subject.isRecording)
+        XCTAssertFalse(subject.isMicrophoneMuted)
+    }
+
     func test_setRecording_whenDeactivating_callsStopRecording() throws {
         source.stub(for: \.isRecording, with: true)
         makeSubject()
@@ -159,6 +220,17 @@ final class AudioDeviceModule_Tests: XCTestCase, @unchecked Sendable {
         try subject.setMuted(true)
 
         XCTAssertEqual(source.timesCalled(.setMicrophoneMuted), 0)
+    }
+
+    func test_setMuted_whenNativeStateAlreadyMatches_reconcilesCachedState() throws {
+        source.stub(for: \.isMicrophoneMuted, with: true)
+        makeSubject()
+        source.stub(for: \.isMicrophoneMuted, with: false)
+
+        try subject.setMuted(false)
+
+        XCTAssertEqual(source.timesCalled(.setMicrophoneMuted), 0)
+        XCTAssertFalse(subject.isMicrophoneMuted)
     }
 
     func test_setMuted_whenMuting_updatesStateAndPublisher() throws {

--- a/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore_InterruptionsEffectTests.swift
+++ b/StreamVideoTests/Utils/AudioSession/RTCAudioStore/Namespace/Effects/RTCAudioStore_InterruptionsEffectTests.swift
@@ -139,7 +139,7 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
             return XCTFail("Expected dispatched actions.")
         }
 
-        XCTAssertEqual(actions.count, 4)
+        XCTAssertEqual(actions.count, 3)
         guard case .setInterrupted(false) = actions[0].wrappedValue else {
             return XCTFail("Expected action[0] setInterrupted(false).")
         }
@@ -148,9 +148,6 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
         }
         guard case .setRecording(true) = actions[2].wrappedValue else {
             return XCTFail("Expected action[2] setRecording(true).")
-        }
-        guard case .setMicrophoneMuted(true) = actions[3].wrappedValue else {
-            return XCTFail("Expected action[3] setMicrophoneMuted(true).")
         }
     }
 
@@ -182,7 +179,7 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
             return XCTFail("Expected dispatched actions.")
         }
 
-        XCTAssertEqual(actions.count, 6)
+        XCTAssertEqual(actions.count, 5)
         guard case .setInterrupted(false) = actions[0].wrappedValue else {
             return XCTFail("Expected action[0] setInterrupted(false).")
         }
@@ -197,9 +194,6 @@ final class RTCAudioStore_InterruptionsEffectTests: XCTestCase, @unchecked Senda
         }
         guard case .setMutedSpeechDetectionEnabled(true) = actions[4].wrappedValue else {
             return XCTFail("Expected action[4] setMutedSpeechDetectionEnabled(true).")
-        }
-        guard case .setMicrophoneMuted(true) = actions[5].wrappedValue else {
-            return XCTFail("Expected action[5] setMicrophoneMuted(true).")
         }
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1969](https://linear.app/stream/issue/IOS-1969/bugaudio-wasnt-activated-as-expected-after-joining-call)
- UI freeze reported through the supplied LLDB backtrace; no linked issue.

### 🎯 Goal

Ensure recording activation preserves the requested microphone state and prevent SwiftUI renderer updates from waiting synchronously on WebRTC.

This introduces no public API changes.

### 📝 Summary

- Restore cached microphone state after native recording starts and before recording becomes observable.
- Roll back recording when mute restoration fails and reconcile native state if rollback also fails.
- Remove stale interruption-time mute replay.
- Avoid reading `RTCVideoTrack.isEnabled` from the renderer’s main-thread logging path.
- Add extended DocC for every touched production symbol.
- Add regression coverage for audio recovery, failure handling, and renderer blocking.

### 🛠 Implementation

- `AudioDeviceModule.setRecording(_:)` snapshots mute intent before starting native recording, restores it through a non-restarting internal path, and only then publishes recording state.
- Mute restoration failure stops native recording before returning the error. A failed rollback refreshes cached recording and mute values from the native module.
- Normal unmute-while-stopped behavior remains unchanged.
- `InterruptionsEffect` no longer queues a potentially stale microphone snapshot after restarting recording; `AudioDeviceModule` owns post-start restoration.
- `VideoRenderer` logs immutable track metadata without evaluating the synchronized `isEnabled` proxy. Track attachment and size propagation remain unchanged.
- The only diagnostic behavior change is removal of the internal `isMuted` log field.

### 🎨 Showcase

Not applicable. The renderer change prevents a freeze without changing layout or visual appearance.

### 🧪 Manual Testing Notes

Status: pending. Manual testing was intentionally not run as part of this change.

1. Join the same video call from two physical iOS devices, using Alexey’s affected device and a second participant.
2. Join with both microphones unmuted.
   - Verify both participants hear each other immediately.
   - Verify video remains connected.
3. Leave and rejoin with Alexey’s microphone muted.
   - Verify the peer cannot hear Alexey.
   - Unmute and verify the peer hears Alexey immediately.
   - Verify Alexey continues hearing the peer throughout.
4. Repeat join, leave, and mute/unmute transitions several times.
   - Verify microphone state never becomes stale or inverted.
5. While unmuted, trigger a real audio interruption, such as an incoming phone or CallKit call.
   - End the interruption.
   - Verify bidirectional audio resumes without rejoining.
6. Repeat the interruption while muted.
   - Verify the microphone remains muted after recovery.
   - Unmute and verify outgoing audio starts immediately.
7. Keep remote video visible while switching participant layouts, backgrounding and foregrounding the app, and leaving/rejoining.
   - Verify taps, navigation, and animations remain responsive.
   - Verify remote rendering continues without a main-thread stall.
8. If a freeze occurs, capture a main-thread backtrace.
   - Expected: no `RTCVideoTrack.isEnabled` wait originating from `VideoRenderer.handleViewRendering`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ x This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ]xChangelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes (not applicable)
- [x] Affected documentation updated with extended DocC

### 🎁 Meme

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone mute-state handling when recording starts, including safer recovery when restoration fails.
  * Enhanced audio interruption recovery and muted-speech detection behavior.
  * Prevented video rendering diagnostics from accessing potentially unsafe track state.

* **Tests**
  * Added coverage for microphone state restoration, rollback scenarios, interruption recovery, and safe video rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->