### PR TITLE
[v2] Remove deprecated MicrophoneChecker listening APIs

### DIFF
--- a/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/MicrophoneChecker.swift
@@ -2,7 +2,6 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import AVFoundation
 import Combine
 import Foundation
 import StreamVideo
@@ -46,14 +45,6 @@ public final class MicrophoneChecker: ObservableObject {
         return true
     }
 
-    public func startListening(ignoreActiveCall: Bool = false) async {
-        log.warning("Method \(#function) has been deprecated and will be removed in the future.")
-    }
-
-    public func stopListening() async {
-        log.warning("Method \(#function) has been deprecated and will be removed in the future.")
-    }
-    
     // MARK: - private
 
     private func normaliseAndAppend(_ decibel: Float) -> [Float] {

--- a/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
+++ b/StreamVideoSwiftUITests/CallingViews/MicrophoneChecker_Tests.swift
@@ -2,8 +2,6 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import AVFoundation
-import Combine
 import Foundation
 @testable import StreamVideo
 @testable import StreamVideoSwiftUI
@@ -22,7 +20,6 @@ final class MicrophoneChecker_Tests: XCTestCase, @unchecked Sendable {
     }
 
     override func tearDown() async throws {
-        await subject.stopListening()
         InjectedValues[\.callAudioRecorder] = StreamCallAudioRecorder()
         mockAudioRecorder = nil
         mockStreamVideo = nil
@@ -32,7 +29,7 @@ final class MicrophoneChecker_Tests: XCTestCase, @unchecked Sendable {
 
     // MARK: - init
 
-    func test_startListeningAndPostAudioLevels_microphoneCheckerHasExpectedValues() async throws {
+    func test_audioLevelsPostedFromRecorder_microphoneCheckerHasExpectedValues() async throws {
         mockAudioRecorder.startRecording(ignoreActiveCall: true)
 
         let inputs = [


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1994](https://linear.app/stream/issue/IOS-1994/v2-remove-deprecated-microphonechecker-listening-apis)

### 🎯 Goal

Remove the last deprecated public APIs from the Video SwiftUI SDK as the initial v2 cleanup task.

### 📝 Summary

- Removed the deprecated no-op `MicrophoneChecker.startListening(ignoreActiveCall:)` API.
- Removed the deprecated no-op `MicrophoneChecker.stopListening()` API.
- Updated `MicrophoneChecker_Tests` to reflect automatic audio level observation from initialization.

### 🛠 Implementation

`MicrophoneChecker` has observed audio levels automatically from initialization since the slow-network fix in #852. The `startListening` and `stopListening` methods were left as deprecated no-ops that only logged warnings. This PR removes them entirely for v2.

No migration is required for SDK usage: instantiate `MicrophoneChecker` and read `audioLevels` / `isSilent` as before.

### 🎨 Showcase

N/A — no UI changes.

|  Before  |  After  |
| -------- | ------- |
|  N/A   |  N/A  |

### 🧪 Manual Testing Notes

- Confirm `MicrophoneChecker` still reports `audioLevels` and `isSilent` in the lobby without calling start/stop.
- Run `StreamVideoSwiftUITests` (or at least `MicrophoneChecker_Tests`).
- Grep the demo app and any custom `ViewFactory` lobby code for `startListening` / `stopListening` and remove those calls if present.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated microphone listening controls from the microphone checker.
  * Cleaned up unused audio framework dependencies.

* **Tests**
  * Updated microphone checker tests to reflect the simplified listening behavior.
  * Renamed an audio-level test for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->