### PR TITLE
Pass the X-Stream-Header in SFU requests

### DIFF
--- a/Sources/StreamVideo/protobuf/sfu/signal_rpc/signal.twirp.swift
+++ b/Sources/StreamVideo/protobuf/sfu/signal_rpc/signal.twirp.swift
@@ -97,6 +97,7 @@ class Stream_Video_Sfu_Signal_SignalServer: @unchecked Sendable {
         var request = URLRequest(url: url)
         request.setValue("application/protobuf", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "authorization")
+        request.setValue(SystemEnvironment.xStreamClientHeader, forHTTPHeaderField: "X-Stream-Client")
         request.httpMethod = "POST"
         return request
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-2012/pass-the-x-stream-header-in-sfu-requests.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

|  Before  |  After  |
| -------- | ------- |
|  `img`   |  `img`  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Outgoing requests now use a consistent SDK identifier in the client identification header.
  * Client identification values are centralized to improve consistency across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->