### PR TITLE
Expose stopAllRTMPBroadcasts on Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `Call.stopAllRTMPBroadcasts()` to stop every RTMP-out broadcast of a call in one call, matching the JavaScript SDK's `stopAllRTMPBroadcasts`.
+
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -976,6 +976,14 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         try await coordinatorClient.stopRTMPBroadcast(type: callType, id: callId, name: name)
     }
 
+    /// Stops all RTMP broadcasts of the call.
+    /// - Returns: `StopAllRTMPBroadcastsResponse`.
+    /// - Throws: An error if stopping the RTMP broadcasts fails.
+    @discardableResult
+    public func stopAllRTMPBroadcasts() async throws -> StopAllRTMPBroadcastsResponse {
+        try await coordinatorClient.stopAllRTMPBroadcasts(type: callType, id: callId)
+    }
+
     // MARK: - Events
 
     /// Sends a custom event to the call.

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -827,6 +827,30 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssert(call?.state.broadcasting == false)
     }
 
+    func test_stopAllRTMPBroadcasts_coordinatorWasCalledWithExpectedValues() async throws {
+        // Given
+        let mockCoordinatorClient = MockDefaultAPIEndpoints()
+        let subject = Call(
+            from: .init(call: .dummy(), members: [], ownCapabilities: []),
+            coordinatorClient: mockCoordinatorClient,
+            callController: .dummy(defaultAPI: mockCoordinatorClient)
+        )
+
+        // When
+        _ = try? await subject.stopAllRTMPBroadcasts()
+
+        // Then
+        let input = try XCTUnwrap(
+            mockCoordinatorClient
+                .recordedInputPayload(
+                    (String, String).self,
+                    for: .stopAllRTMPBroadcasts
+                )?.first
+        )
+        XCTAssertEqual(subject.callType, input.0)
+        XCTAssertEqual(subject.callId, input.1)
+    }
+
     // MARK: - enableClientCapabilities
 
     func test_enableClientCapabilities_correctlyUpdatesStateAdapter() async throws {


### PR DESCRIPTION
## 🎯 Goal

Closes the RTMP-out gap identified in the cross-SDK consistency audit: iOS could start RTMP broadcasts and stop them individually by name, but had no way to stop all of them at once.

The `stopAllRTMPBroadcasts` endpoint (`POST /video/call/{type}/{id}/rtmp_broadcasts/stop`) already existed in the generated API layer — it just had no public wrapper on top.

## 🛠 Implementation

Adds `Call.stopAllRTMPBroadcasts()`, forwarding to the generated coordinator client:

```swift
@discardableResult
public func stopAllRTMPBroadcasts() async throws -> StopAllRTMPBroadcastsResponse
```

The name matches the JavaScript SDK's `stopAllRTMPBroadcasts` exactly. Android and Flutter have no RTMP-out API at all, so JS was the only reference.

## 🧪 Testing

`test_stopAllRTMPBroadcasts_coordinatorWasCalledWithExpectedValues` in `Call_Tests` asserts the coordinator is called with the call's type and id. `MockDefaultAPIEndpoints` already had the stubbing wired up, so no test-infra changes were needed.

Full `Call_Tests` suite passes (42/42).

## ☝️ Note on naming

The two existing RTMP methods are inverted relative to JS — Swift has `startRTMPBroadcast(request:)` (singular) / `stopRTMPBroadcasts(name:)` (plural) where JS has `startRTMPBroadcasts(data)` / `stopRTMPBroadcast(name)`. That's the audit's D16 finding.

This PR does **not** touch them, since correcting it is a source-breaking public API change that would need deprecated aliases. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)