### PR TITLE
Expose shared Core typography on VideoAppearance tokens + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,63 +4,253 @@ Guidance for AI coding agents (Copilot, Cursor, Aider, Claude, etc.) working in 
 
 ### Repository purpose
 
-This repository hosts Stream’s Swift Video/Calling SDK for Apple platforms. It provides the real‑time audio/video client, call state & signaling, and SwiftUI/UI kit components to build 1:1 and group calls with chat integration.
+This repository hosts Stream’s Swift Video SDK for Apple platforms. It provides the real‑time audio/video client, call state & signaling, and SwiftUI/UIKit components to build 1:1 and group calls with chat integration.
 
-Agents should optimize for media quality, API stability, backwards compatibility, and high test coverage.
+The current development line is **v2** (SDK 2.0). Feature work on this branch targets the `v2` base, not `develop`. v2 is allowed to break public UI configuration where the design-token migration requires it; do not break the calling/media client casually.
+
+Agents should optimize for media quality, API stability, backwards compatibility of the call path, and high test coverage.
+
+## v2 design system
+
+v2 introduces a **shared design-token system** so Chat and Video can reskin from one source. Shared color, layout, and typography tokens live in **StreamCoreUI** (`DesignSystemTokens`). Each product SDK owns its own appearance type and its own product tokens. Icons and images stay on each SDK for now.
+
+### Types and ownership
+
+- **`DesignSystemTokens`** (Core, class): `tokens.colors` (semantic colors plus `tokens.colors.palette` for brand/chrome ramps), `tokens.layout` (spacing, radii, strokes, elevations), and `tokens.fonts` (shared SwiftUI typography). Override color ramps **before the first read**. Colors stay on UIKit `UIColor`; fonts stay on SwiftUI `Font`. UIKit `UIFont` faces stay on product UIKit SDKs (for example StreamChatUI).
+- **`VideoAppearance`**: Video’s design-system type. Holds `tokens: DesignSystemTokens` and `colors: VideoAppearance.Colors` (14 Video-only colors). No images or sounds. Video owns **no** layout or font tokens; layout and shared fonts come from `tokens`.
+- **`Appearance`** (legacy): existing SwiftUI `Colors` struct plus images, fonts, and sounds. `@Injected(\.appearance)` / `@Injected(\.fonts)` and `StreamVideoUI(..., appearance:)` still take this type. Shared typography lives on `videoAppearance.tokens.fonts`. **Do not migrate existing views** onto `VideoAppearance` or `tokens.fonts` unless the task explicitly asks.
+
+Product prefix is **Video**, not Call. Use `VideoAppearance` / `VideoAppearance.Colors`.
+
+```swift
+let tokens = DesignSystemTokens()
+tokens.colors.palette.brand500 = .red
+tokens.layout.spacingMd = 16
+
+let videoAppearance = VideoAppearance(tokens: tokens)
+videoAppearance.colors.indicatorSpeaking = .green
+
+// Existing views, until they migrate:
+let appearance = Appearance(colors: colors, images: images, fonts: fonts, sounds: sounds)
+StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
+```
+
+Access paths on `VideoAppearance`:
+
+- Shared: `videoAppearance.tokens.colors.accentPrimary`, `videoAppearance.tokens.layout.spacingMd`, `videoAppearance.tokens.fonts.body`
+- Video-only: `videoAppearance.colors.controlAcceptCallBackground`
+
+`VideoAppearance.Colors.init` defaults to `DesignSystemTokens()`, so `Colors()` works without supplying tokens.
+
+Token split and re-sync rules live in Core: `Sources/StreamCoreUI/DesignSystem/TokenScope.md`. Do not add Chat (`chat*`) tokens to this SDK.
+
+### Mixed Chat + Video apps
+
+`InjectedValues` is a StreamCore type. Both SDKs must not publish the same key names (`appearance`, `colors`, `fonts`, `images`, `tokens`) or a customer file that imports both will not compile. Video views still inject `fonts` from legacy `Appearance`; Chat UIKit keeps local `UIFont` faces.
+
+Intended customer API (Chat will mirror this when it adopts):
+
+```swift
+struct InboxHeader: View {
+    @Injected(\.videoAppearance) private var videoAppearance
+    @Injected(\.chatAppearance) private var chatAppearance
+
+    var body: some View {
+        HStack(spacing: videoAppearance.tokens.layout.spacingMd) {
+            Label("3 missed", systemImage: "phone.down.fill")
+                .background(Color(videoAppearance.colors.controlAcceptCallBackground))
+            Label("2 unread", systemImage: "message.fill")
+                .foregroundColor(Color(chatAppearance.tokens.colors.textPrimary))
+        }
+        .font(videoAppearance.tokens.fonts.body)
+    }
+}
+```
+
+Pass the **same** `DesignSystemTokens` instance into both appearances so brand/layout/fonts stay in sync. If the customer constructed Chat and Video with different token instances, each surface must read `tokens` from **its own** appearance; they are no longer interchangeable.
+
+This injection split is the destination API. It is **not** wired on Video yet: views still use `@Injected(\.appearance)` → legacy `Appearance`. Do not add `videoAppearance` to `InjectedValues` or rename the existing keys unless the task asks.
+
+### Linking
+
+- `StreamVideo` depends on StreamCore.
+- `StreamVideoSwiftUI` depends on StreamVideo + **StreamCoreUI** (for tokens). Do not also link StreamCore into the SwiftUI or UIKit product targets; StreamCoreUI’s target already depends on StreamCore (`log`), and an extra link duplicates `StreamCore.o` into the SwiftUI dylib (size bot).
+- `StreamVideoUIKit` depends on StreamVideo + StreamVideoSwiftUI + StreamCore (UIKit exposes SwiftUI types that reference StreamCore models).
+- Tests may link StreamCore explicitly.
+
+### Constraints for this work
+
+- CoreUI’s `UIColor(light:dark:)` stays internal; Chat already has a public one.
+- Icons and images stay on each SDK until a follow-up.
+- Danger `commit_lint` fails commit subjects that end with a period.
+- Do not change `CHANGELOG.md` or `README.md` unless explicitly asked.
+- Local simulator used for this work: `platform=iOS Simulator,name=iPhone 17,OS=26.5`.
 
 ### Tech & toolchain
