### PR TITLE
[Fix]Test flakiness

### DIFF
--- a/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
+++ b/Sources/StreamVideo/CallStateMachine/Stages/Call+JoiningStage.swift
@@ -104,16 +104,32 @@ extension Call.StateMachine.Stage {
                     call.leave(reason: "join.interception.failed")
                     transitionErrorOrLog(error)
                 } catch {
+                    // `joinCall` can still throw TimeOutError after leave.
+                    if Task.isCancelled {
+                        return
+                    }
+
                     var input = input
                     input.currentNumberOfRetries += 1
 
                     if input.currentNumberOfRetries < input.retryPolicy.maxRetries {
-                        let delay = UInt64((input.retryPolicy.delay(input.currentNumberOfRetries)) * 1_000_000_000)
+                        let delay = UInt64(
+                            (input.retryPolicy.delay(input.currentNumberOfRetries))
+                                * 1_000_000_000
+                        )
                         log.error(
                             "Joining call id:\(call.callId) type:\(call.callType) failed. Will retry after a delay.",
                             error: error
                         )
-                        try? await Task.sleep(nanoseconds: delay)
+                        // `try? Task.sleep` swallowed CancellationError
+                        // and re-entered `.joining` after leave (CI hang).
+                        // Cancel must return.
+                        do {
+                            try await Task.sleep(nanoseconds: delay)
+                            try Task.checkCancellation()
+                        } catch is CancellationError {
+                            return
+                        }
                         transitionOrError(.joining(call, input: .join(input)))
                     } else {
                         input.deliverySubject.send(completion: .failure(error))

--- a/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
+++ b/StreamVideoTests/CallStateMachine/CallStateMachine/Stages/CallStateMachine_JoiningStageTests.swift
@@ -665,6 +665,47 @@ final class StreamCallStateMachineStageJoiningStage_Tests: StreamVideoTestCase, 
         cancellable.cancel()
     }
 
+    func test_execute_whenCancelledDuringRetryDelay_doesNotReenterJoining() async throws {
+        let unexpectedReentry = expectation(
+            description: "Join should not retry after cancellation."
+        )
+        unexpectedReentry.isInverted = true
+        let context = Call.StateMachine.Stage.Context(
+            call: call,
+            input: .join(
+                .init(
+                    create: true,
+                    callSettings: .init(audioOn: false),
+                    options: .init(memberIds: [.unique]),
+                    ring: true,
+                    notify: false,
+                    source: .inApp,
+                    deliverySubject: .init(nil),
+                    retryPolicy: .init(maxRetries: 3, delay: { _ in 5 })
+                )
+            )
+        )
+
+        callController.stub(for: .join, with: ClientError())
+        subject.transition = {
+            if $0.id == .joining {
+                unexpectedReentry.fulfill()
+            }
+        }
+        subject.context = context
+
+        _ = subject.transition(from: .idle(.init()))
+
+        await fulfilmentInMainActor {
+            self.callController.timesCalled(.join) == 1
+        }
+
+        subject.willTransitionAway()
+
+        await fulfillment(of: [unexpectedReentry], timeout: 0.5)
+        XCTAssertEqual(callController.timesCalled(.join), 1)
+    }
+
     func test_execute_withRetries_whenJoinFailsAndThereAreAvailableRetries_transitionsToJoining() async throws {
         let context = Call.StateMachine.Stage.Context(
             call: call,

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -272,13 +272,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         // Initial CallFlow
         _ = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
             .perform { try await $0.call.create(memberIds: [user1]) }
             .assertEventuallyInMainActor { $0.call.state.members.endIndex == 1 }
 
         // Second CallFlow that uses a new StreamVideo client
         try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
             .perform { try await $0.call.get() }
             .assertEventuallyInMainActor { $0.call.state.members.endIndex == 1 && $0.call.state.members.first?.user.id == user1 }
             .perform { try await $0.call.addMembers(ids: [user2]) }
@@ -384,14 +384,16 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             .callFlow(
                 id: callId,
                 type: .default,
-                userId: creatorUserId
+                userId: creatorUserId,
+                audioSessionPolicy: DefaultAudioSessionPolicy()
             )
 
         let participantUserFlow = try await helpers
             .callFlow(
                 id: callId,
                 type: .default,
-                userId: participantUserId
+                userId: participantUserId,
+                audioSessionPolicy: DefaultAudioSessionPolicy()
             )
 
         let creatorFlow = try await creatorUserFlow
@@ -492,9 +494,9 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -529,9 +531,9 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user1CallFlowAfterCallCreation = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -567,9 +569,9 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
             .perform { $0.client.subscribe(for: CallRingEvent.self) }
 
         // We are joining first to be able to mock the permissions only for the
@@ -607,12 +609,24 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         try await helpers
-            .callFlow(id: callId, type: .livestream, userId: .unique, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: .unique,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(backstage: .init(enabled: true)) }
             .perform { try await $0.call.join() }
 
         try await helpers
-            .callFlow(id: callId, type: .livestream, userId: participant, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: participant,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .performWithErrorExpectation { try await $0.call.join() }
             .tryMap { $0.value as? APIError }
             .assert { $0.value.code == 17 }
@@ -638,10 +652,22 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let creatorCallFlow = try await helpers
-            .callFlow(id: callId, type: .livestream, userId: creator, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: creator,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
 
         let otherHostCallFlow = try await helpers
-            .callFlow(id: callId, type: .livestream, userId: otherHost, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: otherHost,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
 
         _ = try await creatorCallFlow
             .perform { try await $0.call.create(
@@ -657,7 +683,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
         try await helpers
-            .callFlow(id: callId, type: .livestream, userId: participant, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: participant,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .performWithErrorExpectation { try await $0.call.join() }
             .tryMap { $0.value as? APIError }
             .assert { $0.value.code == 17 }
@@ -676,7 +708,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let joiningDate = Date(timeIntervalSinceNow: joinAheadTimeSeconds + 2)
 
         try await helpers
-            .callFlow(id: callId, type: .livestream, userId: .unique, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: .unique,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform {
                 try await $0.call.create(
                     startsAt: startingDate,
@@ -690,7 +728,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         try await self
             .helpers
-            .callFlow(id: callId, type: .livestream, userId: participant, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .livestream,
+                userId: participant,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .performWithErrorExpectation { try await $0.call.join() }
             .assertEventually { _ in Date() >= joiningDate }
             .perform { try await $0.call.join() }
@@ -704,12 +748,24 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let host = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join() }
 
         let participantCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: .unique, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: .unique,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -737,12 +793,24 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let host = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join() }
 
         let participantCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: .unique, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: .unique,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -772,13 +840,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = "participant"
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host)
+            .callFlow(id: callId, type: .audioRoom, userId: host, audioSessionPolicy: DefaultAudioSessionPolicy())
             .perform { try await $0.call.create(members: [.init(role: "host", userId: host)], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join() }
             .assertEventuallyInMainActor { $0.call.state.ownCapabilities.contains(.updateCallPermissions) }
 
         let participantCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: participant)
+            .callFlow(id: callId, type: .audioRoom, userId: participant, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -811,7 +879,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
@@ -830,7 +904,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                         id: callId,
                         type: .audioRoom,
                         userId: participant,
-                        environment: "demo"
+                        environment: "demo",
+                        audioSessionPolicy: DefaultAudioSessionPolicy()
                     )
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
@@ -852,13 +927,25 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
         let participantCallFlow = try await self
             .helpers
-            .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: participant,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -892,7 +979,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
@@ -912,7 +1005,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             group.addTask {
                 try await self
                     .helpers
-                    .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
+                    .callFlow(
+                        id: callId,
+                        type: .audioRoom,
+                        userId: participant,
+                        environment: "demo",
+                        audioSessionPolicy: DefaultAudioSessionPolicy()
+                    )
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
@@ -935,14 +1034,26 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
             .assertEventuallyInMainActor { $0.call.state.ownCapabilities.contains(.updateCallPermissions) }
 
         let participantCallFlow = try await self
             .helpers
-            .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: participant,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -986,7 +1097,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
+            .callFlow(
+                id: callId,
+                type: .audioRoom,
+                userId: host,
+                environment: "demo",
+                audioSessionPolicy: DefaultAudioSessionPolicy()
+            )
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
@@ -1008,7 +1125,8 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
                         id: callId,
                         type: .audioRoom,
                         userId: participant,
-                        environment: "demo"
+                        environment: "demo",
+                        audioSessionPolicy: DefaultAudioSessionPolicy()
                     )
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendVideo) == false }
@@ -1072,10 +1190,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let creatorCallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: creator)
+            .callFlow(id: callId, type: .default, userId: creator, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let participantCallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: participant)
+            .callFlow(id: callId, type: .default, userId: participant, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let creatorJoinedCallFlow = try await creatorCallFlow
             .perform {
@@ -1117,7 +1235,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 1 }
 
         let participantRejoinedFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: participant)
+            .callFlow(id: callId, type: .default, userId: participant, audioSessionPolicy: DefaultAudioSessionPolicy())
             .perform {
                 try await $0.call.join()
             }
@@ -1161,10 +1279,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1201,10 +1319,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1238,10 +1356,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1294,10 +1412,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1)
+            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2)
+            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1377,10 +1495,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         helpers.permissions.setMicrophonePermission(isGranted: true)
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user1)
+            .callFlow(id: callId, type: .audioRoom, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user2)
+            .callFlow(id: callId, type: .audioRoom, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user1CallFlowAfterCallCreation = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1429,10 +1547,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         helpers.permissions.setMicrophonePermission(isGranted: true)
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user1)
+            .callFlow(id: callId, type: .audioRoom, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user2)
+            .callFlow(id: callId, type: .audioRoom, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
             .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
         let user1CallFlowAfterCallCreation = try await user1CallFlow

--- a/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
+++ b/StreamVideoTests/IntegrationTests/Call_IntegrationTests.swift
@@ -272,13 +272,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         // Initial CallFlow
         _ = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
             .perform { try await $0.call.create(memberIds: [user1]) }
             .assertEventuallyInMainActor { $0.call.state.members.endIndex == 1 }
 
         // Second CallFlow that uses a new StreamVideo client
         try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
             .perform { try await $0.call.get() }
             .assertEventuallyInMainActor { $0.call.state.members.endIndex == 1 && $0.call.state.members.first?.user.id == user1 }
             .perform { try await $0.call.addMembers(ids: [user2]) }
@@ -381,20 +381,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         helpers.duringDismantleObservedAllCallEnded = false
 
         let creatorUserFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .default,
-                userId: creatorUserId,
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .default, userId: creatorUserId)
 
         let participantUserFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .default,
-                userId: participantUserId,
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .default, userId: participantUserId)
 
         let creatorFlow = try await creatorUserFlow
             .perform { try await $0.call.create(memberIds: [creatorUserId, participantUserId]) }
@@ -494,9 +484,9 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -531,9 +521,9 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
 
         let user1CallFlowAfterCallCreation = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -569,9 +559,9 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
             .perform { $0.client.subscribe(for: CallRingEvent.self) }
 
         // We are joining first to be able to mock the permissions only for the
@@ -609,24 +599,12 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         try await helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: .unique,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: .unique, environment: "demo")
             .perform { try await $0.call.create(backstage: .init(enabled: true)) }
             .perform { try await $0.call.join() }
 
         try await helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: participant,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: participant, environment: "demo")
             .performWithErrorExpectation { try await $0.call.join() }
             .tryMap { $0.value as? APIError }
             .assert { $0.value.code == 17 }
@@ -652,22 +630,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let creatorCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: creator,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: creator, environment: "demo")
 
         let otherHostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: otherHost,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: otherHost, environment: "demo")
 
         _ = try await creatorCallFlow
             .perform { try await $0.call.create(
@@ -683,13 +649,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
         try await helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: participant,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: participant, environment: "demo")
             .performWithErrorExpectation { try await $0.call.join() }
             .tryMap { $0.value as? APIError }
             .assert { $0.value.code == 17 }
@@ -708,13 +668,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let joiningDate = Date(timeIntervalSinceNow: joinAheadTimeSeconds + 2)
 
         try await helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: .unique,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: .unique, environment: "demo")
             .perform {
                 try await $0.call.create(
                     startsAt: startingDate,
@@ -728,13 +682,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
 
         try await self
             .helpers
-            .callFlow(
-                id: callId,
-                type: .livestream,
-                userId: participant,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .livestream, userId: participant, environment: "demo")
             .performWithErrorExpectation { try await $0.call.join() }
             .assertEventually { _ in Date() >= joiningDate }
             .perform { try await $0.call.join() }
@@ -748,24 +696,12 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let host = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join() }
 
         let participantCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: .unique,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: .unique, environment: "demo")
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -793,24 +729,12 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let host = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join() }
 
         let participantCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: .unique,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: .unique, environment: "demo")
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -840,13 +764,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = "participant"
 
         let hostCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: host, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .audioRoom, userId: host)
             .perform { try await $0.call.create(members: [.init(role: "host", userId: host)], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join() }
             .assertEventuallyInMainActor { $0.call.state.ownCapabilities.contains(.updateCallPermissions) }
 
         let participantCallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: participant, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .audioRoom, userId: participant)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -879,13 +803,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
