### PR TITLE
[v2] Add the shared design token system to the Video SDK

### DIFF
--- a/.github/actions/xcode-cache/action.yml
+++ b/.github/actions/xcode-cache/action.yml
@@ -10,5 +10,4 @@ runs:
       id: spm-cache
       with:
         path: spm_cache
-        key: ${{ env.IMAGE }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: ${{ env.IMAGE }}-spm-
+        key: ${{ env.IMAGE }}-spm-${{ hashFiles('Package.swift') }}

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -167,6 +167,8 @@ jobs:
     if: ${{ github.event.inputs.record_snapshots_swiftui != 'true' && github.event.inputs.record_snapshots_uikit != 'true' }}
     steps:
     - uses: actions/checkout@v4.1.1
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/bootstrap
       env:
         INSTALL_INTERFACE_ANALYZER: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# 2.0.0
+
+### ✅ Added
+- New `DesignSystemTokens` in `StreamCoreUI` is used in `VideoAppearance` for primitive UI tokens [#1258](https://github.com/GetStream/stream-video-swift/pull/1258)
+
+### 🔄 Changed
+- The `Appearance` object has been replaced with `VideoAppearance` object [#1258](https://github.com/GetStream/stream-video-swift/pull/1258)
+
 # Upcoming
 
 ### ✅ Added

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/03-video-theme.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/03-video-theme.swift
@@ -10,6 +10,13 @@ import SwiftUI
 @MainActor
 private func content() {
     container {
+        let tokens = DesignSystemTokens()
+        tokens.colors.accentPrimary = .red
+        let appearance = VideoAppearance(tokens: tokens)
+        appearance.colors.indicatorSpeaking = .green
+    }
+
+    container {
         let streamBlue = UIColor(red: 0, green: 108.0 / 255.0, blue: 255.0 / 255.0, alpha: 1)
         var colors = Colors()
         colors.tintColor = Color(streamBlue)

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,12 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
         .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.15.0"),
-        .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.10.1")
+        // Temporary pin to the develop commit that added StreamCoreUI
+        // tokens. Restore `from:` once they ship in a tag.
+        .package(
+            url: "https://github.com/GetStream/stream-core-swift.git",
+            revision: "7dcc7c889dcd1d860576c82cac8a0f486cec7d26"
+        )
     ],
     targets: [
         .target(
@@ -37,7 +42,10 @@ let package = Package(
         ),
         .target(
             name: "StreamVideoSwiftUI",
-            dependencies: ["StreamVideo"],
+            dependencies: [
+                "StreamVideo",
+                .product(name: "StreamCoreUI", package: "stream-core-swift")
+            ],
             resources: [
                 .process("Resources")
             ]

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You can customize the look and feel of the screens presented in the calling flow
 
 Most of our components are public, so you can use them as building blocks if you want to build your custom UI.
 
-All the texts, images, fonts and sounds used in the SDK are configurable via our `Appearance` class, to help you brand the views to be inline with your hosting app.
+All the texts, images, fonts and sounds used in the SDK are configurable via `VideoAppearance`. Shared color and layout tokens live on `DesignSystemTokens` from StreamCoreUI; pass the same instance into Chat later so both SDKs reskin together.
 
 ### UIKit SDK
 

--- a/Sources/StreamVideoSwiftUI/Appearance.swift
+++ b/Sources/StreamVideoSwiftUI/Appearance.swift
@@ -25,8 +25,15 @@ public class Appearance {
     }
     
     /// Provider for custom localization which is dependent on App Bundle.
-    public nonisolated(unsafe) static var localizationProvider: (_ key: String, _ table: String) -> String = { key, table in
-        Bundle.streamVideoUI.localizedString(forKey: key, value: nil, table: table)
+    public nonisolated(unsafe) static var localizationProvider: (
+        _ key: String,
+        _ table: String
+    ) -> String = { key, table in
+        Bundle.streamVideoUI.localizedString(
+            forKey: key,
+            value: nil,
+            table: table
+        )
     }
 }
 

--- a/Sources/StreamVideoSwiftUI/Colors.swift
+++ b/Sources/StreamVideoSwiftUI/Colors.swift
@@ -6,6 +6,11 @@ import SwiftUI
 import UIKit
 
 /// Provides the colors used throughout the SDK.
+///
+/// Existing views still read this bag from ``Appearance/colors``.
+/// Video-specific design-system tokens live on
+/// ``VideoAppearance/Colors``; shared tokens live on
+/// ``DesignSystemTokens``.
 public struct Colors {
     
     public init() { /* Public init. */ }

--- a/Sources/StreamVideoSwiftUI/DesignSystem/VideoAppearance+Colors.swift
+++ b/Sources/StreamVideoSwiftUI/DesignSystem/VideoAppearance+Colors.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamCoreUI
+import UIKit
+
+/// Video-specific color tokens, derived from ``DesignSystemTokens/Colors``.
+///
+/// Read them on the Video appearance:
+/// `videoAppearance.colors.indicatorSpeaking`.
+extension VideoAppearance {
+    public final class Colors {
+        private let colors: DesignSystemTokens.Colors
+
+        // MARK: - Control
+
+        public lazy var controlAcceptCallBackground: UIColor = colors
+            .accentSuccess
+        public lazy var controlAcceptCallText: UIColor = colors.textOnAccent
+        public lazy var controlVideoBackgroundControlBackground: UIColor = colors
+            .backgroundCoreSurfaceSubtle
+        public lazy var controlVideoBackgroundControlBackgroundSelected: UIColor =
+            colors.accentPrimary
+        public lazy var controlVideoBackgroundControlText: UIColor = colors
+            .textPrimary
+        public lazy var controlVideoBackgroundControlTextSelected: UIColor =
+            colors.textOnAccent
+
+        // MARK: - Indicator
+
+        public lazy var indicatorFair: UIColor = colors.accentWarning
+        public lazy var indicatorGreat: UIColor = colors.accentSuccess
+        public lazy var indicatorPoor: UIColor = colors.accentError
+        public lazy var indicatorSpeaking: UIColor = colors.palette.brand300
+
+        // MARK: - Label
+
+        public lazy var labelBackgroundNeutral: UIColor = colors.palette.chrome150
+        public lazy var labelBackgroundPrimary: UIColor = colors.palette.brand150
+        public lazy var labelTextNeutral: UIColor = colors.textPrimary
+        public lazy var labelTextPrimary: UIColor = colors.palette.brand900
+
+        public init(tokens: DesignSystemTokens = DesignSystemTokens()) {
+            self.colors = tokens.colors
+        }
+    }
+}

--- a/Sources/StreamVideoSwiftUI/Fonts.swift
+++ b/Sources/StreamVideoSwiftUI/Fonts.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 
 /// Provides access to fonts used in the SDK.
-public struct Fonts {
+public struct Fonts: Sendable {
     
     public init() { /* Public init. */ }
     

--- a/Sources/StreamVideoSwiftUI/VideoAppearance.swift
+++ b/Sources/StreamVideoSwiftUI/VideoAppearance.swift
@@ -1,0 +1,39 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@_exported import StreamCoreUI
+import StreamVideo
+import SwiftUI
+
+/// Video design-system configuration.
+///
+/// Shared color and layout tokens come from ``DesignSystemTokens``. Pass
+/// the same instance into Chat's appearance so both SDKs reskin together.
+/// Video-only colors live on ``colors``. Existing views still use
+/// ``Appearance`` until they migrate.
+///
+/// ```swift
+/// let tokens = DesignSystemTokens()
+/// tokens.colors.accentPrimary = .red
+/// let appearance = VideoAppearance(tokens: tokens)
+/// appearance.colors.indicatorSpeaking = .green
+/// ```
+public final class VideoAppearance {
+    /// The instance the Video SDK uses unless it is given another one.
+    ///
+    /// Not synchronized. This is a process-wide UI configuration object.
+    public nonisolated(unsafe) static let shared = VideoAppearance()
+
+    /// Shared color and layout tokens. Mutating this instance is visible
+    /// to any other appearance constructed with it.
+    public let tokens: DesignSystemTokens
+
+    /// Video-specific colors, derived from ``tokens``.
+    public var colors: Colors
+
+    public init(tokens: DesignSystemTokens = DesignSystemTokens()) {
+        self.tokens = tokens
+        self.colors = Colors(tokens: tokens)
+    }
+}

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -59,8 +59,8 @@
 		84F7384D287C198500A363F4 /* StreamVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F737ED287C13AC00A363F4 /* StreamVideo.framework */; };
 		84F7384E287C198500A363F4 /* StreamVideo.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84F737ED287C13AC00A363F4 /* StreamVideo.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C0DE0C6E00000000000000C3 /* StreamCore in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B2 /* StreamCore */; };
-		C0DE0C6E00000000000000C4 /* StreamCore in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B3 /* StreamCore */; };
 		C0DE0C6E00000000000000C5 /* StreamCore in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B4 /* StreamCore */; };
+		C0DE0C6E00000000000000C9 /* StreamCoreUI in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B8 /* StreamCoreUI */; };
 		C0DE0C6E00000000000000C6 /* StreamCore in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B5 /* StreamCore */; };
 		C0DE0C6E00000000000000C7 /* StreamCore in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B6 /* StreamCore */; };
 		C0DE0C6E00000000000000C8 /* StreamCore in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE0C6E00000000000000B7 /* StreamCore */; };
@@ -417,6 +417,7 @@
 				CallView/VideoRenderer_Tests.swift,
 				CallView/VisibilityThresholdModifier_Tests.swift,
 				CallViewModel_Tests.swift,
+				"DesignSystem/Appearance+DesignSystem_Tests.swift",
 				Livestreaming/LivestreamPlayer_Tests.swift,
 				StreamVideoUITestCase.swift,
 				Utils/AudioValuePercentageNormaliser_Tests.swift,
@@ -540,6 +541,7 @@
 				"StreamVideo/WebRTC/v2/SDP Parsing/README.md",
 				StreamVideoSwiftUI/.swiftgen.yml,
 				StreamVideoSwiftUI/Appearance.swift,
+				StreamVideoSwiftUI/VideoAppearance.swift,
 				StreamVideoSwiftUI/CallContainer.swift,
 				StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift,
 				StreamVideoSwiftUI/CallingViews/CallConnectingView.swift,
@@ -616,6 +618,7 @@
 				StreamVideoSwiftUI/CallView/VisibilityThresholdModifier.swift,
 				StreamVideoSwiftUI/CallViewModel.swift,
 				StreamVideoSwiftUI/Colors.swift,
+				"StreamVideoSwiftUI/DesignSystem/VideoAppearance+Colors.swift",
 				StreamVideoSwiftUI/Fonts.swift,
 				StreamVideoSwiftUI/Generated/L10n_template.stencil,
 				StreamVideoSwiftUI/Generated/L10n.swift,
@@ -711,6 +714,7 @@
 				"/Localized: StreamVideoSwiftUI/Resources/Localizable.strings",
 				"/Localized: StreamVideoSwiftUI/Resources/Localizable.stringsdict",
 				StreamVideoSwiftUI/Appearance.swift,
+				StreamVideoSwiftUI/VideoAppearance.swift,
 				StreamVideoSwiftUI/CallContainer.swift,
 				StreamVideoSwiftUI/CallingViews/CallBackgrounds.swift,
 				StreamVideoSwiftUI/CallingViews/CallConnectingView.swift,
@@ -787,6 +791,7 @@
 				StreamVideoSwiftUI/CallView/VisibilityThresholdModifier.swift,
 				StreamVideoSwiftUI/CallViewModel.swift,
 				StreamVideoSwiftUI/Colors.swift,
+				"StreamVideoSwiftUI/DesignSystem/VideoAppearance+Colors.swift",
 				StreamVideoSwiftUI/Fonts.swift,
 				StreamVideoSwiftUI/Generated/L10n_template.stencil,
 				StreamVideoSwiftUI/Generated/L10n.swift,
@@ -1113,7 +1118,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				84F73843287C195600A363F4 /* StreamVideo.framework in Frameworks */,
-				C0DE0C6E00000000000000C4 /* StreamCore in Frameworks */,
+				C0DE0C6E00000000000000C9 /* StreamCoreUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1424,7 +1429,7 @@
 			);
 			name = StreamVideoSwiftUI;
 			packageProductDependencies = (
-				C0DE0C6E00000000000000B3 /* StreamCore */,
+				C0DE0C6E00000000000000B8 /* StreamCoreUI */,
 			);
 			productName = StreamVideoSwiftUI;
 			productReference = 84F73807287C141000A363F4 /* StreamVideoSwiftUI.framework */;
@@ -3373,8 +3378,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.10.1;
+				kind = revision;
+				revision = 7dcc7c889dcd1d860576c82cac8a0f486cec7d26;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -3490,15 +3495,15 @@
 			package = C0DE0C6E00000000000000A1 /* XCRemoteSwiftPackageReference "stream-core-swift" */;
 			productName = StreamCore;
 		};
