### PR TITLE
Declare frame recording endpoints in DefaultAPIEndpoints

### DIFF
--- a/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
+++ b/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
@@ -1280,7 +1280,10 @@ protocol DefaultAPIEndpoints {
         
     func startClosedCaptions(type: String, id: String, startClosedCaptionsRequest: StartClosedCaptionsRequest) async throws
         -> StartClosedCaptionsResponse
-        
+
+    func startFrameRecording(type: String, id: String, startFrameRecordingRequest: StartFrameRecordingRequest) async throws
+        -> StartFrameRecordingResponse
+
     func startRecording(
         type: String,
         id: String,
@@ -1295,7 +1298,9 @@ protocol DefaultAPIEndpoints {
         
     func stopClosedCaptions(type: String, id: String, stopClosedCaptionsRequest: StopClosedCaptionsRequest) async throws
         -> StopClosedCaptionsResponse
-        
+
+    func stopFrameRecording(type: String, id: String) async throws -> StopFrameRecordingResponse
+
     func stopLive(type: String, id: String, stopLiveRequest: StopLiveRequest) async throws -> StopLiveResponse
         
     func stopRecording(type: String, id: String, recordingType: String) async throws -> StopRecordingResponse


### PR DESCRIPTION
### 🔗 Issue Links

_N/A_

### 🎯 Goal

A regeneration of `DefaultAPI.swift` against a newer OpenAPI spec was reviewed to see what — if anything — should be carried over into the current file. Almost all of it was rejected (see below), but it did surface one real gap worth fixing: two endpoints are implemented on `DefaultAPI` but were never declared on the `DefaultAPIEndpoints` protocol, so they can't be reached through the protocol abstraction.

### 📝 Summary

- Declare `startFrameRecording(type:id:startFrameRecordingRequest:)` on `DefaultAPIEndpoints`.
- Declare `stopFrameRecording(type:id:)` on `DefaultAPIEndpoints`.

### 🛠 Implementation

Both methods already exist as `open func` on `DefaultAPI`; only the protocol declarations were missing. Conformance still compiled because a protocol simply doesn't require them, which is why the gap went unnoticed. Declarations are placed next to their `startClosedCaptions` / `stopClosedCaptions` neighbours, matching the ordering the generator produces.

Deliberately **not** taken from the regenerated file:

- The `/video/…` → `/api/v2/video/…` path change on all 46 endpoints — staying on the current paths.
- Removal of the file header, `HTTPMethod`, `Request`, `DefaultAPITransport`, `DefaultAPIClientMiddleware`, `EmptyResponse`, and the switch to `import StreamCore`.
- `JSONDecoder/Encoder.streamCore` → `.default`.
- Signature reflowing and indentation churn.
- Deletion of `createDevice`, `deleteDevice`, `listDevices`, `createGuest`, `videoConnect` — all five are called from `StreamVideo.swift`.
- Renaming `sendVideoReaction`'s request/response to `SendVideoReactionRequest`/`SendVideoReactionResponse` — the generated models still only define `SendReactionRequest`/`SendReactionResponse`, so the rename does not compile.

All 46 methods present in both versions were compared with whitespace stripped and the `/api/v2` prefix normalised away: **no existing method gained a parameter**. The new endpoints in the newer spec (aggregate/session stats, call reports, participant session metrics, SIP resolution) are intentionally left out of this PR.

### 🎨 Showcase

_N/A — no user-facing surface._

### 🧪 Manual Testing Notes

No behavioural change: no request path, HTTP method, payload, or call site is touched. `xcodebuild -scheme StreamVideo` builds cleanly.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

`DefaultAPIEndpoints` is internal and no behaviour changes, so no changelog entry and no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)