@@ -900,13 +818,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             group.addTask {
                 try await self
                     .helpers
-                    .callFlow(
-                        id: callId,
-                        type: .audioRoom,
-                        userId: participant,
-                        environment: "demo",
-                        audioSessionPolicy: DefaultAudioSessionPolicy()
-                    )
+                    .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
@@ -927,25 +839,13 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
         let participantCallFlow = try await self
             .helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: participant,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -979,13 +879,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
@@ -1005,13 +899,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             group.addTask {
                 try await self
                     .helpers
-                    .callFlow(
-                        id: callId,
-                        type: .audioRoom,
-                        userId: participant,
-                        environment: "demo",
-                        audioSessionPolicy: DefaultAudioSessionPolicy()
-                    )
+                    .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 2 }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendAudio) == false }
@@ -1034,26 +922,14 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
             .assertEventuallyInMainActor { $0.call.state.ownCapabilities.contains(.updateCallPermissions) }
 
         let participantCallFlow = try await self
             .helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: participant,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -1097,13 +973,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let hostCallFlow = try await helpers
-            .callFlow(
-                id: callId,
-                type: .audioRoom,
-                userId: host,
-                environment: "demo",
-                audioSessionPolicy: DefaultAudioSessionPolicy()
-            )
+            .callFlow(id: callId, type: .audioRoom, userId: host, environment: "demo")
             .perform { try await $0.call.create(memberIds: [host], backstage: .init(enabled: false)) }
             .perform { try await $0.call.join(callSettings: .init(audioOn: true, videoOn: false)) }
 
