### PR TITLE
Report user session id with collected feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 - `CallParticipant.withUpdated(...)` no longer resets `source` to `.webRTCUnspecified`, which previously broke the `videoIngressSource` and `participantSource` sort comparators after any participant update. `source` is now also part of `CallParticipant` equality. [#1251](https://github.com/GetStream/stream-video-swift/pull/1251)
+- `Call.collectUserFeedback(rating:reason:custom:)` now reports the call's user session id, so feedback can be correlated with the call session and its stats on the backend. The id is retained after the call ends, which makes it available to post-call rating screens. [#1254](https://github.com/GetStream/stream-video-swift/pull/1254)
 
 # [1.51.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.51.0)
 _August 13, 2026_

--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -76,6 +76,14 @@ class CallController: @unchecked Sendable {
     private var webRTCParticipantsObserver: AnyCancellable?
     private var participants: CollectionDelayedUpdateObserver<[String: CallParticipant]>?
 
+    /// The latest non-empty session id observed for this call.
+    ///
+    /// `WebRTCStateAdapter.cleanUp()` resets the session id while the call is
+    /// torn down, but user feedback is usually collected *after* the call has
+    /// ended. Retaining the id here keeps it available to
+    /// ``collectUserFeedback(custom:rating:reason:)``.
+    @Atomic private var lastSessionId: String?
+
     private let disposableBag = DisposableBag()
 
     init(
@@ -479,6 +487,11 @@ class CallController: @unchecked Sendable {
 
     /// Collects user feedback asynchronously.
     ///
+    /// The submission carries the call's session id, which allows the feedback
+    /// to be correlated with the call session (and its stats) on the backend.
+    /// It is reported even when the feedback is collected after the call
+    /// ended, which is the common case for a post-call rating screen.
+    ///
     /// - Parameters:
     ///   - custom: Optional custom data in the form of a dictionary of String keys and RawJSON values.
     ///   - rating: Optional rating provided by the user.
@@ -498,7 +511,8 @@ class CallController: @unchecked Sendable {
                 rating: rating,
                 reason: reason,
                 sdk: SystemEnvironment.sdkName,
-                sdkVersion: SystemEnvironment.version
+                sdkVersion: SystemEnvironment.version,
+                userSessionId: lastSessionId
             )
         )
     }
@@ -790,7 +804,16 @@ class CallController: @unchecked Sendable {
         webRTCClientSessionIDObserver = await webRTCCoordinator
             .stateAdapter
             .$sessionID
-            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in self?.call?.state.sessionId = $0 }
+            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] sessionId in
+                guard let self else { return }
+                call?.state.sessionId = sessionId
+                /// The empty value emitted during cleanUp is skipped on
+                /// purpose, so that feedback collected after the call ended
+                /// still reports the session it refers to.
+                if !sessionId.isEmpty {
+                    lastSessionId = sessionId
+                }
+            }
     }
 
     private func observeStatsReporterUpdates() async {

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -610,6 +610,43 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         }
     }
 
+    // MARK: - collectUserFeedback
+
+    func test_collectUserFeedback_duringCall_reportsSessionId() async throws {
+        let (subject, defaultAPI, factory) = makeSubjectWithMockAPI()
+        let call = await MockCall(.dummy())
+        subject.call = call
+        let expected = await setSessionId(.unique, on: factory, observedBy: call)
+        defaultAPI.stub(for: .collectUserFeedback, with: CollectUserFeedbackResponse(duration: ""))
+
+        _ = try await subject.collectUserFeedback(rating: 5)
+
+        XCTAssertEqual(try collectedFeedbackRequest(from: defaultAPI).userSessionId, expected)
+    }
+
+    func test_collectUserFeedback_afterCallEnded_reportsSessionIdOfEndedSession() async throws {
+        let (subject, defaultAPI, factory) = makeSubjectWithMockAPI()
+        let call = await MockCall(.dummy())
+        subject.call = call
+        let expected = await setSessionId(.unique, on: factory, observedBy: call)
+        /// The state adapter resets its session id while the call is torn down,
+        /// but a post-call rating screen collects the feedback afterwards.
+        subject.cleanUp()
+        await fulfillment {
+            await factory
+                .mockCoordinatorStack
+                .coordinator
+                .stateAdapter
+                .sessionID
+                .isEmpty
+        }
+        defaultAPI.stub(for: .collectUserFeedback, with: CollectUserFeedbackResponse(duration: ""))
+
+        _ = try await subject.collectUserFeedback(rating: 5)
+
+        XCTAssertEqual(try collectedFeedbackRequest(from: defaultAPI).userSessionId, expected)
+    }
+
     // MARK: - cleanUp
 
     func test_cleanUp_callIsNil() async throws {
@@ -1252,6 +1289,57 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
     }
 
     // MARK: - Private helpers
