### PR TITLE
Expose frame recording on Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `Call.startFrameRecording(recordingExternalStorage:)` and `Call.stopFrameRecording()`, along with the `CallState.frameRecordingStatus` property that tracks frame recording for the active call.
+
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- `Call.startFrameRecording(recordingExternalStorage:)` and `Call.stopFrameRecording()`, along with the `CallState.frameRecordingStatus` property that tracks frame recording for the active call.
+- `Call.startFrameRecording(recordingExternalStorage:)` and `Call.stopFrameRecording()`, along with the `CallState.frameRecordingStatus` property that tracks frame recording for the active call. [#1246](https://github.com/GetStream/stream-video-swift/pull/1246)
 
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)

--- a/Sources/StreamVideo/Call.swift
+++ b/Sources/StreamVideo/Call.swift
@@ -938,6 +938,46 @@ public class Call: @unchecked Sendable, WSEventsSubscriber {
         return response.recordings
     }
 
+    // MARK: - Frame recording
+
+    /// Starts frame-by-frame recording of the call, optionally specifying an external storage
+    /// location.
+    ///
+    /// While frame recording is active, the backend periodically captures a frame per published
+    /// track and emits a `CallFrameRecordingFrameReadyEvent` carrying the URL of each captured
+    /// frame. Use ``Call/subscribe(for:)`` to observe those events.
+    ///
+    /// The capture interval, quality and mode are configured through the call type's frame
+    /// recording settings (``FrameRecordingSettingsRequest``) rather than per call.
+    ///
+    /// - Parameter recordingExternalStorage: The external storage location for the captured
+    ///  frames (optional).
+    /// - Returns: `StartFrameRecordingResponse`.
+    /// - Throws: An error if starting frame recording fails.
+    @discardableResult
+    public func startFrameRecording(
+        recordingExternalStorage: String? = nil
+    ) async throws -> StartFrameRecordingResponse {
+        try await coordinatorClient.startFrameRecording(
+            type: callType,
+            id: callId,
+            startFrameRecordingRequest: .init(
+                recordingExternalStorage: recordingExternalStorage
+            )
+        )
+    }
+
+    /// Stops frame-by-frame recording of the call.
+    /// - Returns: `StopFrameRecordingResponse`.
+    /// - Throws: An error if stopping frame recording fails.
+    @discardableResult
+    public func stopFrameRecording() async throws -> StopFrameRecordingResponse {
+        try await coordinatorClient.stopFrameRecording(
+            type: callType,
+            id: callId
+        )
+    }
+
     // MARK: - Broadcasting
 
     /// Starts HLS broadcasting of the call.