@@ -1121,13 +991,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             group.addTask {
                 try await self
                     .helpers
-                    .callFlow(
-                        id: callId,
-                        type: .audioRoom,
-                        userId: participant,
-                        environment: "demo",
-                        audioSessionPolicy: DefaultAudioSessionPolicy()
-                    )
+                    .callFlow(id: callId, type: .audioRoom, userId: participant, environment: "demo")
                     .perform { try await $0.call.join(callSettings: .init(audioOn: false, videoOn: false)) }
                     .assertEventuallyInMainActor { $0.call.currentUserHasCapability(.sendVideo) == false }
                     .assertEventuallyInMainActor { $0.call.state.callSettings.videoOn == false }
@@ -1190,10 +1054,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let participant = String.unique
 
         let creatorCallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: creator, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: creator)
 
         let participantCallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: participant, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: participant)
 
         let creatorJoinedCallFlow = try await creatorCallFlow
             .perform {
@@ -1235,7 +1099,7 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
             .assertEventuallyInMainActor { $0.call.state.participants.endIndex == 1 }
 
         let participantRejoinedFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: participant, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: participant)
             .perform {
                 try await $0.call.join()
             }
@@ -1279,10 +1143,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1319,10 +1183,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1356,10 +1220,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1412,10 +1276,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         let user2 = String.unique
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user1)
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .default, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .default, userId: user2)
 
         let user1JoinedFlow = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1495,10 +1359,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         helpers.permissions.setMicrophonePermission(isGranted: true)
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .audioRoom, userId: user1)
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .audioRoom, userId: user2)
 
         let user1CallFlowAfterCallCreation = try await user1CallFlow
             .perform { try await $0.call.create(memberIds: [user1, user2]) }