+
+    private func makeSubjectWithMockAPI() -> (
+        CallController,
+        MockDefaultAPIEndpoints,
+        MockWebRTCCoordinatorFactory
+    ) {
+        let defaultAPI = MockDefaultAPIEndpoints()
+        let webRTCCoordinatorFactory = MockWebRTCCoordinatorFactory(
+            videoConfig: Self.videoConfig
+        )
+        let subject = CallController(
+            defaultAPI: defaultAPI,
+            user: user,
+            callId: callId,
+            callType: callType,
+            apiKey: apiKey,
+            videoConfig: Self.videoConfig,
+            initialCallSettings: initialCallSettings,
+            cachedLocation: cachedLocation,
+            webRTCCoordinatorFactory: webRTCCoordinatorFactory
+        )
+        return (subject, defaultAPI, webRTCCoordinatorFactory)
+    }
+
+    /// Sets the session id on the state adapter and waits until the controller
+    /// has observed it, using the call state that the same observation updates.
+    @discardableResult
+    private func setSessionId(
+        _ value: String,
+        on factory: MockWebRTCCoordinatorFactory,
+        observedBy call: MockCall
+    ) async -> String {
+        await factory.mockCoordinatorStack.coordinator.stateAdapter.set(sessionID: value)
+        await fulfilmentInMainActor { call.state.sessionId == value }
+        return value
+    }
+
+    private func collectedFeedbackRequest(
+        from defaultAPI: MockDefaultAPIEndpoints,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> CollectUserFeedbackRequest {
+        try XCTUnwrap(
+            defaultAPI.recordedInputPayload(
+                (String, String, CollectUserFeedbackRequest).self,
+                for: .collectUserFeedback
+            )?.first?.2,
+            file: file,
+            line: line
+        )
+    }
 
     private func assertTransitionToStage(
         _ id: WebRTCCoordinator.StateMachine.Stage.ID,


### PR DESCRIPTION
Addresses the D7 finding from the cross-SDK consistency audit on iOS.

`CollectUserFeedbackRequest` has a `userSessionId` field that the SDK never set, so feedback submitted from iOS could not be joined to the call session it refers to — or to that session's stats. Both other platforms report it: JS sends `user_session_id`, Android passes `sessionId`.

### Why not read the session id at submission time

`WebRTCStateAdapter.cleanUp()` resets the session id to `""` while the call is torn down, reached on every call end via `leave()` → Leaving → CleanUp, and directly via `CallController.cleanUp()`. User feedback is typically collected *after* that, from a post-call rating screen — the pattern in our own `18-call-quality-rating.swift` docs. A live read therefore ships `"user_session_id": ""` in exactly the case the finding is about.

So `CallController` retains the latest non-empty session id from the observer that already tracks session-id changes, and reports that.

### Notes

- The id is available as long as feedback is submitted from the same `Call` instance that joined. An app that re-creates the call via `streamVideo.call(callType:callId:)` for its rating screen gets a fresh controller and no id. JS is instance-scoped in the same way.
- `@Atomic` is needed because `lastSessionId` is written on `@MainActor` and read from the `nonisolated async` `collectUserFeedback`.

### Left out of scope

Two parts of D7 that are cross-SDK decisions rather than iOS-side fixes:

- The `sdk` identifier naming split — `stream-ios` vs `stream-js`/`stream-react` vs `stream-video-android`. `SystemEnvironment.sdkName` rides on every client event, not just feedback, so renaming it unilaterally would break existing dashboards.
- JS's `x-stream-platform-data` entry inside `custom`. It's 1-of-3, and injecting SDK data into the user-supplied `custom` dictionary risks key collisions in a payload apps control.

### Testing

Two tests added to `CallController_Tests`, both driving real paths — `test_collectUserFeedback_afterCallEnded_reportsSessionIdOfEndedSession` exercises the actual `cleanUp()` teardown and fails against a live read (`("Optional("")") is not equal to ("Optional("2F59B930-…")")`). Full class: 47 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User feedback now includes the call’s latest WebRTC session ID for accurate backend correlation.
  * Session information remains available when feedback is submitted after call cleanup.
  * Empty session updates no longer overwrite the retained session ID.

* **Documentation**
  * Updated the upcoming changelog with the feedback session ID improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->