### PR TITLE
Expose API for getting the ring state

### DIFF
--- a/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
+++ b/Sources/StreamVideo/OpenApi/generated/APIs/DefaultAPI.swift
@@ -1214,6 +1214,29 @@ open class DefaultAPI: DefaultAPIEndpoints, @unchecked Sendable {
             try self.jsonDecoder.decode(ReportClientEventResponse.self, from: $0)
         }
     }
+    
+    open func getCallRingState(type: String, id: String, callSessionId: String) async throws -> GetCallRingStateResponse {
+        var path = "/api/v2/video/call/{type}/{id}/ring_state"
+
+        let typePreEscape = "\(APIHelper.mapValueToPathItem(type))"
+        let typePostEscape = typePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: String(format: "{%@}", "type"), with: typePostEscape, options: .literal, range: nil)
+        let idPreEscape = "\(APIHelper.mapValueToPathItem(id))"
+        let idPostEscape = idPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: String(format: "{%@}", "id"), with: idPostEscape, options: .literal, range: nil)
+        let queryParams = APIHelper.mapValuesToQueryItems([
+            "call_session_id": (wrappedValue: callSessionId.encodeToJSON(), isExplode: true)
+        ])
+
+        let urlRequest = try makeRequest(
+            uriPath: path,
+            queryParams: queryParams ?? [],
+            httpMethod: "GET"
+        )
+        return try await send(request: urlRequest) {
+            try self.jsonDecoder.decode(GetCallRingStateResponse.self, from: $0)
+        }
+    }
 }
 
 protocol DefaultAPIEndpoints {
@@ -1343,4 +1366,6 @@ protocol DefaultAPIEndpoints {
     func ringCall(type: String, id: String, ringCallRequest: RingCallRequest) async throws -> RingCallResponse
     
     func reportClientCallEvent(reportClientEventRequest: ReportClientEventRequest) async throws -> ReportClientEventResponse
+    
+    func getCallRingState(type: String, id: String, callSessionId: String) async throws -> GetCallRingStateResponse
 }

--- a/Sources/StreamVideo/OpenApi/generated/Models/GetCallRingStateResponse.swift
+++ b/Sources/StreamVideo/OpenApi/generated/Models/GetCallRingStateResponse.swift
@@ -1,0 +1,82 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public final class GetCallRingStateResponse: @unchecked Sendable, Codable, JSONEncodable {
+    /// Users that accepted the call, mapped to when they accepted
+    public var acceptedBy: [String: Date]
+    /// The CID of the call
+    public var callCid: String
+    /// When the call ended
+    public var callEndedAt: Date?
+    /// The user that created the call, i.e. the caller
+    public var createdByUserId: String
+    /// Duration of the request in milliseconds
+    public var duration: String
+    /// Users that missed the call, mapped to when they were marked as missed
+    public var missedBy: [String: Date]
+    /// Users that rejected the call, mapped to when they rejected
+    public var rejectedBy: [String: Date]
+    /// When the call session ended
+    public var sessionEndedAt: Date?
+    /// The call session this state belongs to, empty when the call has never rung
+    public var sessionId: String
+    /// When the call session started
+    public var sessionStartedAt: Date?
+
+    public init(acceptedBy: [String: Date], callCid: String, callEndedAt: Date? = nil, createdByUserId: String, duration: String, missedBy: [String: Date], rejectedBy: [String: Date], sessionEndedAt: Date? = nil, sessionId: String, sessionStartedAt: Date? = nil) {
+        self.acceptedBy = acceptedBy
+        self.callCid = callCid
+        self.callEndedAt = callEndedAt
+        self.createdByUserId = createdByUserId
+        self.duration = duration
+        self.missedBy = missedBy
+        self.rejectedBy = rejectedBy
+        self.sessionEndedAt = sessionEndedAt
+        self.sessionId = sessionId
+        self.sessionStartedAt = sessionStartedAt
+    }
+
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case acceptedBy = "accepted_by"
+        case callCid = "call_cid"
+        case callEndedAt = "call_ended_at"
+        case createdByUserId = "created_by_user_id"
+        case duration
+        case missedBy = "missed_by"
+        case rejectedBy = "rejected_by"
+        case sessionEndedAt = "session_ended_at"
+        case sessionId = "session_id"
+        case sessionStartedAt = "session_started_at"
+    }
+}
+
+extension GetCallRingStateResponse: Hashable {
+    public static func == (lhs: GetCallRingStateResponse, rhs: GetCallRingStateResponse) -> Bool {
+        lhs.acceptedBy == rhs.acceptedBy &&
+        lhs.callCid == rhs.callCid &&
+        lhs.callEndedAt == rhs.callEndedAt &&
+        lhs.createdByUserId == rhs.createdByUserId &&
+        lhs.duration == rhs.duration &&
+        lhs.missedBy == rhs.missedBy &&
+        lhs.rejectedBy == rhs.rejectedBy &&
+        lhs.sessionEndedAt == rhs.sessionEndedAt &&
+        lhs.sessionId == rhs.sessionId &&
+        lhs.sessionStartedAt == rhs.sessionStartedAt
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(acceptedBy)
+        hasher.combine(callCid)
+        hasher.combine(callEndedAt)
+        hasher.combine(createdByUserId)
+        hasher.combine(duration)
+        hasher.combine(missedBy)
+        hasher.combine(rejectedBy)
+        hasher.combine(sessionEndedAt)
+        hasher.combine(sessionId)
+        hasher.combine(sessionStartedAt)
+    }
+}

--- a/StreamVideoTests/Mock/MockDefaultAPIEndpoints.swift
+++ b/StreamVideoTests/Mock/MockDefaultAPIEndpoints.swift
@@ -78,6 +78,7 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
         case videoConnect
         case ringCall
         case clientCallEvent
+        case getCallRingState
     }
 
     enum MockFunctionInputKey: Payloadable {
@@ -132,6 +133,7 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
         case videoConnect
         case ringCall(request: RingCallRequest)
         case clientCallEvent(request: ReportClientEventRequest)
+        case getCallRingState(type: String, id: String, callSessionId: String)
 
         var payload: Any {
             switch self {
@@ -237,6 +239,8 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
                 return request
             case let .clientCallEvent(request: request):
                 return request
+            case let .getCallRingState(type, id, callSessionId):
+                return (type, id, callSessionId)
             }
         }
     }
@@ -625,5 +629,12 @@ final class MockDefaultAPIEndpoints: DefaultAPIEndpoints, Mockable, @unchecked S
             return value
         }
         return try stubbedResult(for: .clientCallEvent)
+    }
+
+    func getCallRingState(type: String, id: String, callSessionId: String) async throws -> GetCallRingStateResponse {
+        stubbedFunctionInput[.getCallRingState]?.append(
+            .getCallRingState(type: type, id: id, callSessionId: callSessionId)
+        )
+        return try stubbedResult(for: .getCallRingState)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Needed for https://linear.app/stream/issue/IOS-2004/implement-checks-of-ring-state.

### 🎯 Goal

Expose new endpoint for getting the ring state.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added mock API coverage for retrieving a call’s ring state.
  - The mock endpoint records call type, ID, and session ID inputs and returns a configurable response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->