@@ -1547,10 +1411,10 @@ final class Call_IntegrationTests: XCTestCase, @unchecked Sendable {
         helpers.permissions.setMicrophonePermission(isGranted: true)
 
         let user1CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user1, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .audioRoom, userId: user1)
 
         let user2CallFlow = try await helpers
-            .callFlow(id: callId, type: .audioRoom, userId: user2, audioSessionPolicy: DefaultAudioSessionPolicy())
+            .callFlow(id: callId, type: .audioRoom, userId: user2)
             .assertEventuallyInMainActor { $0.call.state.sessionId.isEmpty == false }
 
         let user1CallFlowAfterCallCreation = try await user1CallFlow

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
@@ -104,8 +104,7 @@ extension Call_IntegrationTests {
             clientResolutionMode: StreamVideoHelper.ClientResolutionMode = .ignoreCache,
             streamVideoEnvironment: StreamVideo.Environment = .silentAudioDevice,
             overrideAPIKey: String? = nil,
-            overrideToken: String? = nil,
-            audioSessionPolicy: AudioSessionPolicy = InactiveAudioSessionPolicy()
+            overrideToken: String? = nil
         ) async throws -> CallFlow<Void> {
             let authentication = try await authentication
                 .authenticate(userId: userId, environment: environment)
@@ -119,7 +118,7 @@ extension Call_IntegrationTests {
                 streamVideoEnvironment: streamVideoEnvironment
             )
             let call = client.call(callType: type, callId: id)
-            await call.updateAudioSessionPolicy(audioSessionPolicy)
+            await call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
             registeredCalls[userId] = call
             return .init(
                 client: client,

--- a/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
+++ b/StreamVideoTests/IntegrationTests/Components/Helpers/Call_IntegrationTests+Helpers.swift
@@ -104,7 +104,8 @@ extension Call_IntegrationTests {
             clientResolutionMode: StreamVideoHelper.ClientResolutionMode = .ignoreCache,
             streamVideoEnvironment: StreamVideo.Environment = .silentAudioDevice,
             overrideAPIKey: String? = nil,
-            overrideToken: String? = nil
+            overrideToken: String? = nil,
+            audioSessionPolicy: AudioSessionPolicy = InactiveAudioSessionPolicy()
         ) async throws -> CallFlow<Void> {
             let authentication = try await authentication
                 .authenticate(userId: userId, environment: environment)
@@ -118,7 +119,7 @@ extension Call_IntegrationTests {
                 streamVideoEnvironment: streamVideoEnvironment
             )
             let call = client.call(callType: type, callId: id)
-            await call.updateAudioSessionPolicy(InactiveAudioSessionPolicy())
+            await call.updateAudioSessionPolicy(audioSessionPolicy)
             registeredCalls[userId] = call
             return .init(
                 client: client,


### PR DESCRIPTION
### 🎯 Goal

Stop a cancelled join from retrying after leave. `try? Task.sleep` swallowed `CancellationError`, the joining stage re-entered, and CI hung.

This is **not** a general flake sweep. Join-miss and other two-client flakes are still open.

### 📝 Summary

- **Keep:** If join is cancelled during retry delay (or `joinCall` throws after leave), return instead of transitioning back to `.joining`.
- **Keep:** Unit test `test_execute_whenCancelledDuringRetryDelay_doesNotReenterJoining`.
- **Formatting only:** a few `callFlow(...)` call sites in `Call_IntegrationTests` collapsed to one line (leftover from a reverted experiment). No test-behavior change.
- **Not in this PR:** Joined audio watchdog skip (never shipped). `DefaultAudioSessionPolicy` on two-client tests (tried, then reverted; net PR still uses `InactiveAudioSessionPolicy`). `leaveCallRepeatedly` / `clientResolutionMode` / `ignoreCache` are already on `develop`.

### 🛠 Implementation

In `Call+JoiningStage`:

1. If the generic join `catch` runs and `Task.isCancelled` is already true (`joinCall` can still throw `TimeOutError` after leave), return.
2. Retry delay uses `try await Task.sleep` + `Task.checkCancellation()`. On `CancellationError`, return. Do **not** `try?` the sleep — that used to swallow cancel and call `transitionOrError(.joining(...))`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)