-		C0DE0C6E00000000000000B3 /* StreamCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DE0C6E00000000000000A1 /* XCRemoteSwiftPackageReference "stream-core-swift" */;
-			productName = StreamCore;
-		};
 		C0DE0C6E00000000000000B4 /* StreamCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C0DE0C6E00000000000000A1 /* XCRemoteSwiftPackageReference "stream-core-swift" */;
 			productName = StreamCore;
+		};
+		C0DE0C6E00000000000000B8 /* StreamCoreUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE0C6E00000000000000A1 /* XCRemoteSwiftPackageReference "stream-core-swift" */;
+			productName = StreamCoreUI;
 		};
 		C0DE0C6E00000000000000B5 /* StreamCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/StreamVideoSwiftUITests/DesignSystem/Appearance+DesignSystem_Tests.swift
+++ b/StreamVideoSwiftUITests/DesignSystem/Appearance+DesignSystem_Tests.swift
@@ -1,0 +1,98 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamVideo
+@testable import StreamVideoSwiftUI
+import SwiftUI
+import UIKit
+import XCTest
+
+final class Appearance_DesignSystem_Tests: XCTestCase, @unchecked Sendable {
+
+    private lazy var subject: VideoAppearance! = .init()
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - Isolated instance
+
+    func test_init_usesItsOwnTokensAndColors() {
+        let other = VideoAppearance()
+
+        XCTAssertFalse(subject.tokens === other.tokens)
+        XCTAssertFalse(subject.colors === other.colors)
+    }
+
+    func test_init_sharedTokens_areTheSameInstance() {
+        let tokens = DesignSystemTokens()
+        let video = VideoAppearance(tokens: tokens)
+        let other = VideoAppearance(tokens: tokens)
+
+        XCTAssertTrue(video.tokens === tokens)
+        XCTAssertTrue(other.tokens === tokens)
+    }
+
+    // MARK: - Forwarding
+
+    func test_tokens_colorWrite_readsBack() {
+        subject.tokens.colors.palette.brand500 = .magenta
+
+        XCTAssertEqual(subject.tokens.colors.palette.brand500, .magenta)
+    }
+
+    func test_tokens_layoutWrite_readsBack() {
+        subject.tokens.layout.spacingMd = 99
+
+        XCTAssertEqual(subject.tokens.layout.spacingMd, 99)
+    }
+
+    // MARK: - Cascade
+
+    func test_sharedTokenOverriddenBeforeFirstRead_videoColorUsesOverride() {
+        let tokens = DesignSystemTokens()
+        tokens.colors.palette.brand300 = .magenta
+        subject = VideoAppearance(tokens: tokens)
+
+        XCTAssertEqual(subject.colors.indicatorSpeaking, .magenta)
+    }
+
+    func test_videoColorOverridden_readsBackOverride() {
+        subject.colors.indicatorSpeaking = .magenta
+
+        XCTAssertEqual(subject.colors.indicatorSpeaking, .magenta)
+    }
+
+    func test_colorsInit_withoutTokens_usesDefaultDesignSystemTokens() {
+        let colors = VideoAppearance.Colors()
+        let expected = DesignSystemTokens().colors.palette.brand300
+
+        assertEqualDynamicColor(colors.indicatorSpeaking, expected)
+    }
+
+    // Dynamic `UIColor(light:dark:)` instances are not `==` even when they
+    // resolve to the same pair, so compare the resolved styles instead.
+    private func assertEqualDynamicColor(
+        _ lhs: UIColor,
+        _ rhs: UIColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let light = UITraitCollection(userInterfaceStyle: .light)
+        let dark = UITraitCollection(userInterfaceStyle: .dark)
+        XCTAssertEqual(
+            lhs.resolvedColor(with: light),
+            rhs.resolvedColor(with: light),
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            lhs.resolvedColor(with: dark),
+            rhs.resolvedColor(with: dark),
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
Puts the Video SDK on `DesignSystemTokens` from `StreamCoreUI`, so the v2 UI redesign is built on the same primitives as the rest of Stream's SDKs. This PR introduces `VideoAppearance` and the shared color and layout tokens. Existing views stay on `Appearance` until they migrate.

> [!NOTE]
> Draft until [GetStream/stream-core-swift#81](https://github.com/GetStream/stream-core-swift/pull/81) merges and ships. `Package.swift` is pinned to the `core-ui-design-tokens` branch and needs repointing to a released version before this can land.

## Architecture

`Appearance` is unchanged for views: `colors`, `images`, `fonts`, `sounds`, and `StreamVideoUI`. `VideoAppearance` is the new design-system type. Shared color and layout tokens come from a `DesignSystemTokens` instance passed into it. Video-only colors are the nested type `VideoAppearance.Colors` and are read on `videoAppearance.colors`.

```mermaid
flowchart TB
  subgraph core ["StreamCoreUI"]
    DT["DesignSystemTokens"]
    DT --> C["Colors"]
    DT --> L["Layout"]
  end

  subgraph video ["StreamVideoSwiftUI"]
    A["Appearance\ncolors, images, fonts, sounds"]
    VA["VideoAppearance"]
    VA --> DT
    VA --> VC["colors\nVideoAppearance.Colors"]
    VC --> C
  end
```

```swift
let tokens = DesignSystemTokens()
tokens.colors.accentPrimary = .red
let videoAppearance = VideoAppearance(tokens: tokens)
videoAppearance.colors.indicatorSpeaking = .green
```

Pass the same `DesignSystemTokens` instance into Chat later so both SDKs reskin together. Color tokens derive lazily, so override ramps before the first read.

## Testing

`Appearance_DesignSystem_Tests` covers isolated instances, shared `DesignSystemTokens` identity, and the cascade from a shared ramp into a video token.

## Follow-ups

- Chat adoption: [IOS-1999](https://linear.app/stream/issue/IOS-1999)
- Moving the token scope split into the generator: [IOS-2000](https://linear.app/stream/issue/IOS-2000)
