### PR TITLE
Adopt namespaced Core tokens for VideoAppearance colors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ v2 introduces a **shared design-token system** so Chat and Video can reskin from
 ### Types and ownership
 
 - **`DesignSystemTokens`** (Core, class): `tokens.colors` (semantic colors plus `tokens.colors.palette` for brand/chrome ramps), `tokens.layout` (spacing, radii, strokes, elevations), and `tokens.fonts` (shared SwiftUI typography). Override color ramps **before the first read**. Colors stay on UIKit `UIColor`; fonts stay on SwiftUI `Font`. UIKit `UIFont` faces stay on product UIKit SDKs (for example StreamChatUI).
-- **`VideoAppearance`**: Video’s design-system type. Holds `tokens: DesignSystemTokens` and `colors: VideoAppearance.Colors` (14 Video-only colors). No images or sounds. Video owns **no** layout or font tokens; layout and shared fonts come from `tokens`.
+- **`VideoAppearance`**: Video’s design-system type. Holds `tokens: DesignSystemTokens` and `colors: VideoAppearance.Colors` (Video-only colors from `tokens/video`). No images or sounds. Video owns **no** layout or font tokens; layout and shared fonts come from `tokens`. Labels and other shared semantics live on `tokens.colors`.
 - **`Appearance`** (legacy): existing SwiftUI `Colors` struct plus images, fonts, and sounds. `@Injected(\.appearance)` / `@Injected(\.fonts)` and `StreamVideoUI(..., appearance:)` still take this type. Shared typography lives on `videoAppearance.tokens.fonts`. **Do not migrate existing views** onto `VideoAppearance` or `tokens.fonts` unless the task explicitly asks.
 
 Product prefix is **Video**, not Call. Use `VideoAppearance` / `VideoAppearance.Colors`.
@@ -28,7 +28,7 @@ tokens.colors.palette.brand500 = .red
 tokens.layout.spacingMd = 16
 
 let videoAppearance = VideoAppearance(tokens: tokens)
-videoAppearance.colors.indicatorSpeaking = .green
+videoAppearance.colors.indicatorSoundIndicatorSpeaking = .green
 
 // Existing views, until they migrate:
 let appearance = Appearance(colors: colors, images: images, fonts: fonts, sounds: sounds)
@@ -38,7 +38,7 @@ StreamVideoUI(streamVideo: streamVideo, appearance: appearance)
 Access paths on `VideoAppearance`:
 
 - Shared: `videoAppearance.tokens.colors.accentPrimary`, `videoAppearance.tokens.layout.spacingMd`, `videoAppearance.tokens.fonts.body`
-- Video-only: `videoAppearance.colors.controlAcceptCallBackground`
+- Video-only: `videoAppearance.colors.controlAcceptCallButtonBackground`
 
 `VideoAppearance.Colors.init` defaults to `DesignSystemTokens()`, so `Colors()` works without supplying tokens.
 
