### PR TITLE
[Refactor] Move last session id tracking into WebRTCStateAdapter

### DIFF
--- a/Sources/StreamVideo/Controllers/CallController.swift
+++ b/Sources/StreamVideo/Controllers/CallController.swift
@@ -76,14 +76,6 @@ class CallController: @unchecked Sendable {
     private var webRTCParticipantsObserver: AnyCancellable?
     private var participants: CollectionDelayedUpdateObserver<[String: CallParticipant]>?
 
-    /// The latest non-empty session id observed for this call.
-    ///
-    /// `WebRTCStateAdapter.cleanUp()` resets the session id while the call is
-    /// torn down, but user feedback is usually collected *after* the call has
-    /// ended. Retaining the id here keeps it available to
-    /// ``collectUserFeedback(custom:rating:reason:)``.
-    @Atomic private var lastSessionId: String?
-
     private let disposableBag = DisposableBag()
 
     init(
@@ -512,7 +504,7 @@ class CallController: @unchecked Sendable {
                 reason: reason,
                 sdk: SystemEnvironment.sdkName,
                 sdkVersion: SystemEnvironment.version,
-                userSessionId: lastSessionId
+                userSessionId: await webRTCCoordinator.stateAdapter.lastSessionID
             )
         )
     }
@@ -804,16 +796,7 @@ class CallController: @unchecked Sendable {
         webRTCClientSessionIDObserver = await webRTCCoordinator
             .stateAdapter
             .$sessionID
-            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] sessionId in
-                guard let self else { return }
-                call?.state.sessionId = sessionId
-                /// The empty value emitted during cleanUp is skipped on
-                /// purpose, so that feedback collected after the call ended
-                /// still reports the session it refers to.
-                if !sessionId.isEmpty {
-                    lastSessionId = sessionId
-                }
-            }
+            .sinkTask(storeIn: disposableBag) { @MainActor [weak self] in self?.call?.state.sessionId = $0 }
     }
 
     private func observeStatsReporterUpdates() async {

--- a/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
+++ b/Sources/StreamVideo/WebRTC/v2/WebRTCStateAdapter.swift
@@ -49,8 +49,16 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     let audioSession: CallAudioSession
     let trackStorage: WebRTCTrackStorage = .init()
 
+    /// The latest non-empty session id observed during the call's lifetime.
+    ///
+    /// ``cleanUp()`` resets ``sessionID`` while the call is torn down, but
+    /// consumers may need to refer to the session that just ended (e.g. user
+    /// feedback is usually collected *after* the call has ended). This
+    /// property retains the id for them.
+    private(set) var lastSessionID: String
+
     /// Published properties that represent different parts of the WebRTC state.
-    @Published private(set) var sessionID: String = UUID().uuidString
+    @Published private(set) var sessionID: String
     @Published private(set) var token: String = ""
     @Published private(set) var callSettings: CallSettings
     @Published private(set) var audioSettings: AudioSettings = .init()
@@ -196,6 +204,9 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
         self.apiKey = apiKey
         self.callCid = callCid
         self.videoConfig = videoConfig
+        let sessionID = UUID().uuidString
+        self._sessionID = .init(initialValue: sessionID)
+        self.lastSessionID = sessionID
         self._callSettings = .init(initialValue: callSettings)
         let peerConnectionFactory = peerConnectionFactory
         self.peerConnectionFactory = peerConnectionFactory
@@ -225,6 +236,11 @@ actor WebRTCStateAdapter: ObservableObject, StreamAudioSessionAdapterDelegate, W
     /// Sets the session ID.
     func set(sessionID value: String) {
         self.sessionID = value
+        /// The empty value set during ``cleanUp()`` is skipped on purpose, so
+        /// that ``lastSessionID`` keeps pointing to the session that ended.
+        if !value.isEmpty {
+            lastSessionID = value
+        }
     }
 
     /// Sets the call settings.

--- a/StreamVideoTests/Controllers/CallController_Tests.swift
+++ b/StreamVideoTests/Controllers/CallController_Tests.swift
@@ -614,9 +614,8 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
 
     func test_collectUserFeedback_duringCall_reportsSessionId() async throws {
         let (subject, defaultAPI, factory) = makeSubjectWithMockAPI()
-        let call = await MockCall(.dummy())
-        subject.call = call
-        let expected = await setSessionId(.unique, on: factory, observedBy: call)
+        let expected = String.unique
+        await factory.mockCoordinatorStack.coordinator.stateAdapter.set(sessionID: expected)
         defaultAPI.stub(for: .collectUserFeedback, with: CollectUserFeedbackResponse(duration: ""))
 
         _ = try await subject.collectUserFeedback(rating: 5)
@@ -628,7 +627,8 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
         let (subject, defaultAPI, factory) = makeSubjectWithMockAPI()
         let call = await MockCall(.dummy())
         subject.call = call
-        let expected = await setSessionId(.unique, on: factory, observedBy: call)
+        let expected = String.unique
+        await factory.mockCoordinatorStack.coordinator.stateAdapter.set(sessionID: expected)
         /// The state adapter resets its session id while the call is torn down,
         /// but a post-call rating screen collects the feedback afterwards.
         subject.cleanUp()
@@ -1311,19 +1311,6 @@ final class CallController_Tests: StreamVideoTestCase, @unchecked Sendable {
             webRTCCoordinatorFactory: webRTCCoordinatorFactory
         )
         return (subject, defaultAPI, webRTCCoordinatorFactory)
-    }
-
-    /// Sets the session id on the state adapter and waits until the controller
-    /// has observed it, using the call state that the same observation updates.
-    @discardableResult
-    private func setSessionId(
-        _ value: String,
-        on factory: MockWebRTCCoordinatorFactory,
-        observedBy call: MockCall
-    ) async -> String {
-        await factory.mockCoordinatorStack.coordinator.stateAdapter.set(sessionID: value)
-        await fulfilmentInMainActor { call.state.sessionId == value }
-        return value
     }
 
     private func collectedFeedbackRequest(

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -109,6 +109,26 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await assertEqualAsync(await subject.sessionID, expected)
     }
 
+    func test_setSessionID_shouldUpdateLastSessionID() async throws {
+        let expected = String.unique
+
+        await subject.set(sessionID: expected)
+
+        let lastSessionID = await subject.lastSessionID
+        XCTAssertEqual(lastSessionID, expected)
+    }
+
+    func test_setSessionID_withEmptyValue_shouldNotUpdateLastSessionID() async throws {
+        let expected = String.unique
+        await subject.set(sessionID: expected)
+
+        await subject.set(sessionID: "")
+
+        await assertEqualAsync(await subject.sessionID, "")
+        let lastSessionID = await subject.lastSessionID
+        XCTAssertEqual(lastSessionID, expected)
+    }
+
     // MARK: - setIsTracingEnabled
 
     func test_setIsTracingEnabled_shouldUpdateIsTracingEnabled() async throws {
@@ -812,6 +832,9 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await assertNilAsync(await subject.sfuAdapter)
         await assertEqualAsync(await subject.token, "")
         await assertEqualAsync(await subject.sessionID, "")
+        /// The session that just ended remains available for consumers that
+        /// run after cleanUp (e.g. user feedback collection).
+        await assertFalseAsync(await subject.lastSessionID.isEmpty)
         await assertEqualAsync(await subject.ownCapabilities, [])
         await assertEqualAsync(await subject.participants, [:])
         await assertEqualAsync(await subject.participantsCount, 0)


### PR DESCRIPTION
### 🔗 Issue Links

Follow-up to the review comment on #1254: https://github.com/GetStream/stream-video-swift/pull/1254#discussion_r3892985892

### 🎯 Goal

#1254 kept the last known session id on `CallController` so that user feedback collected *after* a call ended could still report it. That made the controller shadow a piece of session state that `WebRTCStateAdapter` already owns. The adapter is the stateful component and should be the one providing this information.

### 📝 Summary

- `WebRTCStateAdapter` exposes `lastSessionID`, the latest non-empty session id observed during the call's lifetime.
- `CallController` no longer keeps its own `lastSessionId`; `collectUserFeedback` reads it from the state adapter.
- `CallController.observeSessionIDUpdates` is back to only mirroring the session id into `call.state`.
- Tests for `lastSessionID` added to `WebRTCStateAdapter_Tests`; the feedback tests in `CallController_Tests` were de-flaked.

### 🛠 Implementation

`lastSessionID` is seeded in `init` from the same UUID that seeds `sessionID` (which moved from a default initializer to `init`, matching the existing `_callSettings` pattern), and `set(sessionID:)` updates it while skipping the empty value written by `cleanUp()`.

The `init` seeding is what makes the first join work: `Connecting` only calls `refreshSession()` when `updateSession` is true, so on a first attempt the session id never passes through `set(sessionID:)`. Deriving `lastSessionID` purely from that setter would have left it empty for the common case.

On the test side, `collectUserFeedback` now reads straight from the state adapter, so the feedback tests no longer need to wait for the controller to observe the change. That let the `setSessionId` helper go — its `fulfilmentInMainActor { call.state.sessionId == value }` wait raced with the task started from `CallController.call`'s `didSet`, which re-assigns `call.state.sessionId` and could clobber the observed value. Both tests were flaky because of it on `develop` as well; each of them failed in a local run before this change.

### 🧪 Manual Testing Notes

Not needed — no behaviour change. Submit feedback from the post-call rating screen and verify `user_session_id` is present on the `collectUserFeedback` request.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

#no_changelog — internal refactor, the user-facing entry shipped with #1254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-call feedback handling so feedback remains associated with the correct call session after cleanup.
  * Prevented session information from being lost when a call ends.
  * Updated session tracking to handle cleared or temporary session values more reliably.

* **Tests**
  * Added coverage for preserving session information through call cleanup and feedback submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->