--- a/Sources/StreamVideo/CallState.swift
+++ b/Sources/StreamVideo/CallState.swift
@@ -46,6 +46,7 @@ public class CallState: ObservableObject {
     @Published public internal(set) var compositeRecordingStatus: Bool?
     @Published public internal(set) var individualRecordingStatus: Bool?
     @Published public internal(set) var rawRecordingStatus: Bool?
+    @Published public internal(set) var frameRecordingStatus: Bool?
     @Published public internal(set) var blockedUserIds: Set<String> = []
     @Published public internal(set) var settings: CallSettingsResponse?
     @Published public internal(set) var ownCapabilities: [OwnCapability] = [] {
@@ -303,13 +304,14 @@ public class CallState: ObservableObject {
         case .typeAppUpdatedEvent:
             break
         case .typeCallFrameRecordingFailedEvent:
-            break
+            frameRecordingStatus = false
         case .typeCallFrameRecordingFrameReadyEvent:
+            // note: captured frames are exposed via event subscriptions
             break
         case .typeCallFrameRecordingStartedEvent:
-            break
+            frameRecordingStatus = true
         case .typeCallFrameRecordingStoppedEvent:
-            break
+            frameRecordingStatus = false
         case .typeKickedUserEvent:
             break
         case .typeCallStatsReportReadyEvent:
@@ -567,6 +569,7 @@ public class CallState: ObservableObject {
         rawRecordingStatus = egress?.rawRecording?.status == runningStatus
         individualRecordingStatus = egress?.individualRecording?.status == runningStatus
         compositeRecordingStatus = egress?.compositeRecording?.status == runningStatus
+        frameRecordingStatus = egress?.frameRecording?.status == runningStatus
     }
 
     private func configureDuration(

--- a/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
+++ b/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
@@ -1281,6 +1281,9 @@ protocol DefaultAPIEndpoints {
     func startClosedCaptions(type: String, id: String, startClosedCaptionsRequest: StartClosedCaptionsRequest) async throws
         -> StartClosedCaptionsResponse
         
+    func startFrameRecording(type: String, id: String, startFrameRecordingRequest: StartFrameRecordingRequest) async throws
+        -> StartFrameRecordingResponse
+        
     func startRecording(
         type: String,
         id: String,
@@ -1295,6 +1298,8 @@ protocol DefaultAPIEndpoints {
         
     func stopClosedCaptions(type: String, id: String, stopClosedCaptionsRequest: StopClosedCaptionsRequest) async throws
         -> StopClosedCaptionsResponse
+        
+    func stopFrameRecording(type: String, id: String) async throws -> StopFrameRecordingResponse
         
     func stopLive(type: String, id: String, stopLiveRequest: StopLiveRequest) async throws -> StopLiveResponse
         

--- a/StreamVideoTests/Call/Call_Tests.swift
+++ b/StreamVideoTests/Call/Call_Tests.swift
@@ -370,6 +370,190 @@ final class Call_Tests: StreamVideoTestCase, @unchecked Sendable {
         )
     }
 
+    // MARK: - Frame recording
+
+    func test_startFrameRecording_coordinatorWasCalledWithExpectedValues() async throws {
+        let mockCoordinatorClient = MockDefaultAPIEndpoints()
+        let call = Call(
+            from: .init(call: .dummy(), members: [], ownCapabilities: []),
+            coordinatorClient: mockCoordinatorClient,
+            callController: .dummy(defaultAPI: mockCoordinatorClient)
+        )
+        let externalStorage = String.unique
+
+        _ = try? await call.startFrameRecording(
+            recordingExternalStorage: externalStorage
+        )
+
+        let input = try XCTUnwrap(
+            mockCoordinatorClient
+                .recordedInputPayload(
+                    (String, String, StartFrameRecordingRequest).self,
+                    for: .startFrameRecording
+                )?.first
+        )
+        XCTAssertEqual(call.callType, input.0)
+        XCTAssertEqual(call.callId, input.1)
+        XCTAssertEqual(input.2.recordingExternalStorage, externalStorage)
+    }
+
+    func test_startFrameRecording_withoutExternalStorage_coordinatorWasCalledWithExpectedValues() async throws {
+        let mockCoordinatorClient = MockDefaultAPIEndpoints()
+        let call = Call(
+            from: .init(call: .dummy(), members: [], ownCapabilities: []),
+            coordinatorClient: mockCoordinatorClient,
+            callController: .dummy(defaultAPI: mockCoordinatorClient)
+        )
+
+        _ = try? await call.startFrameRecording()
+
+        let input = try XCTUnwrap(
+            mockCoordinatorClient
+                .recordedInputPayload(
+                    (String, String, StartFrameRecordingRequest).self,
+                    for: .startFrameRecording
+                )?.first
+        )
+        XCTAssertNil(input.2.recordingExternalStorage)
+    }
+
+    func test_stopFrameRecording_coordinatorWasCalledWithExpectedValues() async throws {
+        let mockCoordinatorClient = MockDefaultAPIEndpoints()
+        let call = Call(
+            from: .init(call: .dummy(), members: [], ownCapabilities: []),
+            coordinatorClient: mockCoordinatorClient,
+            callController: .dummy(defaultAPI: mockCoordinatorClient)
+        )
+
+        _ = try? await call.stopFrameRecording()
+
+        let input = try XCTUnwrap(
+            mockCoordinatorClient
+                .recordedInputPayload(
+                    (String, String).self,
+                    for: .stopFrameRecording
+                )?.first
+        )
+        XCTAssertEqual(call.callType, input.0)
+        XCTAssertEqual(call.callId, input.1)
+    }
+
+    func test_updateState_fromFrameRecordingStartedEvent() async throws {
+        try await assertUpdateState(
+            with: [
+                .init(
+                    event: .typeCallFrameRecordingStartedEvent(
+                        .init(
+                            call: .dummy(),
+                            callCid: callCid,
+                            createdAt: .init(),
+                            egressId: .unique
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: true
+                )
+            ]
+        )
+    }
+
+    func test_updateState_frameRecordingStarted_fromFrameRecordingStoppedEvent() async throws {
+        try await assertUpdateState(
+            with: [
+                .init(
+                    event: .typeCallFrameRecordingStartedEvent(
+                        .init(
+                            call: .dummy(),
+                            callCid: callCid,
+                            createdAt: .init(),
+                            egressId: .unique
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: true
+                ),
+                .init(
+                    event: .typeCallFrameRecordingStoppedEvent(
+                        .init(
+                            call: .dummy(),
+                            callCid: callCid,
+                            createdAt: .init(),
+                            egressId: .unique
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: false
+                )
+            ]
+        )
+    }
+
+    func test_updateState_frameRecordingStarted_fromFrameRecordingFailedEvent() async throws {
+        try await assertUpdateState(
+            with: [
+                .init(
+                    event: .typeCallFrameRecordingStartedEvent(
+                        .init(
+                            call: .dummy(),
+                            callCid: callCid,
+                            createdAt: .init(),
+                            egressId: .unique
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: true
+                ),
+                .init(
+                    event: .typeCallFrameRecordingFailedEvent(
+                        .init(
+                            call: .dummy(),
+                            callCid: callCid,
+                            createdAt: .init(),
+                            egressId: .unique
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: false
+                )
+            ]
+        )
+    }
+
+    func test_updateState_frameRecordingStarted_fromFrameReadyEvent_statusRemainsUnchanged() async throws {
+        try await assertUpdateState(
+            with: [
+                .init(
+                    event: .typeCallFrameRecordingStartedEvent(
+                        .init(
+                            call: .dummy(),
+                            callCid: callCid,
+                            createdAt: .init(),
+                            egressId: .unique
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: true
+                ),
+                .init(
+                    event: .typeCallFrameRecordingFrameReadyEvent(
+                        .init(
+                            callCid: callCid,
+                            capturedAt: .init(),
+                            createdAt: .init(),
+                            egressId: .unique,
+                            sessionId: .unique,
+                            trackType: "TRACK_TYPE_VIDEO",
+                            url: .unique,
+                            users: [:]
+                        )
+                    ),
+                    keyPath: \.state.frameRecordingStatus,
+                    expected: true
+                )
+            ]
+        )
+    }
+
     // MARK: - setIncomingVideoQualitySettings
 
     func test_setIncomingVideoQualitySettings_updatesCallState() async throws {

--- a/StreamVideoTests/CallState/CallState_Tests.swift
+++ b/StreamVideoTests/CallState/CallState_Tests.swift
@@ -300,6 +300,33 @@ final class CallState_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(subject.duration, 0)
     }
 
+    // MARK: - Frame recording
+
+    func test_update_fromCallResponse_withRunningFrameRecording_setsFrameRecordingStatus() {
+        let subject = CallState(.dummy())
+
+        subject.update(
+            from: CallResponse.dummy(
+                egress: .dummy(frameRecording: .init(status: "running"))
+            )
+        )
+
+        XCTAssertEqual(subject.frameRecordingStatus, true)
+    }
+
+    func test_update_fromCallResponse_withoutFrameRecording_resetsFrameRecordingStatus() {
+        let subject = CallState(.dummy())
+        subject.update(
+            from: CallResponse.dummy(
+                egress: .dummy(frameRecording: .init(status: "running"))
+            )
+        )
+
+        subject.update(from: CallResponse.dummy(egress: .dummy()))
+
+        XCTAssertEqual(subject.frameRecordingStatus, false)
+    }
+
     // MARK: - Private helpers
 
     private func assertParticipantsUpdate(

--- a/StreamVideoTests/Mock/MockDefaultAPIEndpoints.swift
+++ b/StreamVideoTests/Mock/MockDefaultAPIEndpoints.swift
@@ -54,10 +54,12 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
         case stopRTMPBroadcast
         case startHLSBroadcasting
         case startClosedCaptions
+        case startFrameRecording
         case startRecording
         case startTranscription
         case stopHLSBroadcasting
         case stopClosedCaptions
+        case stopFrameRecording
         case stopLive
         case stopRecording
         case stopTranscription
@@ -106,10 +108,12 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
         case stopRTMPBroadcast(type: String, id: String, name: String)
         case startHLSBroadcasting(type: String, id: String)
         case startClosedCaptions(type: String, id: String, request: StartClosedCaptionsRequest)
+        case startFrameRecording(type: String, id: String, request: StartFrameRecordingRequest)
         case startRecording(type: String, id: String, request: StartRecordingRequest)
         case startTranscription(type: String, id: String, request: StartTranscriptionRequest)
         case stopHLSBroadcasting(type: String, id: String)
         case stopClosedCaptions(type: String, id: String, request: StopClosedCaptionsRequest)
+        case stopFrameRecording(type: String, id: String)
         case stopLive(type: String, id: String, request: StopLiveRequest)
         case stopRecording(type: String, id: String)
         case stopTranscription(type: String, id: String, request: StopTranscriptionRequest)
@@ -185,6 +189,8 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
                 return (type, id)
             case let .startClosedCaptions(type, id, request):
                 return (type, id, request)
+            case let .startFrameRecording(type, id, request):
+                return (type, id, request)
             case let .startRecording(type, id, request):
                 return (type, id, request)
             case let .startTranscription(type, id, request):
@@ -193,6 +199,8 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
                 return (type, id)
             case let .stopClosedCaptions(type, id, request):
                 return (type, id, request)
+            case let .stopFrameRecording(type, id):
+                return (type, id)
             case let .stopLive(type, id, request):
                 return (type, id, request)
             case let .stopRecording(type, id):
@@ -445,6 +453,17 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
         return try stubbedResult(for: .startClosedCaptions)
     }
 
+    func startFrameRecording(
+        type: String,
+        id: String,
+        startFrameRecordingRequest: StartFrameRecordingRequest
+    ) async throws -> StartFrameRecordingResponse {
+        stubbedFunctionInput[.startFrameRecording]?.append(
+            .startFrameRecording(type: type, id: id, request: startFrameRecordingRequest)
+        )
+        return try stubbedResult(for: .startFrameRecording)
+    }
+
     func startRecording(
         type: String,
         id: String,
@@ -482,6 +501,11 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
             .stopClosedCaptions(type: type, id: id, request: stopClosedCaptionsRequest)
         )
         return try stubbedResult(for: .stopClosedCaptions)
+    }
+
+    func stopFrameRecording(type: String, id: String) async throws -> StopFrameRecordingResponse {
+        stubbedFunctionInput[.stopFrameRecording]?.append(.stopFrameRecording(type: type, id: id))
+        return try stubbedResult(for: .stopFrameRecording)
     }
 
     func stopLive(type: String, id: String, stopLiveRequest: StopLiveRequest) async throws -> StopLiveResponse {

--- a/StreamVideoTests/Utilities/Dummy/EgressResponse+Dummy.swift
+++ b/StreamVideoTests/Utilities/Dummy/EgressResponse+Dummy.swift
@@ -8,9 +8,15 @@ import StreamVideo
 extension EgressResponse {
     static func dummy(
         broadcasting: Bool = false,
+        frameRecording: FrameRecordingResponse? = nil,
         hls: EgressHLSResponse? = nil,
         rtmps: [EgressRTMPResponse] = []
     ) -> EgressResponse {
-        .init(broadcasting: broadcasting, hls: hls, rtmps: rtmps)
+        .init(
+            broadcasting: broadcasting,
+            frameRecording: frameRecording,
+            hls: hls,
+            rtmps: rtmps
+        )
     }
 }


### PR DESCRIPTION
## 🎯 Goal

Frame recording was reachable on the JS SDK but not on iOS. This closes that gap (audit finding **G2**, and the `Frame recording` row of the capability matrix).

## 🛠 Implementation

`startFrameRecording` / `stopFrameRecording` were already generated on the concrete `DefaultAPI`, but they were the **only two** endpoints missing from the `DefaultAPIEndpoints` protocol. `Call.coordinatorClient` is typed as that protocol, so frame recording was genuinely unreachable rather than merely un-wrapped — a wrapper alone would not have compiled. I checked the other nine endpoints the audit lists as unexposed (`deleteCall`, `getEdges`, `listTranscriptions`, …) and all nine are already in the protocol, so this is specific to frame recording.

- **`Call`** — `startFrameRecording(recordingExternalStorage:)` and `stopFrameRecording()`.
- **`CallState`** — new `frameRecordingStatus`. The four frame recording events were all matched and discarded (`break`); started sets `true`, stopped/failed set `false`, and `frameReady` stays a no-op since captured frames are delivered through event subscriptions. Also derived from `egress.frameRecording` on every call response, using the same `"running"` rule already applied to the composite, individual and raw recording flags.
- **`DefaultAPI.swift`** — the two missing protocol requirements, placed where the generator's own ordering puts them. This file is excluded from swiftformat (`--exclude **/OpenApi`), so the existing separator whitespace is preserved to keep regeneration a no-op.

## 🤝 Consistency with the other SDKs

JS is the only other platform that exposes this, and it applies **no capability check** — `OwnCapability` has no frame recording case, so none was added here either. Swift's convention is to flatten a single-field request object into a named parameter, exactly as `startTranscription(transcriptionExternalStorage:)` does, so `recordingExternalStorage: String? = nil` is the matching shape rather than passing a request object.

Neither SDK previously tracked frame recording status. JS's `updateFromCallResponse` derives `recording` / `individualRecording` / `rawRecording` with `status === 'running'` — the identical rule Swift's `didUpdate(_ egress:)` already used — so `frameRecordingStatus` extends that existing family rather than introducing a new pattern.

Mode, quality and capture interval are configured through the call type's frame recording settings and were already reachable via `Call.update(settingsOverride:)` (`CallSettingsRequest.frameRecording`), so they were never part of this gap.

## 🧪 Testing

Nine new tests, all passing (`StreamVideoTests`, iPhone 16 / iOS 18.3.1):

- coordinator called with the expected type, id and payload for start (with and without external storage) and stop
- `frameRecordingStatus` transitions for the started, stopped and failed events, and that `frameReady` leaves it unchanged
- `frameRecordingStatus` set from a call response carrying a running frame recording, and reset when it is absent

⚠️ One thing worth flagging for CI: the first test executed in `Call_Tests` absorbs the process cold-start cost and timed out against XCTest's 2-minute per-test allowance on the first cold run here. It passes consistently once the build is warm (verified by running it behind an earlier-sorting test). This is a pre-existing property of the suite, not something this PR introduces.

## ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform)
- [x] Documented code (public API documented with DocC comments)
- [x] Changelog updated
- [x] Unit tests added