@@ -58,7 +58,7 @@ struct InboxHeader: View {
     var body: some View {
         HStack(spacing: videoAppearance.tokens.layout.spacingMd) {
             Label("3 missed", systemImage: "phone.down.fill")
-                .background(Color(videoAppearance.colors.controlAcceptCallBackground))
+                .background(Color(videoAppearance.colors.controlAcceptCallButtonBackground))
             Label("2 unread", systemImage: "message.fill")
                 .foregroundColor(Color(chatAppearance.tokens.colors.textPrimary))
         }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Access paths on `VideoAppearance`:
 
 `VideoAppearance.Colors.init` defaults to `DesignSystemTokens()`, so `Colors()` works without supplying tokens.
 
-Token split and re-sync rules live in Core: `Sources/StreamCoreUI/DesignSystem/TokenScope.md`. Do not add Chat (`chat*`) tokens to this SDK.
+Token ownership lives in `design-system-tokens`. Video consumes Core plus `tokens/video` (`VideoAppearance.Colors`). Do not add Chat tokens to this SDK.
 
 ### Mixed Chat + Video apps
 

--- a/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/03-video-theme.swift
+++ b/DocumentationTests/DocumentationTests/DocumentationTests/04-ui-components/03-video-theme.swift
@@ -13,7 +13,7 @@ private func content() {
         let tokens = DesignSystemTokens()
         tokens.colors.accentPrimary = .red
         let appearance = VideoAppearance(tokens: tokens)
-        appearance.colors.indicatorSpeaking = .green
+        appearance.colors.indicatorSoundIndicatorSpeaking = .green
     }
 
     container {

--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.30.0"),
         .package(url: "https://github.com/GetStream/stream-video-swift-webrtc.git", exact: "145.15.0"),
-        // Temporary pin to the develop commit that added StreamCoreUI
-        // fonts. Restore `from:` once they ship in a tag.
+        // Temporary pin to the develop commit that split Core tokens
+        // by namespace. Restore `from:` once they ship in a tag.
         .package(
             url: "https://github.com/GetStream/stream-core-swift.git",
-            revision: "fecb30ec066d29b4fd4acd3d9b6039558057d91f"
+            revision: "15cac261ec252453f09c909b258386ffcac7d42c"
         )
     ],
     targets: [

--- a/Sources/StreamVideoSwiftUI/DesignSystem/VideoAppearance+Colors.swift
+++ b/Sources/StreamVideoSwiftUI/DesignSystem/VideoAppearance+Colors.swift
@@ -2,47 +2,52 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+// This file is auto-generated. Do not edit.
+
 import StreamCoreUI
 import UIKit
 
-/// Video-specific color tokens, derived from ``DesignSystemTokens/Colors``.
-///
-/// Read them on the Video appearance:
-/// `videoAppearance.colors.indicatorSpeaking`.
 extension VideoAppearance {
+    /// VideoAppearance color tokens derived from StreamCoreUI.
     public final class Colors {
         private let colors: DesignSystemTokens.Colors
 
         // MARK: - Control
 
-        public lazy var controlAcceptCallBackground: UIColor = colors
-            .accentSuccess
-        public lazy var controlAcceptCallText: UIColor = colors.textOnAccent
-        public lazy var controlVideoBackgroundControlBackground: UIColor = colors
-            .backgroundCoreSurfaceSubtle
-        public lazy var controlVideoBackgroundControlBackgroundSelected: UIColor =
-            colors.accentPrimary
-        public lazy var controlVideoBackgroundControlText: UIColor = colors
-            .textPrimary
-        public lazy var controlVideoBackgroundControlTextSelected: UIColor =
+        public lazy var controlAcceptCallButtonBackground: UIColor =
+            colors.accentSuccess
+        public lazy var controlAcceptCallButtonText: UIColor =
+            colors.textOnAccent
+        public lazy var controlCallControlErrorBadgeBackground: UIColor =
+            colors.accentWarning
+        public lazy var controlCallControlErrorBadgeText: UIColor = UIColor(
+            red: 0,
+            green: 0,
+            blue: 0,
+            alpha: 1
+        )
+        public lazy var controlDeclineCallButtonBackground: UIColor =
+            colors.accentError
+        public lazy var controlDeclineCallButtonText: UIColor =
             colors.textOnAccent
 
         // MARK: - Indicator
 
-        public lazy var indicatorFair: UIColor = colors.accentWarning
-        public lazy var indicatorGreat: UIColor = colors.accentSuccess
-        public lazy var indicatorPoor: UIColor = colors.accentError
-        public lazy var indicatorSpeaking: UIColor = colors.palette.brand300
-
-        // MARK: - Label
-
-        public lazy var labelBackgroundNeutral: UIColor = colors.palette.chrome150
-        public lazy var labelBackgroundPrimary: UIColor = colors.palette.brand150
-        public lazy var labelTextNeutral: UIColor = colors.textPrimary
-        public lazy var labelTextPrimary: UIColor = colors.palette.brand900
+        public lazy var indicatorConnectionQualityFair: UIColor =
+            colors.accentWarning
+        public lazy var indicatorConnectionQualityGreat: UIColor =
+            colors.accentSuccess
+        public lazy var indicatorConnectionQualityPoor: UIColor =
+            colors.accentError
+        public lazy var indicatorMicrophoneLevelBarActive: UIColor =
+            colors.palette.brand400
+        public lazy var indicatorMicrophoneLevelBarInactive: UIColor =
+            colors.palette.chrome200
+        public lazy var indicatorSoundIndicatorSpeaking: UIColor =
+            colors.palette.brand400
 
         public init(tokens: DesignSystemTokens = DesignSystemTokens()) {
-            self.colors = tokens.colors
+            colors = tokens.colors
         }
     }
 }

--- a/Sources/StreamVideoSwiftUI/VideoAppearance.swift
+++ b/Sources/StreamVideoSwiftUI/VideoAppearance.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// let tokens = DesignSystemTokens()
 /// tokens.colors.accentPrimary = .red
 /// let appearance = VideoAppearance(tokens: tokens)
-/// appearance.colors.indicatorSpeaking = .green
+/// appearance.colors.indicatorSoundIndicatorSpeaking = .green
 /// ```
 public final class VideoAppearance {
     /// The instance the Video SDK uses unless it is given another one.

--- a/StreamVideo.xcodeproj/project.pbxproj
+++ b/StreamVideo.xcodeproj/project.pbxproj
@@ -3379,7 +3379,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
 				kind = revision;
-				revision = fecb30ec066d29b4fd4acd3d9b6039558057d91f;
+				revision = 15cac261ec252453f09c909b258386ffcac7d42c;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StreamVideoSwiftUITests/DesignSystem/Appearance+DesignSystem_Tests.swift
+++ b/StreamVideoSwiftUITests/DesignSystem/Appearance+DesignSystem_Tests.swift
@@ -60,23 +60,32 @@ final class Appearance_DesignSystem_Tests: XCTestCase, @unchecked Sendable {
 
     func test_sharedTokenOverriddenBeforeFirstRead_videoColorUsesOverride() {
         let tokens = DesignSystemTokens()
-        tokens.colors.palette.brand300 = .magenta
+        tokens.colors.palette.brand400 = .magenta
         subject = VideoAppearance(tokens: tokens)
 
-        XCTAssertEqual(subject.colors.indicatorSpeaking, .magenta)
+        XCTAssertEqual(
+            subject.colors.indicatorSoundIndicatorSpeaking,
+            .magenta
+        )
     }
 
     func test_videoColorOverridden_readsBackOverride() {
-        subject.colors.indicatorSpeaking = .magenta
+        subject.colors.indicatorSoundIndicatorSpeaking = .magenta
 
-        XCTAssertEqual(subject.colors.indicatorSpeaking, .magenta)
+        XCTAssertEqual(
+            subject.colors.indicatorSoundIndicatorSpeaking,
+            .magenta
+        )
     }
 
     func test_colorsInit_withoutTokens_usesDefaultDesignSystemTokens() {
         let colors = VideoAppearance.Colors()
-        let expected = DesignSystemTokens().colors.palette.brand300
+        let expected = DesignSystemTokens().colors.palette.brand400
 
-        assertEqualDynamicColor(colors.indicatorSpeaking, expected)
+        assertEqualDynamicColor(
+            colors.indicatorSoundIndicatorSpeaking,
+            expected
+        )
     }
 
     // Dynamic `UIColor(light:dark:)` instances are not `==` even when they


### PR DESCRIPTION
### 🔗 Issue Links

- https://linear.app/stream/issue/IOS-2000/move-the-token-product-scope-split-upstream-into-design-system-tokens
- GetStream/design-system-tokens#74
- GetStream/stream-core-swift#83

### 🎯 Goal

Point Video at the namespaced Core token commit and ship the generated Video-only color names, so product tokens no longer live in StreamCoreUI.

### 📝 Summary

- Pin StreamCore to `15cac26` (namespace split)
- Replace `VideoAppearance.Colors` with the generated Video token names
- Labels stay on shared `tokens.colors`
- Views still use legacy `Appearance.fonts`

### 🛠 Implementation

Video-only colors now match `tokens/video` (`controlAcceptCallButtonBackground`, `indicatorSoundIndicatorSpeaking`, decline-call, connection quality, microphone bars). Tests and AGENTS examples were updated to the new names. Existing call views were not migrated.

### 🧪 Manual Testing Notes

- `xcodebuild -project StreamVideo.xcodeproj -scheme StreamVideoSwiftUI -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.2' test -only-testing:StreamVideoSwiftUITests/Appearance_DesignSystem_Tests`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer, more specific video appearance color tokens for call controls, connection quality, microphone levels, and speaking indicators.
  - Updated the speaking indicator color to use the refreshed brand palette.

- **Documentation**
  - Updated customization examples and token guidance to reflect the revised color names and ownership.

- **Tests**
  - Updated appearance and documentation checks to validate the renamed color tokens and refreshed palette values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->