### PR TITLE
Expose deleteRecording on Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `Call.deleteRecording(callSessionId:filename:)` for deleting a recording of a call session, matching the JavaScript SDK's `deleteRecording`.
+
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 

--- a/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/08-recording.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/06-advanced/08-recording.swift
@@ -59,6 +59,19 @@ private func content() {
     }
 
     container {
+        @MainActor
+        func deleteRecording(_ recording: CallRecording) {
+            guard let callSessionId = call.state.session?.id else { return }
+            Task {
+                try await call.deleteRecording(
+                    callSessionId: callSessionId,
+                    filename: recording.filename
+                )
+            }
+        }
+    }
+
+    container {
         struct PlayerView: View {
 
             let recording: CallRecording

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -938,6 +938,31 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         return response.recordings
     }
 
+    /// Deletes a recording of the call.
+    ///
+    /// Recordings are stored per call session, so deleting one requires both
+    /// the session it belongs to and its filename. The filename comes from
+    /// ``CallRecording/filename`` as returned by ``listRecordings()``, while
+    /// the session id is available in `state.session?.id` for the ongoing
+    /// session.
+    /// - Parameters:
+    ///   - callSessionId: the id of the call session the recording belongs to.
+    ///   - filename: the filename of the recording to delete.
+    /// - Returns: `DeleteRecordingResponse`.
+    /// - Throws: An error if the recording can't be deleted.
+    @discardableResult
+    public func deleteRecording(
+        callSessionId: String,
+        filename: String
+    ) async throws -> DeleteRecordingResponse {
+        try await coordinatorClient.deleteRecording(
+            type: callType,
+            id: callId,
+            session: callSessionId,
+            filename: filename
+        )
+    }
+
     // MARK: - Broadcasting
 
     /// Starts HLS broadcasting of the call.

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -886,6 +886,36 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssertEqual(input.2.userId, userId)
     }
 
+    // MARK: - deleteRecording
+
+    func test_deleteRecording_coordinatorWasCalledWithExpectedValues() async throws {
+        let mockCoordinatorClient = MockDefaultAPIEndpoints()
+        let call = Call(
+            from: .init(call: .dummy(), members: [], ownCapabilities: []),
+            coordinatorClient: mockCoordinatorClient,
+            callController: .dummy(defaultAPI: mockCoordinatorClient)
+        )
+        let callSessionId = String.unique
+        let filename = String.unique
+
+        _ = try? await call.deleteRecording(
+            callSessionId: callSessionId,
+            filename: filename
+        )
+
+        let input = try XCTUnwrap(
+            mockCoordinatorClient
+                .recordedInputPayload(
+                    (String, String, String, String).self,
+                    for: .deleteRecording
+                )?.first
+        )
+        XCTAssertEqual(call.callType, input.0)
+        XCTAssertEqual(call.callId, input.1)
+        XCTAssertEqual(callSessionId, input.2)
+        XCTAssertEqual(filename, input.3)
+    }
+
     // MARK: - setVideoFilter
 
     func test_setVideoFilter_moderationVideoAdapterWasUpdated() async {


### PR DESCRIPTION
### 🔗 Issue Links

Cross-SDK consistency audit — "Delete recording: generated, unexposed on both mobile SDKs".

### 🎯 Goal

`DELETE /video/call/{type}/{id}/{session}/recordings/{filename}` has been present in our generated OpenAPI layer for a while, but nothing wrapped it. iOS apps could start, stop and list recordings and then had no way to remove one. JavaScript is the only other Video SDK that exposes deletion (Android and Flutter also stop at the generated endpoint), so this closes the gap against the one reference implementation we have.

### 📝 Summary

- Added `Call.deleteRecording(callSessionId:filename:)`, returning `DeleteRecordingResponse`.
- Added a unit test asserting the coordinator receives call type, call id, session id and filename.
- Added a `DocumentationTests` snippet so the new API stays compile-checked.
- Updated the changelog.

### 🛠 Implementation

The wrapper is a thin pass-through to `coordinatorClient.deleteRecording`, matching the shape of the neighbouring recording methods:

```swift
@discardableResult
public func deleteRecording(
    callSessionId: String,
    filename: String
) async throws -> DeleteRecordingResponse
```

Two decisions worth calling out:

- **Parameter naming.** The generated layer labels the path parameter `session:`, but `CallState.sessionId` on iOS is the *user's* session id — the value `pin(sessionId:)` and `unpin(sessionId:)` take. Naming this one `session` or `sessionId` would have been ambiguous at the call site, so it is `callSessionId`, which also matches the JS parameter name exactly.
- **No state mutation.** There is no recordings collection on `CallState` to invalidate, and JS does not touch state here either, so the method only performs the request.

The `filename` comes from `CallRecording.filename` via `listRecordings()`; the call session id is available as `state.session?.id` for the ongoing session.

Two adjacent gaps from the same audit are deliberately **not** in this PR:

- `listRecordings` cannot be scoped to a session on iOS. JS (`listRecordings(callSessionId?)`) and Android (`listRecordings(sessionId:)`) both accept one, but our generated `listRecordings(type:id:)` has no session parameter — that needs the spec regenerated rather than a hand-written wrapper.
- `deleteTranscription` is generated-but-unexposed in exactly the same way, and JS exposes it. Happy to fold it in if reviewers prefer one PR for both.

### 🎨 Showcase

N/A — no UI changes.

### 🧪 Manual Testing Notes

Record a call, then from the same call object:

```swift
let recordings = try await call.listRecordings()
if let callSessionId = call.state.session?.id, let recording = recordings.first {
    try await call.deleteRecording(
        callSessionId: callSessionId,
        filename: recording.filename
    )
}
// listRecordings() no longer returns that filename
```

Automated: `-only-testing:StreamVideoTests/Call_Tests/test_deleteRecording_coordinatorWasCalledWithExpectedValues` passes on iPhone 17 Pro (iOS 26.5); the `DocumentationTests` scheme builds; swiftformat `--lint` and swiftlint `--strict` are clean on the touched files.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

_The public recording docs page is in the docs repo and still needs a deletion section; the `DocumentationTests` snippet is in place for it._

### 🎁 Meme

When the endpoint has been sitting right there the whole time. 🫠

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deleting call-session recordings by providing the session ID and filename.
  * Added support for soft- and hard-deleting calls.
  * Added frame recording controls, including external storage support and recording status visibility.
  * Call state now updates correctly when a call is deleted.
  * Added documentation demonstrating how to validate an active call session before deleting a recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->