### PR TITLE
Report fast reconnect duration in join telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Transient peer-connection disconnections no longer trigger an immediate full rejoin, allowing the existing ICE restart flow to recover the session. [#1231](https://github.com/GetStream/stream-video-swift/pull/1231)
 - `CallParticipant.withUpdated(...)` no longer resets `source` to `.webRTCUnspecified`, which previously broke the `videoIngressSource` and `participantSource` sort comparators after any participant update. `source` is now also part of `CallParticipant` equality. [#1251](https://github.com/GetStream/stream-video-swift/pull/1251)
+- Fast reconnects no longer report a duration of zero in SFU telemetry. The `.fast` branch of the join telemetry shadowed the value that carried the elapsed time, so `timeSeconds` was always `0`. [#1255](https://github.com/GetStream/stream-video-swift/pull/1255)
 
 # [1.51.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.51.0)
 _August 13, 2026_

--- a/Sources/StreamVideo/WebRTC/v2/StateMachine/Components/JoinedStateTelemetryReporter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/StateMachine/Components/JoinedStateTelemetryReporter.swift
@@ -40,7 +40,6 @@ struct JoinedStateTelemetryReporter {
             case .regular:
                 return .connectionTimeSeconds(duration)
             case .fast:
-                var reconnection = Stream_Video_Sfu_Signal_Reconnection()
                 reconnection.strategy = .fast
                 return .reconnection(reconnection)
             case .rejoin:

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Components/JoinedStateTelemetryReporter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Components/JoinedStateTelemetryReporter_Tests.swift
@@ -1,0 +1,117 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamVideo
+import XCTest
+
+final class JoinedStateTelemetryReporter_Tests: XCTestCase, @unchecked Sendable {
+
+    private let sessionId: String = .unique
+    private let unifiedSessionId: String = .unique
+
+    // MARK: - regular
+
+    func test_reportTelemetry_regular_sendsConnectionTime() async throws {
+        let (subject, sfuStack) = makeSubject(flowType: .regular)
+
+        let telemetry = try await reportTelemetry(subject, sfuStack: sfuStack)
+
+        switch telemetry.data {
+        case let .connectionTimeSeconds(value):
+            XCTAssertGreaterThan(value, 0)
+        default:
+            XCTFail("Unexpected telemetry data \(String(describing: telemetry.data)).")
+        }
+    }
+
+    // MARK: - reconnections
+
+    func test_reportTelemetry_fast_sendsStrategyAndDuration() async throws {
+        let (subject, sfuStack) = makeSubject(flowType: .fast)
+
+        let telemetry = try await reportTelemetry(subject, sfuStack: sfuStack)
+
+        try assertReconnection(telemetry, strategy: .fast)
+    }
+
+    func test_reportTelemetry_rejoin_sendsStrategyAndDuration() async throws {
+        let (subject, sfuStack) = makeSubject(flowType: .rejoin)
+
+        let telemetry = try await reportTelemetry(subject, sfuStack: sfuStack)
+
+        try assertReconnection(telemetry, strategy: .rejoin)
+    }
+
+    func test_reportTelemetry_migrate_sendsStrategyAndDuration() async throws {
+        let (subject, sfuStack) = makeSubject(flowType: .migrate)
+
+        let telemetry = try await reportTelemetry(subject, sfuStack: sfuStack)
+
+        try assertReconnection(telemetry, strategy: .migrate)
+    }
+
+    // MARK: - session identifiers
+
+    func test_reportTelemetry_forwardsSessionIdentifiers() async throws {
+        let (subject, sfuStack) = makeSubject(flowType: .fast)
+
+        _ = try await reportTelemetry(subject, sfuStack: sfuStack)
+
+        let request = try XCTUnwrap(sfuStack.service.sendStatsWasCalledWithRequest)
+        XCTAssertEqual(request.sessionID, sessionId)
+        XCTAssertEqual(request.unifiedSessionID, unifiedSessionId)
+    }
+
+    // MARK: - Private
+
+    private func makeSubject(
+        flowType: JoinedStateTelemetryReporter.FlowType
+    ) -> (JoinedStateTelemetryReporter, MockSFUStack) {
+        var subject = JoinedStateTelemetryReporter()
+        subject.flowType = flowType
+        return (subject, MockSFUStack())
+    }
+
+    private func reportTelemetry(
+        _ subject: JoinedStateTelemetryReporter,
+        sfuStack: MockSFUStack,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws -> Stream_Video_Sfu_Signal_Telemetry {
+        /// The reported duration is measured from the moment the reporter was
+        /// created, so we let some time pass to assert on a non-zero value.
+        await wait(for: 0.1)
+        await subject.reportTelemetry(
+            sessionId: sessionId,
+            unifiedSessionId: unifiedSessionId,
+            sfuAdapter: sfuStack.adapter
+        )
+        return try XCTUnwrap(
+            sfuStack.service.sendStatsWasCalledWithRequest?.telemetry,
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertReconnection(
+        _ telemetry: Stream_Video_Sfu_Signal_Telemetry,
+        strategy: Stream_Video_Sfu_Models_WebsocketReconnectStrategy,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        switch telemetry.data {
+        case let .reconnection(reconnection):
+            XCTAssertEqual(reconnection.strategy, strategy, file: file, line: line)
+            /// The duration used to be dropped for `.fast`, because the branch
+            /// shadowed the reconnection value that carried it.
+            XCTAssertGreaterThan(reconnection.timeSeconds, 0, file: file, line: line)
+        default:
+            XCTFail(
+                "Unexpected telemetry data \(String(describing: telemetry.data)).",
+                file: file,
+                line: line
+            )
+        }
+    }
+}

--- a/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/WebRTC/v2/StateMachine/Stages/WebRTCCoordinatorStateMachine_JoiningStageTests.swift
@@ -1130,6 +1130,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             XCTFail()
         case let .reconnection(reconnection):
             XCTAssertEqual(reconnection.strategy, .rejoin)
+            XCTAssertGreaterThan(reconnection.timeSeconds, 0)
         case .none:
             XCTFail()
         }
@@ -1337,6 +1338,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             XCTFail()
         case let .reconnection(reconnection):
             XCTAssertEqual(reconnection.strategy, .fast)
+            XCTAssertGreaterThan(reconnection.timeSeconds, 0)
         case .none:
             XCTFail()
         }
@@ -1779,6 +1781,7 @@ final class WebRTCCoordinatorStateMachine_JoiningStageTests: XCTestCase, @unchec
             XCTFail()
         case let .reconnection(reconnection):
             XCTAssertEqual(reconnection.strategy, .migrate)
+            XCTAssertGreaterThan(reconnection.timeSeconds, 0)
         case .none:
             XCTFail()
         }


### PR DESCRIPTION
Addresses the D5 finding from the cross-SDK consistency audit — flagged High, and the audit's "fix this first" item.

`JoinedStateTelemetryReporter` populates a `Reconnection` value with the elapsed duration, but the `.fast` branch declared a *second* local `reconnection` that shadowed it and set only `strategy`. The shadowed value is what got sent, so `timeSeconds` was `0` for every fast reconnect from iOS — structurally zero, silently dragging any cross-platform duration average down. `.rejoin` and `.migrate` mutate the outer value and were always correct, which is why this survived review.

JS and Android both send strategy and time together in one payload, so this is a Swift-only defect rather than a design difference.

```diff
             case .fast:
-                var reconnection = Stream_Video_Sfu_Signal_Reconnection()
                 reconnection.strategy = .fast
                 return .reconnection(reconnection)
```

### Testing

`JoinedStateTelemetryReporter` had no test coverage at all. Added `JoinedStateTelemetryReporter_Tests` covering all four flow types plus session-id forwarding, and verified the `.fast` case genuinely guards the bug — with the fix reverted it fails as:

```
JoinedStateTelemetryReporter_Tests.swift:35: XCTAssertGreaterThan failed: ("0.0") is not greater than ("0.0")
```

while `regular`, `rejoin` and `migrate` stay green, matching the finding's scope.

The three existing `reportsTelemetry` tests in `WebRTCCoordinatorStateMachine_JoiningStageTests` asserted `reconnection.strategy` but never `timeSeconds` — the gap that let a zero duration through the real state-machine flow. They now assert both, and all three pass.

### Note on an unrelated failing test

`test_willTransitionAway_audioReadinessPending_skipsPeerConnections` fails in a full-class run of `WebRTCCoordinatorStateMachine_JoiningStageTests`. It is **pre-existing and unrelated**: it fails the same way on clean `develop` with these changes stashed (52 passed / 1 failed), and passes when run in isolation, so it is ordering-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SFU telemetry now reports the actual elapsed duration for fast reconnect, rejoin, and migration events instead of zero.
  * Connection telemetry now consistently includes reconnection details and session identifiers.

* **Tests**
  * Added coverage verifying connection timing, reconnection strategies, session identifiers, and positive duration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->