-- Language: Swift
+
+- Language: Swift 5.10 (`swift-tools-version:5.10` in `Package.swift`)
 - UI frameworks: SwiftUI first; UIKit components may also be present
 - Media stack: WebRTC/AVFoundation under the hood
 - Primary distribution: Swift Package Manager (SPM)
-- Xcode: 15.x or newer (Apple Silicon supported)
-- Platforms / deployment targets: Use the values set in Package.swift; do not lower without approval
-- CI: GitHub Actions (assume PR validation for build + tests + lint)
-- Apple docs helper: Use https://sosumi.ai/ (MCP or direct) for up-to-date
-  Apple platform APIs, Swift/Objective-C references, and UI design guidance.
-- Xcode MCP: Agents may use the Xcode MCP to build, test, and interact with
-  apps on simulators and real devices. See
-  `https://developer.apple.com/documentation/xcode/giving-agentic-coding-tools-access-to-xcode`.
+- Project file: `StreamVideo.xcodeproj` (used for builds and tests)
+- Xcode: 15.x or newer (Apple Silicon supported); CI also validates on older Xcode
+- Platforms / deployment targets: Use the values set in `Package.swift`; do not lower without approval
+- CI: GitHub Actions + Fastlane (see `.github/workflows/smoke-checks.yml`)
+- Linting: SwiftLint (v0.59.1) — config in `.swiftlint.yml`
+- Formatting: SwiftFormat (v0.58.2) — config in `.swiftformat`
+- Git hooks: lefthook (`lefthook.yml`) — runs SwiftLint fix + SwiftFormat on pre-commit
+- Tool versions are pinned in `Githubfile`
+- Apple docs helper: Use https://sosumi.ai/ (MCP or direct) for up-to-date Apple platform APIs
+- Xcode MCP: Agents may use the Xcode MCP to build, test, and interact with apps on simulators and real devices. See `https://developer.apple.com/documentation/xcode/giving-agentic-coding-tools-access-to-xcode`.
+
+### Dependencies
+
+- **StreamCore** / **StreamCoreUI** from [`stream-core-swift`](https://github.com/GetStream/stream-core-swift.git) (revision pin until tokens ship in a tag)
+- **swift-protobuf** (exact 1.30.0)
+- **stream-video-swift-webrtc** (exact 145.15.0)
+
+Do not add new third-party deps without discussion.
 
 ## Project Structure & Module Organization
-- Root: `Package.swift` (SPM entry).
-- Sources: `Sources/StreamVideo/`, `Sources/StreamVideoSwiftUI/`, `Sources/StreamVideoUIKit/`.
-- Tests: `StreamVideoTests/`, `StreamVideoSwiftUITests/`, `StreamVideoUIKitTests/` .
-- Demos: `DemoApp/` and `DemoAppUIKit` samples.
-- Documentation tests: `DocumentationTests/DocumentationTests/`.
+
+```
+Sources/
+  StreamVideo/              # Core client: API, models, WebRTC, call state
+  StreamVideoSwiftUI/       # SwiftUI components, appearance, design system
+    DesignSystem/           # VideoAppearance product tokens
+  StreamVideoUIKit/         # UIKit wrappers around SwiftUI
+StreamVideoTests/           # Unit + integration tests for StreamVideo
+StreamVideoSwiftUITests/    # SwiftUI snapshot & unit tests
+StreamVideoUIKitTests/      # UIKit tests
+DemoApp/                    # Primary SwiftUI demo app
+DemoAppUIKit/               # UIKit demo app
+DocumentationTests/         # DocC documentation tests
+Scripts/                    # Helper scripts (bootstrap, codex checks)
+fastlane/                   # Fastlane lanes for CI
+```
+
 - Mirror nearby module patterns; keep file names aligned with the primary type (e.g., `CallViewModel.swift`).
 
 ### New files & target membership
-- When creating new source or resource files, add them to the correct Xcode target(s). Update the project (e.g. project.pbxproj) so each new file is included in the appropriate target's "Compile Sources" (or "Copy Bundle Resources" for assets). Match the target(s) used by sibling files in the same directory (e.g. Sources/StreamVideo/ → StreamVideo; Sources/StreamVideoSwiftUI/ → StreamVideoSwiftUI; Sources/StreamVideoUIKit/ → StreamVideoUIKit; Tests/StreamVideoTests/ → StreamVideoTests; Tests/StreamVideoSwiftUITests/ → StreamVideoSwiftUITests; Tests/StreamVideoUIKitTests/ → StreamVideoUIKitTests). Omitting target membership will cause build failures or unused files.
+
+When creating new source or resource files, add them to the correct Xcode target(s). Update the project (e.g. `project.pbxproj`) so each new file is included in the appropriate target's "Compile Sources" (or "Copy Bundle Resources" for assets). Match the target(s) used by sibling files in the same directory (e.g. `Sources/StreamVideo/` → StreamVideo; `Sources/StreamVideoSwiftUI/` → StreamVideoSwiftUI; `Sources/StreamVideoUIKit/` → StreamVideoUIKit; `Tests/StreamVideoTests/` → StreamVideoTests; `Tests/StreamVideoSwiftUITests/` → StreamVideoSwiftUITests; `Tests/StreamVideoUIKitTests/` → StreamVideoUIKitTests). Omitting target membership will cause build failures or unused files.
+
+### Local setup (SPM)
+
+1. Open the repository in Xcode (root contains `Package.swift` and `StreamVideo.xcodeproj`).
+2. Resolve packages.
+3. Choose an iOS Simulator (e.g., iPhone 17 Pro) and Build.
+
+Optional: run `Scripts/bootstrap.sh` to install pinned versions of SwiftLint, SwiftFormat, and SwiftGen, and to set up lefthook git hooks.
+
+### Demo app
+
+The `DemoApp` target is a fully functional sample app. Prefer running it to validate UI changes. Keep demo configs free of credentials and use placeholders like `YOUR_STREAM_KEY`.
+
+### Schemes
+
+Available shared schemes (under `StreamVideo.xcodeproj/xcshareddata/xcschemes/`):
+
+- `StreamVideo` — builds the core framework
+- `StreamVideoSwiftUI` — builds the SwiftUI framework
+- `StreamVideoUIKit` — builds the UIKit framework
+- `DemoApp` — builds and runs the SwiftUI demo app
+- `DemoAppUIKit` — builds and runs the UIKit demo app
+
+Agents must query existing schemes before invoking xcodebuild.
 
 ## Build, Test, and Development Commands
-- Open in Xcode 15+ via `Package.swift` and build for an iOS Simulator (e.g., iPhone 15).
-- Build (CLI):
-  - `xcodebuild -scheme StreamVideo -destination 'platform=iOS Simulator,name=iPhone 15' -configuration Debug build`
-- Tests (CLI):
-  - `bundle exec fastlane test`
-  - `bundle exec fastlane test_swiftui`
-  - `bundle exec fastlane test_uikit`
-- Lint: `bundle exec fastlane run_swift_format strict:true` (respect `fastlane/Fastfile`).
+
+Prefer Xcode for day-to-day work; use CLI for CI parity & automation.
+
+Build (Debug):
+
+```
+xcodebuild \
+  -project StreamVideo.xcodeproj \
+  -scheme StreamVideo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -configuration Debug build
+```
+
+Run tests:
+
+```
+bundle exec fastlane test
+bundle exec fastlane test_swiftui
+bundle exec fastlane test_uikit
+```
+
+If the device is not available, use one of the active booted devices:
+
+```
+xcodebuild \
+  -project StreamVideo.xcodeproj \
+  -scheme StreamVideo \
+  -destination "platform=iOS Simulator,OS=any,name=$(xcrun simctl list devices booted | grep '(Booted)' | head -1 | sed 's/ (.*)//')" \
+  -configuration Debug test
+```
+
+### Linting & formatting
+
+SwiftFormat (strict):
+
+```
+bundle exec fastlane run_swift_format strict:true
+```
+
+Respect `.swiftlint.yml` and `.swiftformat` rules. Do not broadly disable rules; scope exceptions and justify in PRs.
+
+### CI overview
+
+CI is driven by Fastlane (see `fastlane/Fastfile`). Key lanes:
+
+- `test` — runs StreamVideo unit tests
+- `test_swiftui` — runs StreamVideoSwiftUI tests
+- `test_uikit` — runs StreamVideoUIKit tests
+- `test_e2e` — runs E2E tests
+- `build_swiftui_demo` / `build_uikit_demo` — builds demo apps
+- `run_swift_format` — runs SwiftFormat validation
+- `validate_public_interface` — checks for unintended public API changes
+
+The `smoke-checks.yml` workflow is the primary PR gate.
 
 ### Public API & SemVer
+
 - Follow semantic versioning across public modules.
+- This branch is **2.0**: design-system types (`VideoAppearance`, token access) may be source-breaking. Prefer deprecation for unrelated public API.
 - Any public API change must include updated docs and migration notes.
-- Avoid source‑breaking changes; if unavoidable, deprecate first with a transition path.
 
 ### Performance & quality
-  • Avoid heavy work on the main thread; keep rendering/state updates efficient.
-  • Monitor frame rate, bitrate adaptation, and CPU/GPU usage; prefer hardware‑accelerated codecs when available.
-  • Be careful with retain cycles in capture/render pipelines; audit async capture lists.
-  • Consider adaptive UI for low‑bandwidth scenarios (thumbnail modes, audio‑only fallback).
+
+- Avoid heavy work on the main thread; keep rendering/state updates efficient.
+- Monitor frame rate, bitrate adaptation, and CPU/GPU usage; prefer hardware‑accelerated codecs when available.
+- Be careful with retain cycles in capture/render pipelines; audit async capture lists.
+- Consider adaptive UI for low‑bandwidth scenarios (thumbnail modes, audio‑only fallback).
 
 ## Coding Style & Naming Conventions
+
 - Swift (SPM-first). Indentation: 4 spaces; avoid trailing whitespace.
 - Naming: Types/protocols `UpperCamelCase`; methods/variables `lowerCamelCase`; constants `lowerCamelCase`.
 - Structure large files with `// MARK:` and add `///` docs for public APIs.
-- Do not add new third-party deps without discussion.
+
+### Development guidelines
+
+Code documentation
+
+- Write doc comments (`///`) only for `public` declarations — types, methods, and properties that are part of the SDK's public API.
+- Do not add doc comments to `internal`, `private`, or test code.
+- Keep doc comments concise: a one-line summary; add parameter/return docs only when they are not obvious from the signature.
+- Do not add inline comments narrating what the code or a change does; comment only non-obvious constraints or reasoning.
+
+Accessibility & UI quality
+
+- Ensure SwiftUI and UIKit components have accessibility labels, traits, and dynamic type support.
+- Support both light/dark mode.
+- Use the Appearance system for theming and configuration.
 
 ## Testing Guidelines
+
 - Framework: XCTest with async/await and expectations; avoid time-based sleeps.
 - Use existing `Mockable` protocol to mock dependencies.
 - Place tests under the corresponding `…Tests` target and mirror folder structure.
@@ -131,6 +321,7 @@ Agents should optimize for media quality, API stability, backwards compatibility
     - Full suite remains `bundle exec fastlane test`.
 
 ## Comments
+
 - Use docC for non-private APIs.
 - Use `///` for doc comments.
 - Use `// MARK:` to group code.
@@ -141,16 +332,35 @@ Agents should optimize for media quality, API stability, backwards compatibility
 - Read around the APIs you are documenting and add context to make the comments more useful.
 
 ### Compatibility & dependencies
-  • Maintain compatibility with deployment targets in Package.swift.
-  • Avoid adding new third‑party deps without discussion.
-  • Validate SPM integration in a fresh sample app when changing module boundaries.
+
+- Maintain compatibility with deployment targets in Package.swift.
+- Avoid adding new third‑party deps without discussion.
+- Validate SPM integration in a fresh sample app when changing module boundaries.
+
+### Branching & changelog
+
+- The v2 integration branch is `v2`. Feature branches for SDK 2.0 merge into `v2`, not `develop`.
+- Name branches with a descriptive kebab-case prefix, e.g. `v2-design-fonts`, `v2-design-tokens`.
+- Update `CHANGELOG.md` under the `# Upcoming` section when making client-facing changes (follow the Keep a Changelog format).
+- Only update `CHANGELOG.md` **after the PR has been opened**, so the entry can include the PR link. Push the changelog update as a follow-up commit on the same branch.
+- Keep changelog entries short and user-visible; do not explain implementation details.
 
 ## Commit & Pull Request Guidelines
+
 - Commits: small, focused, imperative subject lines ("Fix crash in renderer").
+- Start commit subject lines with a capital letter.
+- Do not end the subject with a period; Danger `commit_lint` fails the Automated Code Review job.
+- Keep the subject line concise (ideally under 72 characters); put additional context in the body separated by a blank line.
+- Do **not** include ticket IDs or Linear issue keys in commit subjects. Link tickets from the PR instead.
 - Before opening a PR: build all affected schemes, run tests, `bundle exec fastlane run_swift_format strict:true`.
 - PRs must include: clear description, linked issues, CHANGELOG updates for user-visible changes, and screenshots/screencasts for UI changes. No new warnings.
+- Use the GitHub CLI to create a PR and use the Linear MCP to link the relevant issue.
+- When creating a PR for v2 work, the base branch should be `v2`.
+- Do not use `gh pr edit` (GraphQL `projectCards` deprecation). Patch the body with `gh api repos/.../pulls/N -X PATCH`.
+- Do not write "Made with Cursor" in the PR description.
 
 ## Security & Configuration Tips
+
 - Never commit API keys or user data; use env/xcconfig with placeholders.
 - Redact tokens in logs; use TLS; respect backend-provided TURN/ICE config.
 - Shared Codex worktree config lives in `.codex/environments/environment.toml`
@@ -161,6 +371,7 @@ Agents should optimize for media quality, API stability, backwards compatibility
   files.
 
 ### Media & permissions checklist
+
 - Request & handle camera and microphone permissions gracefully.
 - Handle foreground/background transitions; pause/resume capture appropriately.
 - Support device rotation and multi‑orientation previews.

--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
         .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.15.0"),
-        // Temporary pin to the develop commit that added StreamCoreUI
-        // tokens. Restore `from:` once they ship in a tag.
+        // Temporary branch pin until fonts land in develop and ship in a tag.
         .package(
             url: "https://github.com/GetStream/stream-core-swift.git",
-            revision: "7dcc7c889dcd1d860576c82cac8a0f486cec7d26"
+            branch: "core-ui-design-fonts"
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -24,10 +24,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
         .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.15.0"),
-        // Temporary branch pin until fonts land in develop and ship in a tag.
+        // Temporary pin to the develop commit that added StreamCoreUI
+        // fonts. Restore `from:` once they ship in a tag.
         .package(
             url: "https://github.com/GetStream/stream-core-swift.git",
-            branch: "core-ui-design-fonts"
+            revision: "fecb30ec066d29b4fd4acd3d9b6039558057d91f"
         )
     ],
     targets: [

--- a/Sources/StreamVideoSwiftUI/VideoAppearance.swift
+++ b/Sources/StreamVideoSwiftUI/VideoAppearance.swift
@@ -10,8 +10,9 @@ import SwiftUI
 ///
 /// Shared color and layout tokens come from ``DesignSystemTokens``. Pass
 /// the same instance into Chat's appearance so both SDKs reskin together.
-/// Video-only colors live on ``colors``. Existing views still use
-/// ``Appearance`` until they migrate.
+/// Video-only colors live on ``colors``. Shared typography is
+/// ``tokens/fonts``. Existing views still use ``Appearance/fonts``
+/// until they migrate.
 ///
 /// ```swift
 /// let tokens = DesignSystemTokens()

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3378,8 +3378,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
-				kind = branch;
-				branch = "core-ui-design-fonts";
+				kind = revision;
+				revision = fecb30ec066d29b4fd4acd3d9b6039558057d91f;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3378,8 +3378,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
-				kind = revision;
-				revision = 7dcc7c889dcd1d860576c82cac8a0f486cec7d26;
+				kind = branch;
+				branch = "core-ui-design-fonts";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StreamVideoSwiftUITests/DesignSystem/Appearance+DesignSystem_Tests.swift
+++ b/StreamVideoSwiftUITests/DesignSystem/Appearance+DesignSystem_Tests.swift
@@ -49,6 +49,13 @@ final class Appearance_DesignSystem_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(subject.tokens.layout.spacingMd, 99)
     }
 
+    func test_tokens_fontWrite_readsBack() {
+        let custom = Font.system(size: 99)
+        subject.tokens.fonts.body = custom
+
+        XCTAssertEqual(subject.tokens.fonts.body, custom)
+    }
+
     // MARK: - Cascade
 
     func test_sharedTokenOverriddenBeforeFirstRead_videoColorUsesOverride() {


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-2006](https://linear.app/stream/issue/IOS-2006/move-shared-typography-into-streamcoreui)
- Depends on [stream-core-swift#82](https://github.com/GetStream/stream-core-swift/pull/82)

### 🎯 Goal

Make shared Core typography available on `VideoAppearance.tokens.fonts` without migrating existing views off legacy `Appearance.fonts`.

### 📝 Summary

- Pin StreamCore to the `core-ui-design-fonts` branch
- Document that shared fonts live on `videoAppearance.tokens.fonts`
- Keep views, docs, and `Appearance.fonts` unchanged
- Add a test that token fonts can be overridden

### 🛠 Implementation

Core now owns SwiftUI typography on `DesignSystemTokens.fonts`. Video reads that group through `VideoAppearance.tokens` and leaves `@Injected(\.fonts)` / `Appearance.fonts` in place until a later migration. This PR only pins Core and documents the destination path.

### 🎨 Showcase

N/A — no view changes.

### 🧪 Manual Testing Notes

- Resolve packages against `core-ui-design-fonts`
- Run `Appearance_DesignSystem_Tests`

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)