### PR TITLE
[Feature] Expose getEdges on StreamVideo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- `StreamVideo.getEdges()` returns the list of edges (datacenters) available for hosting calls, bringing iOS in line with the JavaScript and Android SDKs.
-- `Call.deleteRecording(callSessionId:filename:)` for deleting a recording of a call session, matching the JavaScript SDK's `deleteRecording`.
+- `StreamVideo.getEdges()` returns the list of edges (datacenters) available for hosting calls [#1247](https://github.com/GetStream/stream-video-swift/pull/1247).
+- `Call.deleteRecording(callSessionId:filename:)` for deleting a recording of a call session [#1244](https://github.com/GetStream/stream-video-swift/pull/1244).
 - Added `Call.delete(hard:)` for deleting a call. [#1243](https://github.com/GetStream/stream-video-swift/pull/1243)
 - `CallDeletedEvent` now updates `Call.state` instead of being ignored. [#1243](https://github.com/GetStream/stream-video-swift/pull/1243)
 - `Call.startFrameRecording(recordingExternalStorage:)` and `Call.stopFrameRecording()`, along with the `CallState.frameRecordingStatus` property that tracks frame recording for the active call. [#1246](https://github.com/GetStream/stream-video-swift/pull/1246)
-- `Call.stopAllRTMPBroadcasts()` to stop every RTMP-out broadcast of a call in one call, matching the JavaScript SDK's `stopAllRTMPBroadcasts`.
+- `Call.stopAllRTMPBroadcasts()` to stop every RTMP-out broadcast of a call in one call [#1245](https://github.com/GetStream/stream-video-swift/pull/1245).
 
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `StreamVideo.getEdges()` returns the list of edges (datacenters) available for hosting calls, bringing iOS in line with the JavaScript and Android SDKs.
+
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 

--- a/Sources/StreamVideo/StreamVideo.swift
+++ b/Sources/StreamVideo/StreamVideo.swift
@@ -337,7 +337,13 @@ public class StreamVideo: ObservableObject, @unchecked Sendable {
     public func listDevices() async throws -> [Device] {
         try await coordinatorClient.listDevices().devices
     }
-    
+
+    /// Lists the edges (datacenters) available for hosting calls.
+    /// - Returns: an array of `EdgeResponse`s.
+    public func getEdges() async throws -> [EdgeResponse] {
+        try await coordinatorClient.getEdges().edges
+    }
+
     /// Disconnects the current `StreamVideo` client.
     public func disconnect() async {
         await webSocketClient?.disconnect()

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -71,6 +71,20 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             .assertEventually { try await $0.client.listDevices().isEmpty }
     }
 
+    // MARK: - Get Edges
+
+    /// Note: the coordinator currently returns an empty `latencyTestUrl` for
+    /// every edge — latency-based edge selection happens server-side — so this
+    /// only asserts the fields the API actually populates.
+    func test_getEdges_returnsEdgesWithIdentifierAndLocation() async throws {
+        try await helpers
+            .callFlow(id: .unique, type: .default, userId: .unique)
+            .perform { try await $0.client.getEdges() }
+            .assert { !$0.value.isEmpty }
+            .assert { $0.value.allSatisfy { edge in !edge.id.isEmpty } }
+            .assert { $0.value.allSatisfy { edge in !edge.continentCode.isEmpty && !edge.countryIsoCode.isEmpty } }
+    }
+
     // MARK: Create
 
     func test_create_callContainsExpectedMembers() async throws {

--- a/StreamVideoTests/StreamVideo_Tests.swift
+++ b/StreamVideoTests/StreamVideo_Tests.swift
@@ -346,6 +346,43 @@ final class StreamVideo_Tests: StreamVideoTestCase, @unchecked Sendable {
         XCTAssert(streamVideo.state.connection == .initialized)
     }
 
+    // MARK: - getEdges
+
+    func test_streamVideo_getEdges_returnsUnwrappedEdges() async throws {
+        // Given
+        let expected = makeEdgeResponse()
+        let httpClient = HTTPClient_Mock()
+        httpClient.dataResponses = [
+            try JSONEncoder.streamCore.encode(
+                GetEdgesResponse(duration: "1", edges: [expected])
+            )
+        ]
+        let streamVideo = StreamVideo.mock(httpClient: httpClient)
+        self.streamVideo = streamVideo
+
+        // When
+        let edges = try await streamVideo.getEdges()
+
+        // Then
+        XCTAssertEqual(edges, [expected])
+    }
+
+    func test_streamVideo_getEdges_propagatesFailure() async throws {
+        // Given
+        let httpClient = HTTPClient_Mock()
+        let streamVideo = StreamVideo.mock(httpClient: httpClient)
+        self.streamVideo = streamVideo
+
+        // When
+        do {
+            _ = try await streamVideo.getEdges()
+            XCTFail("getEdges should fail when no response is available")
+        } catch {
+            // Then
+            XCTAssertEqual(httpClient.requestCounter, 1)
+        }
+    }
+
     // MARK: - Event Publisher & Subscribe Tests
 
     func test_eventPublisher_filtersOnlyCoordinatorEvents() async {
@@ -500,6 +537,21 @@ final class StreamVideo_Tests: StreamVideoTestCase, @unchecked Sendable {
             role: "user",
             teams: [],
             updatedAt: Date()
+        )
+    }
+
+    private func makeEdgeResponse() -> EdgeResponse {
+        EdgeResponse(
+            continentCode: "EU",
+            countryIsoCode: "NL",
+            green: 1,
+            id: "amsterdam",
+            latencyTestUrl: "https://latency.stream-io-video.com/amsterdam",
+            latitude: 52.3676,
+            longitude: 4.9041,
+            red: 3,
+            subdivisionIsoCode: "NH",
+            yellow: 2
         )
     }
 


### PR DESCRIPTION
## 🎯 Goal

Closes the **Edge list** gap identified in the cross-SDK consistency audit. `getEdges` was already generated in `DefaultAPI` but had no public wrapper, making iOS the only SDK where an app cannot list the edges available for hosting calls.

| SDK | Method | Owner | Returns |
|---|---|---|---|
| JavaScript | `edges()` | `StreamVideoClient` | `GetEdgesResponse` |
| Android | `getEdges()` | `StreamVideo` | `Result<List<EdgeData>>` |
| **iOS (this PR)** | `getEdges()` | `StreamVideo` | `[EdgeResponse]` |

## 🛠 Implementation

```swift
/// Lists the edges (datacenters) available for hosting calls.
/// - Returns: an array of `EdgeResponse`s.
public func getEdges() async throws -> [EdgeResponse] {
    try await coordinatorClient.getEdges().edges
}
```

Three choices, each made for cross-SDK consistency:

- **Name** — `getEdges`, matching Android and the generated operation name. JS's `edges()` is the outlier.
- **Owner** — client-level, as it is on both other SDKs. No call context is involved.
- **Shape** — the unwrapped array rather than the envelope. This matches Android (`List<EdgeData>`, mapped from `EdgeResponse`) and the neighbouring `listDevices()`, which already does `.devices`. Field-wise `EdgeResponse` is a superset of Android's `EdgeData` — Android drops `continentCode`, `countryIsoCode` and `subdivisionIsoCode` — so iOS surfaces everything JS does.

## 🧪 Testing

Two unit tests in `StreamVideo_Tests` (decode/unwrap round-trip, error propagation) and one integration test in `Call_IntegrationTests`. All pass, along with the rest of the `StreamVideo_Tests` suite.

One thing worth flagging from running the integration test against the live coordinator: it returns 31 edges, and **`latencyTestUrl` is empty on every one of them** (`subdivisionIsoCode` is empty on many too). Latency-based edge selection is server-side now, which is consistent with the SDK never reading `latencyTestUrl` anywhere. The integration test therefore asserts only the fields the API actually populates — `id`, `continentCode`, `countryIsoCode` — with a comment explaining why. The field stays on the model since it is part of the response contract and both other SDKs expose it.

## ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `getEdges()` to retrieve available call-hosting locations and regional details.

* **Documentation**
  * Updated the changelog with the new edge retrieval capability and related call management updates.

* **Tests**
  * Added coverage for successful responses, error handling, request behavior, and edge metadata validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->