### PR TITLE
[Fix]Xcode 27 compilation of iOS 13 UI backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
+- Added support for Xcode 27. [#1263](https://github.com/GetStream/stream-video-swift/pull/1263)
 - `StreamVideo.getEdges()` returns the list of edges (datacenters) available for hosting calls [#1247](https://github.com/GetStream/stream-video-swift/pull/1247).
 - `Call.deleteRecording(callSessionId:filename:)` for deleting a recording of a call session [#1244](https://github.com/GetStream/stream-video-swift/pull/1244).
 - Added `Call.delete(hard:)` for deleting a call. [#1243](https://github.com/GetStream/stream-video-swift/pull/1243)

--- a/DemoApp/Sources/Components/AudioTrackPlayer/AudioTrackPlayer.swift
+++ b/DemoApp/Sources/Components/AudioTrackPlayer/AudioTrackPlayer.swift
@@ -6,7 +6,7 @@ import AVFoundation
 import Foundation
 import StreamVideo
 
-final class AudioTrackPlayer: NSObject, AVAudioPlayerDelegate, @unchecked Sendable {
+final class AudioTrackPlayer: NSObject, @unchecked Sendable {
     enum Track: String, Equatable, CaseIterable {
         case track1 = "track_1"
         case track2 = "track_2"
@@ -60,8 +60,11 @@ final class AudioTrackPlayer: NSObject, AVAudioPlayerDelegate, @unchecked Sendab
             track = nil
         }
     }
+}
 
-    // MARK: - AVAudioPlayerDelegate
+// MARK: - AVAudioPlayerDelegate
+
+extension AudioTrackPlayer: AVAudioPlayerDelegate {
 
     func audioPlayerDidFinishPlaying(
         _ player: AVAudioPlayer,

--- a/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
+++ b/DemoApp/Sources/Components/Debug/Items/FeatureFlags/DebugMenu+FeatureFlagsView.swift
@@ -10,7 +10,7 @@ extension AppEnvironment {
     /// Wraps a debug menu view in an identifiable container.
     struct FeatureFlag: Identifiable {
         var id: UUID = .init()
-        var viewProvider: () -> AnyView
+        var viewProvider: @MainActor () -> AnyView
     }
 
     nonisolated(unsafe) static var featureFlags: [FeatureFlag] = [

--- a/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/LocalParticipantViewModifier.swift
@@ -73,7 +73,7 @@ public struct LocalParticipantViewModifier: ViewModifier {
     }
 }
 
-@available(iOS, introduced: 13, obsoleted: 14)
+@available(iOS, introduced: 13, deprecated: 14)
 public struct LocalParticipantViewModifier_iOS13: ViewModifier {
 
     private let localParticipant: CallParticipant

--- a/Sources/StreamVideoSwiftUI/CallView/PermissionsPromptView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/PermissionsPromptView.swift
@@ -91,26 +91,31 @@ public struct PermissionsPromptView: View {
         Button {
             presentNavigationPopup = true
         } label: {
-            if #available(iOS 14.0, *) {
-                Label {
-                    Text(L10n.Call.Permissions.Missing.Cta.title)
-                } icon: {
-                    Image(systemName: "gear")
-                }
-                .minimumScaleFactor(0.7)
-            } else {
-                HStack(alignment: .center, spacing: 4) {
-                    Image(systemName: "gear")
-                    Text(L10n.Call.Permissions.Missing.Cta.title)
-                }
-                .minimumScaleFactor(0.7)
-            }
+            settingsButtonLabel
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
         .foregroundColor(.white)
         .background(Color.blue)
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var settingsButtonLabel: some View {
+        if #available(iOS 14.0, *) {
+            Label {
+                Text(L10n.Call.Permissions.Missing.Cta.title)
+            } icon: {
+                Image(systemName: "gear")
+            }
+            .minimumScaleFactor(0.7)
+        } else {
+            HStack(alignment: .center, spacing: 4) {
+                Image(systemName: "gear")
+                Text(L10n.Call.Permissions.Missing.Cta.title)
+            }
+            .minimumScaleFactor(0.7)
+        }
     }
 
     private var alertContentView: Alert {

--- a/Sources/StreamVideoSwiftUI/CallView/SampleBufferVideoCallView.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/SampleBufferVideoCallView.swift
@@ -37,6 +37,7 @@ final class SampleBufferVideoCallView: UIView {
     }
 }
 
+@MainActor
 protocol SampleBufferVideoRendering {
     @available(iOS 14.0, *)
     var requiresFlushToResumeDecoding: Bool { get }

--- a/Sources/StreamVideoSwiftUI/CallView/ViewModifiers/CallEndedViewModifier.swift
+++ b/Sources/StreamVideoSwiftUI/CallView/ViewModifiers/CallEndedViewModifier.swift
@@ -131,7 +131,7 @@ private struct CallEndedViewModifier<Subview: View>: ViewModifier {
     }
 }
 
-@available(iOS, introduced: 13, obsoleted: 14)
+@available(iOS, introduced: 13, deprecated: 14)
 private struct CallEndedViewModifier_iOS13<Subview: View>: ViewModifier {
 
     private var presentationValidator: (Call?) -> Bool

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/BackportStateObject.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/BackportStateObject.swift
@@ -7,12 +7,12 @@ import SwiftUI
 
 /// A property wrapper type that instantiates an observable object.
 @MainActor
-@propertyWrapper @available(iOS, introduced: 13, obsoleted: 14)
+@propertyWrapper @available(iOS, introduced: 13, deprecated: 14)
 public final class BackportStateObject<ObjectType: ObservableObject & Sendable>: DynamicProperty, @unchecked Sendable
     where ObjectType.ObjectWillChangePublisher == ObservableObjectPublisher {
     
     /// Wrapper that helps with initialising without actually having an ObservableObject yet
-    private class ObservedObjectWrapper: ObservableObject, @unchecked Sendable {
+    class ObservedObjectWrapper: ObservableObject, @unchecked Sendable {
         @PublishedObject var wrappedObject: ObjectType? = nil
         init() {}
     }
@@ -53,7 +53,7 @@ public final class BackportStateObject<ObjectType: ObservableObject & Sendable>:
 
 /// Just like @Published this sends willSet events to the enclosing ObservableObject's ObjectWillChangePublisher
 /// but unlike @Published it also sends the wrapped value's published changes on to the enclosing ObservableObject
-@propertyWrapper @available(iOS, introduced: 13, obsoleted: 14)
+@propertyWrapper @available(iOS, introduced: 13, deprecated: 14)
 public struct PublishedObject<Value> {
 
     public init(wrappedValue: Value) where Value: ObservableObject & Sendable,

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/IncomingCallView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/IncomingCallView_iOS13.swift
@@ -5,7 +5,7 @@
 import StreamVideo
 import SwiftUI
 
-@available(iOS, introduced: 13, obsoleted: 14)
+@available(iOS, introduced: 13, deprecated: 14)
 public struct IncomingCallView_iOS13<Factory: ViewFactory>: View {
     @Injected(\.streamVideo) var streamVideo
     @Injected(\.fonts) var fonts

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/PreJoiningView_iOS13.swift
@@ -5,7 +5,7 @@
 import StreamVideo
 import SwiftUI
 
-@available(iOS, introduced: 13, obsoleted: 14)
+@available(iOS, introduced: 13, deprecated: 14)
 public struct LobbyView_iOS13<Factory: ViewFactory>: View {
 
     @ObservedObject var callViewModel: CallViewModel

--- a/Sources/StreamVideoSwiftUI/CallingViews/iOS13/VideoView_iOS13.swift
+++ b/Sources/StreamVideoSwiftUI/CallingViews/iOS13/VideoView_iOS13.swift
@@ -5,7 +5,7 @@
 import StreamVideo
 import SwiftUI
 
-@available(iOS, introduced: 13, obsoleted: 14)
+@available(iOS, introduced: 13, deprecated: 14)
 public struct CallContainer_iOS13<Factory: ViewFactory>: View {
     
     @Injected(\.utils) var utils

--- a/Sources/StreamVideoUIKit/CallViewController.swift
+++ b/Sources/StreamVideoUIKit/CallViewController.swift
@@ -106,7 +106,7 @@ final class CallViewContainer: UIView {
         embed(uiView)
     }
     
-    @available(iOS, introduced: 13, obsoleted: 14)
+    @available(iOS, introduced: 13, deprecated: 14)
     init<Factory: ViewFactory>(view: CallContainer_iOS13<Factory>, frame: CGRect) {
         let uiView = UIHostingController(rootView: view).view!
         uiView.backgroundColor = .clear

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -1940,7 +1940,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideo/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1978,7 +1978,7 @@
 					"$(inherited)",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2007,7 +2007,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideoSwiftUI/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2037,7 +2037,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoSwiftUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2067,7 +2067,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideoUIKit/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2097,7 +2097,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "-DSTREAM_SNAPSHOT_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoUIKitTests;
@@ -2137,7 +2137,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2188,7 +2188,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2220,7 +2220,7 @@
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GCC_OPTIMIZATION_LEVEL = s;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.SwiftUIDemoAppUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2246,7 +2246,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/CallIntent/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = CallIntent;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2277,7 +2277,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/ScreenSharing/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2307,7 +2307,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.SwiftUIDemoAppUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2327,7 +2327,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.SwiftUIDemoAppUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2351,7 +2351,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/CallIntent/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = CallIntent;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2384,7 +2384,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/CallIntent/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = CallIntent;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2557,7 +2557,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2606,7 +2606,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2643,7 +2643,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/ScreenSharing/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2680,7 +2680,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/ScreenSharing/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2728,7 +2728,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2779,7 +2779,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2820,7 +2820,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideo/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2864,7 +2864,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideo/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2894,7 +2894,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2913,7 +2913,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2942,7 +2942,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideoSwiftUI/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2984,7 +2984,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideoSwiftUI/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3013,7 +3013,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoSwiftUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3032,7 +3032,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoSwiftUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3062,7 +3062,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideoUIKit/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3104,7 +3104,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamVideoUIKit/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_GENERATE_MAP_FILE = YES;
 				LD_MAP_FILE_PATH = "linkmaps/$(PRODUCT_NAME)-$(CURRENT_ARCH)-LinkMap.txt";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3133,7 +3133,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "-DSTREAM_SNAPSHOT_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoUIKitTests;
@@ -3152,7 +3152,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.iOS.StreamVideoUIKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -1352,7 +1352,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         for _ in 0..<cycles {
             try await helpers
-                .callFlow(id: .unique, type: .default, userId: userId)
+                .callFlow(
+                    id: .unique,
+                    type: .default,
+                    userId: userId,
+                    // Reuse one client for join/leave cycles.
+                    clientResolutionMode: .default
+                )
                 .perform { try await $0.call.create(memberIds: [userId]) }
                 .perform { try await $0.call.join(callSettings: .init(audioOn: true, speakerOn: routeVariant == .speakerEnabled)) }
                 .perform { $0.call.leave() }

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+StreamVideoHelper.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+StreamVideoHelper.swift
@@ -57,10 +57,12 @@ extension Call_IntegrationTests.Helpers {
             }()
 
             let currentStreamVideo = StreamVideoProviderKey.currentValue
-            let result = {
-                if clientResolutionMode == .default, let existingClient = registeredClients[userId] {
+            let result = await {
+                let existingClient = registeredClients[userId]
+                if clientResolutionMode == .default, let existingClient {
                     return existingClient
                 } else {
+                    await existingClient?.disconnect()
                     return StreamVideo(
                         apiKey: apiKey,
                         user: User(id: userId),

--- a/StreamVideoTests/WebRTC/SFU/SFUAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUAdapter_Tests.swift
@@ -175,7 +175,7 @@ final class SFUAdapterTests: XCTestCase, @unchecked Sendable {
         _ = subject
         var received: [Stream_Video_Sfu_Event_SfuEvent.OneOf_EventPayload] = []
         let newEventReceived = expectation(description: "New socket event received.")
-        let cancellable = subject.publisher.sink {
+        let cancellable = subject!.publisher.sink {
             received.append($0)
             newEventReceived.fulfill()
         }
@@ -603,7 +603,7 @@ final class SFUAdapterTests: XCTestCase, @unchecked Sendable {
         _ = subject
 
         let bucket = ConsumableBucket(
-            subject.publisher.eraseToAnyPublisher()
+            subject!.publisher.eraseToAnyPublisher()
         )
 
         var offer = Stream_Video_Sfu_Event_SubscriberOffer()

--- a/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/SFU/SFUEventAdapter_Tests.swift
@@ -121,7 +121,7 @@ final class SFUEventAdapter_Tests: XCTestCase, @unchecked Sendable {
 
     func test_handleChangePublishQuality_givenEvent_whenPublished_thenUpdatesPublisherQuality() async throws {
         try await stateAdapter.configurePeerConnections()
-        let publisher = await stateAdapter.publisher
+        let publisher = await stateAdapter!.publisher
 
         let participantA = CallParticipant.dummy()
         let participantB = CallParticipant.dummy()

--- a/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/PeerConnection/RTCPeerConnectionCoordinator_Tests.swift
@@ -206,7 +206,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         mockPeerConnection.stub(for: .offer, with: offer)
 
         let expectation = self.expectation(description: "CreateOfferEvent was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.CreateOfferEvent }
             .filter { $0.sessionDescription.sdp == offer.sdp }
@@ -233,7 +233,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         mockPeerConnection.stub(for: .answer, with: answer)
 
         let expectation = self.expectation(description: "CreateAnswerEvent was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.CreateAnswerEvent }
             .filter { $0.sessionDescription.sdp == answer.sdp }
@@ -260,7 +260,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         mockPeerConnection.stub(for: .setLocalDescription, with: value)
 
         let expectation = self.expectation(description: "setLocalDescription was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.SetLocalDescriptionEvent }
             .filter { $0.sessionDescription.sdp == value.sdp }
@@ -287,7 +287,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         mockPeerConnection.stub(for: .setRemoteDescription, with: value)
 
         let expectation = self.expectation(description: "setRemoteDescription was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.SetRemoteDescriptionEvent }
             .filter { $0.sessionDescription.sdp == value.sdp }
@@ -309,7 +309,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
 
     func test_close_eventWasPublished() async throws {
         let expectation = self.expectation(description: "CloseEvent was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.CloseEvent }
             .sink { _ in expectation.fulfill() }
@@ -775,7 +775,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
     func test_restartICE_subjectIsPublisher_eventWasPublished() async throws {
         _ = subject
         let expectation = self.expectation(description: "RestartICEEvent was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.RestartICEEvent }
             .sink { _ in expectation.fulfill() }
@@ -805,7 +805,7 @@ final class RTCPeerConnectionCoordinator_Tests: XCTestCase, @unchecked Sendable 
         peerType = .subscriber
         _ = subject
         let expectation = self.expectation(description: "RestartICEEvent was not received.")
-        let cancellable: AnyCancellable? = mockPeerConnection
+        let cancellable: AnyCancellable? = mockPeerConnection!
             .publisher
             .compactMap { $0 as? StreamRTCPeerConnection.RestartICEEvent }
             .sink { _ in expectation.fulfill() }

--- a/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
+++ b/StreamVideoTests/WebRTC/v2/WebRTCStateAdapter_Tests.swift
@@ -331,7 +331,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await subject.set(sfuAdapter: sfuStack.adapter)
         await subject.enqueueOwnCapabilities { [.sendAudio, .sendVideo, .screenshare] }
         try await subject.configurePeerConnections()
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
 
         let screenShareSessionProvider = await subject.screenShareSessionProvider
         screenShareSessionProvider.activeSession = .init(
@@ -367,7 +367,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         let sfuStack = MockSFUStack()
         await subject.set(sfuAdapter: sfuStack.adapter)
         try await subject.configurePeerConnections()
-        let publisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let publisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         publisher.stubEventSubject.send(
             StreamRTCPeerConnection.CreateOfferEvent(
                 sessionDescription: .init(type: .offer, sdp: "")
@@ -477,7 +477,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         await subject.set(videoFilter: expected)
 
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         XCTAssertEqual(
             mockPublisher.recordedInputPayload(VideoFilter.self, for: .setVideoFilter)?.first?.id,
             expected.id
@@ -550,7 +550,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await subject.configurePeerConnections()
 
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         let mockSubscriber = try await XCTAsyncUnwrap(await subject.subscriber as? MockRTCPeerConnectionCoordinator)
 
         await fulfillment {
@@ -629,7 +629,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await subject.configurePeerConnections()
 
-        let publisher = try await XCTAsyncUnwrap(await subject.publisher)
+        let publisher = try await XCTAsyncUnwrap(await subject!.publisher)
         let subscriber = try await XCTAsyncUnwrap(await subject.subscriber)
         XCTAssertTrue(mockStatsAdapter.publisher === publisher)
         XCTAssertTrue(mockStatsAdapter.subscriber === subscriber)
@@ -651,9 +651,9 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
 
         try await subject.configurePeerConnections()
 
-        await fulfillment { await self.subject.publisher != nil }
+        await fulfillment { await self.subject!.publisher != nil }
 
-        let _publisher = await subject.publisher
+        let _publisher = await subject!.publisher
         let publisher = try XCTUnwrap(_publisher)
         let _subscriber = await subject.subscriber
         let subscriber = try XCTUnwrap(_subscriber)
@@ -682,7 +682,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await subject.enqueueOwnCapabilities { ownCapabilities }
 
         try await subject.configurePeerConnections()
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
 
         XCTAssertEqual(
             mockPublisher.recordedInputPayload(
@@ -714,7 +714,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await subject.enqueueOwnCapabilities { ownCapabilities }
 
         try await subject.configurePeerConnections()
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
 
         XCTAssertEqual(mockPublisher.timesCalled(.beginScreenSharing), 0)
     }
@@ -816,7 +816,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
     func test_cleanUp_shouldResetProperties() async throws {
         let sfuStack = MockSFUStack()
         try await prepare(sfuStack: sfuStack)
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         let mockSubscriber = try await XCTAsyncUnwrap(await subject.subscriber as? MockRTCPeerConnectionCoordinator)
 
         await subject.cleanUp()
@@ -825,8 +825,8 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockSubscriber.timesCalled(.close), 1)
         XCTAssertEqual(sfuStack.webSocket.timesCalled(.disconnectAsync), 1)
 
-        await fulfillment { await self.subject.publisher == nil }
-        await assertNilAsync(await subject.publisher)
+        await fulfillment { await self.subject!.publisher == nil }
+        await assertNilAsync(await subject!.publisher)
         await assertNilAsync(await subject.subscriber)
         await assertNilAsync(await subject.statsAdapter)
         await assertNilAsync(await subject.sfuAdapter)
@@ -889,7 +889,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
             participants: participants,
             participantPins: pins
         )
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         let mockSubscriber = try await XCTAsyncUnwrap(await subject.subscriber as? MockRTCPeerConnectionCoordinator)
         let sessionId = await subject.sessionID
         await subject.didAddTrack(
@@ -914,7 +914,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(mockPublisher.timesCalled(.close), 0)
         XCTAssertEqual(mockSubscriber.timesCalled(.close), 0)
         XCTAssertEqual(sfuStack.webSocket.timesCalled(.disconnectAsync), 0)
-        await assertNilAsync(await subject.publisher)
+        await assertNilAsync(await subject!.publisher)
         await assertNilAsync(await subject.subscriber)
         await assertNilAsync(await subject.statsAdapter)
         await assertNilAsync(await subject.sfuAdapter)
@@ -1199,7 +1199,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         sfuStack.setConnectionState(to: .connected(healthCheckInfo: .init()))
         await subject.set(sfuAdapter: sfuStack.adapter)
         try await subject.configurePeerConnections()
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         let mockSubscriber = try await XCTAsyncUnwrap(await subject.subscriber as? MockRTCPeerConnectionCoordinator)
         let newVideoOptions = VideoOptions(
             preferredCameraPosition: .back
@@ -1381,7 +1381,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         )
 
         await subject.enqueueCallSettings { _ in newCallSettings }
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
 
         await fulfillment {
             mockPublisher.timesCalled(.didUpdateCallSettings) == 1
@@ -1409,7 +1409,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await subject.enqueueCallSettings { _ in .init(videoOn: true) }
 
         let mockPublisher = try await XCTAsyncUnwrap(
-            await subject.publisher as? MockRTCPeerConnectionCoordinator
+            await subject!.publisher as? MockRTCPeerConnectionCoordinator
         )
         await fulfillment {
             mockPublisher.timesCalled(.didUpdateCallSettings) == 1
@@ -1440,7 +1440,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
         await subject.enqueueCallSettings { _ in .init(audioOn: true) }
 
         let mockPublisher = try await XCTAsyncUnwrap(
-            await subject.publisher as? MockRTCPeerConnectionCoordinator
+            await subject!.publisher as? MockRTCPeerConnectionCoordinator
         )
         await fulfillment {
             mockPublisher.timesCalled(.didUpdateCallSettings) == 1
@@ -1474,7 +1474,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
             audioOn: true
         )
 
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         await fulfillment {
             mockPublisher.timesCalled(.didUpdateCallSettings) == 2
         }
@@ -1504,7 +1504,7 @@ final class WebRTCStateAdapter_Tests: XCTestCase, @unchecked Sendable {
             videoOn: true
         )
 
-        let mockPublisher = try await XCTAsyncUnwrap(await subject.publisher as? MockRTCPeerConnectionCoordinator)
+        let mockPublisher = try await XCTAsyncUnwrap(await subject!.publisher as? MockRTCPeerConnectionCoordinator)
         await fulfillment {
             mockPublisher.timesCalled(.didUpdateCallSettings) == 2
         }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-2009/enhancementprepare-for-ios-27-release

### 🎯 Goal

Resolve compilation errors in the SDK’s iOS 13 UI backports when building with Xcode 27.

### 📝 Summary

- Make `ObservedObjectWrapper` internal so SwiftUI’s `@State` macro can generate storage properties without referencing a private type.
- Replace `obsoleted: 14` with `deprecated: 14` across the SwiftUI backports and their UIKit container initializer.

### 🛠 Implementation

The `@State` macro generates internal storage properties whose inferred types include `ObservedObjectWrapper`. Matching the helper’s visibility to those properties resolves the access-control error without making it public.

The iOS 13 fallback declarations remain available for compilation but are deprecated starting with iOS 14. This avoids unavailable-type errors when the compiler checks fallback branches under modern deployment targets. Existing runtime availability checks remain unchanged.

### 🎨 Showcase

N/A — no visual changes.

### 🧪 Manual Testing Notes

Isolated compiler checks passed with Xcode 27 beta 6. Full SDK and sample-app validation remains pending.

1. Add the local package’s `StreamVideo` and `StreamVideoSwiftUI` products to an iOS sample app.
2. Build with Xcode 27 and an iOS 27 deployment target.
3. Confirm that macro access-control and unavailable-backport errors no longer occur.
4. Build a UIKit consumer to verify the updated container initializer.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - iOS 13 fallback views and components remain available on iOS 14 and later, with deprecation warnings instead of being unavailable.
  - The minimum supported iOS deployment target is now iOS 15 across application and test targets.

- **Documentation**
  - Added an upcoming release note announcing Xcode 27 support.

- **Developer Experience**
  - Improved compatibility with modern Swift concurrency requirements and current Swift and Xcode checks.
  - Improved reliability when cancelled connections fail during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->