### PR TITLE
Sort screensharing participants above pinned ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fast reconnects no longer report a duration of zero in SFU telemetry. The `.fast` branch of the join telemetry shadowed the value that carried the elapsed time, so `timeSeconds` was always `0`. [#1255](https://github.com/GetStream/stream-video-swift/pull/1255)
 - `Call.collectUserFeedback(rating:reason:custom:)` now reports the call's user session id, so feedback can be correlated with the call session and its stats on the backend. The id is retained after the call ends, which makes it available to post-call rating screens. [#1254](https://github.com/GetStream/stream-video-swift/pull/1254)
 
+### 🔄 Changed
+- `defaultSortPreset` and `speakerLayoutSortPreset` now rank screensharing participants above pinned ones. Previously a pinned participant would lead the call even while somebody else was sharing their screen. [#1256](https://github.com/GetStream/stream-video-swift/pull/1256)
+
 # [1.51.0](https://github.com/GetStream/stream-video-swift/releases/tag/1.51.0)
 _August 13, 2026_
 

--- a/Sources/StreamVideo/Utils/Sorting/Presets.swift
+++ b/Sources/StreamVideo/Utils/Sorting/Presets.swift
@@ -14,8 +14,8 @@ public nonisolated(unsafe) let ifInvisible = ifInvisibleBy
 
 /// The default sorting preset.
 public nonisolated(unsafe) let defaultSortPreset = [
-    pinned,
     screenSharing,
+    pinned,
     ifInvisibleBy(
         combineComparators(
             [
@@ -33,8 +33,8 @@ public nonisolated(unsafe) let defaultComparators = defaultSortPreset
 
 /// The sorting preset for speaker layout.
 public nonisolated(unsafe) let speakerLayoutSortPreset = [
-    pinned,
     screenSharing,
+    pinned,
     dominantSpeaker,
     ifInvisibleBy(
         combineComparators(

--- a/StreamVideoTests/Utils/Sorting_Tests.swift
+++ b/StreamVideoTests/Utils/Sorting_Tests.swift
@@ -640,6 +640,45 @@ final class Sorting_Tests: XCTestCase, @unchecked Sendable {
         )
     }
 
+    // MARK: - screenSharing vs pinned precedence
+
+    /// A screensharing participant outranks a pinned one in the default preset.
+    func test_defaultComparators_pinnedAndScreenSharing_screenSharingComesFirst() {
+        assertSort(
+            [
+                .dummy(userId: "A", isScreenSharing: false, pin: PinInfo(isLocal: true, pinnedAt: Date())),
+                .dummy(userId: "B", isScreenSharing: true, pin: nil)
+            ],
+            comparator: combineComparators(defaultSortPreset),
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    /// The speaker layout preset ranks screen sharing above pinning too.
+    func test_speakerLayoutComparators_pinnedAndScreenSharing_screenSharingComesFirst() {
+        assertSort(
+            [
+                .dummy(userId: "A", isScreenSharing: false, pin: PinInfo(isLocal: true, pinnedAt: Date())),
+                .dummy(userId: "B", isScreenSharing: true, pin: nil)
+            ],
+            comparator: combineComparators(speakerLayoutSortPreset),
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
+    /// The paginated preset does not rank screen sharing at all, so a pinned
+    /// participant keeps leading there.
+    func test_paginatedComparators_pinnedAndScreenSharing_pinnedComesFirst() {
+        assertSort(
+            [
+                .dummy(userId: "A", isScreenSharing: true, pin: nil),
+                .dummy(userId: "B", isScreenSharing: false, pin: PinInfo(isLocal: true, pinnedAt: Date()))
+            ],
+            comparator: combineComparators(paginatedLayoutSortPreset),
+            expectedTransformer: { [$0[1], $0[0]] }
+        )
+    }
+
     // MARK: - defaultComparators
 
     /// Test the `defaultComparators` mixed: considering both `pinned` and `ifInvisible` for `publishingVideo`.


### PR DESCRIPTION
Addresses the ordering part of the D3 finding from the cross-SDK consistency audit.

The comparator presets ranked pinning above screen sharing, so when one participant is pinned and another is sharing their screen, iOS led with the pinned participant while the other platforms led with the screenshare. The same call rendered in a different order depending on the platform.

`defaultSortPreset` and `speakerLayoutSortPreset` now rank `screenSharing` before `pinned`. Those are the only two presets where both comparators appear:

| Preset | Change |
|---|---|
| `defaultSortPreset` | `pinned, screenSharing` → `screenSharing, pinned` |
| `speakerLayoutSortPreset` | `pinned, screenSharing` → `screenSharing, pinned` |
| `paginatedLayoutSortPreset` | unchanged — ranks `pinned` and has no `screenSharing` comparator |
| `livestreamOrAudioRoomSortPreset` | unchanged — ranks neither |

### Scope

Deliberately limited to the composition order. The rest of D3 is left for separate changes:

- **Raised hand** — a comparator iOS does not have; follow-up PR.
- **Three-state visibility** — `showTrack: Bool` versus `VISIBLE` / `INVISIBLE` / `UNKNOWN`, and the `ifInvisible` / `ifInvisibleOrUnknown` distinction that rides on it. A participant that has not rendered yet is currently treated as visible and skips activity-based ordering, which matters for scroll.
- **The `ifInvisibleBy(userId)` tiebreaker** — kept as is.

### Testing

Three tests added covering the pinned-versus-screensharing case across the default, speaker layout and paginated presets — the last one asserting that paginated still leads with the pinned participant, so the presets that were already correct stay that way. No existing preset test exercised a pinned participant against a screensharing one, which is how the divergence went unnoticed.

`Sorting_Tests` and `CallState_Tests` (which defaults `sortComparators` to this preset): 102 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated participant sorting so screen-sharing participants appear above pinned participants in default and speaker layouts.
  * Preserved pinned-participant priority in paginated layouts.

* **Documentation**
  * Added a changelog entry describing the updated sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->